### PR TITLE
Convert errors thrown from interceptor inbound or outbound stream

### DIFF
--- a/Sources/GRPCCore/Call/Client/Internal/ClientResponse+Convenience.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/ClientResponse+Convenience.swift
@@ -71,6 +71,8 @@ extension ClientResponse {
       } catch let error as RPCError {
         // Known error type.
         self.accepted = .success(Contents(metadata: contents.metadata, error: error))
+      } catch let error as any RPCErrorConvertible {
+        self.accepted = .success(Contents(metadata: contents.metadata, error: RPCError(error)))
       } catch {
         // Unexpected, but should be handled nonetheless.
         self.accepted = .failure(RPCError(code: .unknown, message: String(describing: error)))

--- a/Sources/GRPCCore/Call/Client/Internal/ClientStreamExecutor.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/ClientStreamExecutor.swift
@@ -96,7 +96,11 @@ internal enum ClientStreamExecutor {
       try await stream.write(.metadata(request.metadata))
       try await request.producer(.map(into: stream) { .message(try serializer.serialize($0)) })
     }.castError(to: RPCError.self) { other in
-      RPCError(code: .unknown, message: "Write failed.", cause: other)
+      if let convertible = other as? any RPCErrorConvertible {
+        RPCError(convertible)
+      } else {
+        RPCError(code: .unknown, message: "Write failed.", cause: other)
+      }
     }
 
     switch result {

--- a/Sources/GRPCCore/Call/Client/Internal/ClientStreamExecutor.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/ClientStreamExecutor.swift
@@ -26,7 +26,7 @@ internal enum ClientStreamExecutor {
   ///   - attempt: The attempt number for the RPC that will be executed.
   ///   - serializer: A request serializer.
   ///   - deserializer: A response deserializer.
-  ///   - stream: The stream to excecute the RPC on.
+  ///   - stream: The stream to execute the RPC on.
   /// - Returns: A streamed response.
   @inlinable
   static func execute<Input: Sendable, Output: Sendable, Bytes: GRPCContiguousBytes>(
@@ -95,12 +95,8 @@ internal enum ClientStreamExecutor {
     let result = await Result {
       try await stream.write(.metadata(request.metadata))
       try await request.producer(.map(into: stream) { .message(try serializer.serialize($0)) })
-    }.castError(to: RPCError.self) { other in
-      if let convertible = other as? any RPCErrorConvertible {
-        RPCError(convertible)
-      } else {
-        RPCError(code: .unknown, message: "Write failed.", cause: other)
-      }
+    }.castOrConvertRPCError { other in
+      RPCError(code: .unknown, message: "Write failed.", cause: other)
     }
 
     switch result {

--- a/Sources/GRPCCore/Call/Server/Internal/ServerRPCExecutor.swift
+++ b/Sources/GRPCCore/Call/Server/Internal/ServerRPCExecutor.swift
@@ -188,16 +188,12 @@ struct ServerRPCExecutor {
       ) { request, context in
         try await handler(request, context)
       }
-    }.castError(to: RPCError.self) { error in
-      if let convertible = error as? (any RPCErrorConvertible) {
-        return RPCError(convertible)
-      } else {
-        return RPCError(
-          code: .unknown,
-          message: "Service method threw an unknown error.",
-          cause: error
-        )
-      }
+    }.castOrConvertRPCError { error in
+      RPCError(
+        code: .unknown,
+        message: "Service method threw an unknown error.",
+        cause: error
+      )
     }.flatMap { response in
       response.accepted
     }

--- a/Sources/GRPCCore/Call/Server/Internal/ServerRPCExecutor.swift
+++ b/Sources/GRPCCore/Call/Server/Internal/ServerRPCExecutor.swift
@@ -213,12 +213,8 @@ struct ServerRPCExecutor {
         return try await contents.producer(
           .serializingToRPCResponsePart(into: outbound, with: serializer)
         )
-      }.castError(to: RPCError.self) { error in
-        if let convertible = error as? (any RPCErrorConvertible) {
-          return RPCError(convertible)
-        } else {
-          return RPCError(code: .unknown, message: "", cause: error)
-        }
+      }.castOrConvertRPCError { error in
+        RPCError(code: .unknown, message: "", cause: error)
       }
 
       switch result {

--- a/Sources/GRPCCore/Call/Server/Internal/ServerRPCExecutor.swift
+++ b/Sources/GRPCCore/Call/Server/Internal/ServerRPCExecutor.swift
@@ -214,7 +214,11 @@ struct ServerRPCExecutor {
           .serializingToRPCResponsePart(into: outbound, with: serializer)
         )
       }.castError(to: RPCError.self) { error in
-        RPCError(code: .unknown, message: "", cause: error)
+        if let convertible = error as? (any RPCErrorConvertible) {
+          return RPCError(convertible)
+        } else {
+          return RPCError(code: .unknown, message: "", cause: error)
+        }
       }
 
       switch result {

--- a/Sources/GRPCCore/Internal/Result+Catching.swift
+++ b/Sources/GRPCCore/Internal/Result+Catching.swift
@@ -45,4 +45,25 @@ extension Result {
       return (error as? NewError) ?? buildError(error)
     }
   }
+
+  /// Attempt to map or convert the error to an `RPCError`.
+  ///
+  /// If the cast or conversion is not possible then the provided closure is used to create an error of the given type.
+  ///
+  /// - Parameter buildError: A closure which constructs the desired error if conversion is not possible.
+  @inlinable
+  @available(gRPCSwift 2.0, *)
+  func castOrConvertRPCError(
+    or buildError: (any Error) -> RPCError
+  ) -> Result<Success, RPCError> {
+    return self.mapError { error in
+      if let rpcError = error as? RPCError {
+        return rpcError
+      } else if let convertibleError = error as? any RPCErrorConvertible {
+        return RPCError(convertibleError)
+      } else {
+        return buildError(error)
+      }
+    }
+  }
 }

--- a/Sources/GRPCCore/Internal/Result+Catching.swift
+++ b/Sources/GRPCCore/Internal/Result+Catching.swift
@@ -56,11 +56,9 @@ extension Result {
   func castOrConvertRPCError(
     or buildError: (any Error) -> RPCError
   ) -> Result<Success, RPCError> {
-    return self.mapError { error in
-      if let rpcError = error as? RPCError {
-        return rpcError
-      } else if let convertibleError = error as? any RPCErrorConvertible {
-        return RPCError(convertibleError)
+    return self.castError(to: RPCError.self) { error in
+      if let convertible = error as? any RPCErrorConvertible {
+        return RPCError(convertible)
       } else {
         return buildError(error)
       }

--- a/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTestSupport/ClientRPCExecutorTestHarness.swift
+++ b/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTestSupport/ClientRPCExecutorTestHarness.swift
@@ -132,7 +132,11 @@ struct ClientRPCExecutorTestHarness {
     try await withThrowingTaskGroup(of: Void.self) { group in
       group.addTask {
         try await self.serverTransport.listen { stream, context in
-          try? await self.server.handle(stream: stream)
+          do {
+            try await self.server.handle(stream: stream)
+          } catch {
+            await stream.outbound.finish(throwing: error)
+          }
         }
       }
 

--- a/Tests/GRPCCoreTests/Call/Server/Internal/ServerRPCExecutorTests.swift
+++ b/Tests/GRPCCoreTests/Call/Server/Internal/ServerRPCExecutorTests.swift
@@ -403,14 +403,11 @@ final class ServerRPCExecutorTests: XCTestCase {
     }
 
     let harness = ServerRPCExecutorTestHarness(
-      interceptors: [.throwInProducer(CustomError(), after: .milliseconds(10))]
+      interceptors: [.throwInProducer(CustomError())]
     )
     try await harness.execute(handler: .echo) { inbound in
       try await inbound.write(.metadata(["foo": "bar"]))
       try await inbound.write(.message([0]))
-      try await Task.sleep(for: .milliseconds(50))
-      try await inbound.write(.message([1]))
-      await inbound.finish()
     } consumer: { outbound in
       let parts = try await outbound.collect()
       let status = Status(code: .alreadyExists, message: "foobar")

--- a/Tests/GRPCCoreTests/Call/Server/Internal/ServerRPCExecutorTests.swift
+++ b/Tests/GRPCCoreTests/Call/Server/Internal/ServerRPCExecutorTests.swift
@@ -423,10 +423,13 @@ final class ServerRPCExecutorTests: XCTestCase {
       var rpcErrorMetadata: Metadata { ["error": "yes"] }
     }
 
-    let harness = ServerRPCExecutorTestHarness(interceptors: [.throwInMessageSequence(CustomError())])
+    let harness = ServerRPCExecutorTestHarness(interceptors: [
+      .throwInMessageSequence(CustomError())
+    ])
     try await harness.execute(handler: .echo) { inbound in
       try await inbound.write(.metadata(["foo": "bar"]))
-      try await inbound.write(.message([0])) // the sequence throws instantly, this should not arrive
+      // the sequence throws instantly, this should not arrive
+      try await inbound.write(.message([0]))
       await inbound.finish()
     } consumer: { outbound in
       let parts = try await outbound.collect()

--- a/Tests/GRPCCoreTests/Call/Server/Internal/ServerRPCExecutorTests.swift
+++ b/Tests/GRPCCoreTests/Call/Server/Internal/ServerRPCExecutorTests.swift
@@ -394,4 +394,48 @@ final class ServerRPCExecutorTests: XCTestCase {
       XCTAssertEqual(parts, [.status(status, metadata)])
     }
   }
+
+  func testInterceptorProducerErrorConversion() async throws {
+    struct CustomError: RPCErrorConvertible, Error {
+      var rpcErrorCode: RPCError.Code { .alreadyExists }
+      var rpcErrorMessage: String { "foobar" }
+      var rpcErrorMetadata: Metadata { ["error": "yes"] }
+    }
+
+    let harness = ServerRPCExecutorTestHarness(
+      interceptors: [.throwInProducer(CustomError(), after: .milliseconds(10))]
+    )
+    try await harness.execute(handler: .echo) { inbound in
+      try await inbound.write(.metadata(["foo": "bar"]))
+      try await inbound.write(.message([0]))
+      try await Task.sleep(for: .milliseconds(50))
+      try await inbound.write(.message([1]))
+      await inbound.finish()
+    } consumer: { outbound in
+      let parts = try await outbound.collect()
+      let status = Status(code: .alreadyExists, message: "foobar")
+      let metadata: Metadata = ["error": "yes"]
+      XCTAssertEqual(parts, [.metadata(["foo": "bar"]), .message([0]), .status(status, metadata)])
+    }
+  }
+
+  func testInterceptorMessagesErrorConversion() async throws {
+    struct CustomError: RPCErrorConvertible, Error {
+      var rpcErrorCode: RPCError.Code { .alreadyExists }
+      var rpcErrorMessage: String { "foobar" }
+      var rpcErrorMetadata: Metadata { ["error": "yes"] }
+    }
+
+    let harness = ServerRPCExecutorTestHarness(interceptors: [.throwInMessageSequence(CustomError())])
+    try await harness.execute(handler: .echo) { inbound in
+      try await inbound.write(.metadata(["foo": "bar"]))
+      try await inbound.write(.message([0])) // the sequence throws instantly, this should not arrive
+      await inbound.finish()
+    } consumer: { outbound in
+      let parts = try await outbound.collect()
+      let status = Status(code: .alreadyExists, message: "foobar")
+      let metadata: Metadata = ["error": "yes"]
+      XCTAssertEqual(parts, [.metadata(["foo": "bar"]), .status(status, metadata)])
+    }
+  }
 }

--- a/Tests/GRPCCoreTests/Test Utilities/Call/Client/ClientInterceptors.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/Call/Client/ClientInterceptors.swift
@@ -91,7 +91,9 @@ struct RejectAllClientInterceptor: ClientInterceptor {
       var response = try await next(request, context)
       switch response.accepted {
       case .success(var success):
-        let stream = AsyncThrowingStream<StreamingClientResponse<Output>.Contents.BodyPart, any Error>.makeStream()
+        let stream = AsyncThrowingStream<
+          StreamingClientResponse<Output>.Contents.BodyPart, any Error
+        >.makeStream()
         stream.continuation.finish(throwing: error)
 
         success.bodyParts = RPCAsyncSequence(wrapping: stream.stream)

--- a/Tests/GRPCCoreTests/Test Utilities/Call/Server/ServerInterceptors.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/Call/Server/ServerInterceptors.swift
@@ -25,6 +25,14 @@ extension ServerInterceptor where Self == RejectAllServerInterceptor {
   static func throwError(_ error: any Error) -> Self {
     RejectAllServerInterceptor(throw: error)
   }
+
+  static func throwInProducer(_ error: any Error, after duration: Duration) -> Self {
+    RejectAllServerInterceptor(throwInProducer: error, after: duration)
+  }
+
+  static func throwInMessageSequence(_ error: any Error) -> Self {
+    RejectAllServerInterceptor(throwInMessageSequence: error)
+  }
 }
 
 @available(gRPCSwift 2.0, *)
@@ -42,6 +50,16 @@ struct RejectAllServerInterceptor: ServerInterceptor {
     case `throw`(any Error)
     /// Reject the RPC with a given error.
     case reject(RPCError)
+    /// Throw in the producer closure returned.
+    case throwInProducer(any Error, after: Duration)
+    /// Throw in the async sequence that stream inbound messages.
+    case throwInMessageSequence(any Error)
+  }
+
+  private enum TimeoutResult {
+    case `throw`(any Error)
+    case cancelled
+    case result(Metadata)
   }
 
   let mode: Mode
@@ -52,6 +70,14 @@ struct RejectAllServerInterceptor: ServerInterceptor {
 
   init(reject error: RPCError) {
     self.mode = .reject(error)
+  }
+
+  init(throwInProducer error: any Error, after duration: Duration) {
+    self.mode = .throwInProducer(error, after: duration)
+  }
+
+  init(throwInMessageSequence error: any Error) {
+    self.mode = .throwInMessageSequence(error)
   }
 
   func intercept<Input: Sendable, Output: Sendable>(
@@ -67,6 +93,60 @@ struct RejectAllServerInterceptor: ServerInterceptor {
       throw error
     case .reject(let error):
       return StreamingServerResponse(error: error)
+    case .throwInProducer(let error, let duration):
+      var response = try await next(request, context)
+      switch response.accepted {
+      case .success(var success):
+        let wrappedProducer = success.producer
+        success.producer = { writer in
+          let result: Result<Metadata, any Error> = await withTaskGroup(of: TimeoutResult.self) { group in
+            group.addTask {
+              do {
+                try await Task.sleep(for: duration, tolerance: .nanoseconds(1))
+              } catch {
+                return .cancelled
+              }
+              return .throw(error)
+            }
+
+            group.addTask {
+              do {
+                return .result(try await wrappedProducer(writer))
+              } catch {
+                return .throw(error)
+              }
+            }
+
+            let first = await group.next()!
+            group.cancelAll()
+            let second = await group.next()!
+
+            switch (first, second) {
+            case (.throw(let error), _):
+              return .failure(error)
+            case (.result(let metadata), _):
+              return .success(metadata)
+            case (.cancelled, _):
+              return .failure(CancellationError())
+            }
+          }
+
+          return try result.get()
+        }
+
+        response.accepted = .success(success)
+        return response
+      case .failure:
+        return response
+      }
+    case .throwInMessageSequence(let error):
+      let stream = AsyncThrowingStream<Input, any Error>.makeStream()
+      stream.continuation.finish(throwing: error)
+
+      var request = request
+      request.messages = RPCAsyncSequence(wrapping: stream.stream)
+
+      return try await next(request, context)
     }
   }
 }

--- a/Tests/GRPCCoreTests/Test Utilities/Call/Server/ServerInterceptors.swift
+++ b/Tests/GRPCCoreTests/Test Utilities/Call/Server/ServerInterceptors.swift
@@ -26,8 +26,8 @@ extension ServerInterceptor where Self == RejectAllServerInterceptor {
     RejectAllServerInterceptor(throw: error)
   }
 
-  static func throwInProducer(_ error: any Error, after duration: Duration) -> Self {
-    RejectAllServerInterceptor(throwInProducer: error, after: duration)
+  static func throwInProducer(_ error: any Error) -> Self {
+    RejectAllServerInterceptor(throwInProducer: error)
   }
 
   static func throwInMessageSequence(_ error: any Error) -> Self {
@@ -51,7 +51,7 @@ struct RejectAllServerInterceptor: ServerInterceptor {
     /// Reject the RPC with a given error.
     case reject(RPCError)
     /// Throw in the producer closure returned.
-    case throwInProducer(any Error, after: Duration)
+    case throwInProducer(any Error)
     /// Throw in the async sequence that stream inbound messages.
     case throwInMessageSequence(any Error)
   }
@@ -72,8 +72,8 @@ struct RejectAllServerInterceptor: ServerInterceptor {
     self.mode = .reject(error)
   }
 
-  init(throwInProducer error: any Error, after duration: Duration) {
-    self.mode = .throwInProducer(error, after: duration)
+  init(throwInProducer error: any Error) {
+    self.mode = .throwInProducer(error)
   }
 
   init(throwInMessageSequence error: any Error) {
@@ -93,45 +93,21 @@ struct RejectAllServerInterceptor: ServerInterceptor {
       throw error
     case .reject(let error):
       return StreamingServerResponse(error: error)
-    case .throwInProducer(let error, let duration):
+    case .throwInProducer(let error):
       var response = try await next(request, context)
       switch response.accepted {
       case .success(var success):
         let wrappedProducer = success.producer
         success.producer = { writer in
-          let result: Result<Metadata, any Error> = await withTaskGroup(of: TimeoutResult.self) { group in
+          try await withThrowingTaskGroup(of: Metadata.self) { group in
             group.addTask {
-              do {
-                try await Task.sleep(for: duration, tolerance: .nanoseconds(1))
-              } catch {
-                return .cancelled
-              }
-              return .throw(error)
+              try await wrappedProducer(writer)
             }
 
-            group.addTask {
-              do {
-                return .result(try await wrappedProducer(writer))
-              } catch {
-                return .throw(error)
-              }
-            }
-
-            let first = await group.next()!
             group.cancelAll()
-            let second = await group.next()!
-
-            switch (first, second) {
-            case (.throw(let error), _):
-              return .failure(error)
-            case (.result(let metadata), _):
-              return .success(metadata)
-            case (.cancelled, _):
-              return .failure(CancellationError())
-            }
+            _ = try await group.next()!
+            throw error
           }
-
-          return try result.get()
         }
 
         response.accepted = .success(success)


### PR DESCRIPTION
While `RPCConvertible` errors are properly converted when thrown as part of the `intercept` method, errors thrown from within the `producer` closures or as part of the message sequences are not being converted.
This PR resolves that and adds the necessary unit tests to verify that.