### PR TITLE
Update examples

### DIFF
--- a/Examples/echo-metadata/Sources/ClientArguments.swift
+++ b/Examples/echo-metadata/Sources/ClientArguments.swift
@@ -30,6 +30,6 @@ struct ClientArguments: ParsableArguments {
 
 extension ClientArguments {
   var target: any ResolvableTarget {
-    return .ipv4(host: "127.0.0.1", port: self.port)
+    return .dns(host: "localhost", port: self.port)
   }
 }

--- a/Examples/echo/Sources/Subcommands/ClientArguments.swift
+++ b/Examples/echo/Sources/Subcommands/ClientArguments.swift
@@ -30,6 +30,6 @@ struct ClientArguments: ParsableArguments {
 
 extension ClientArguments {
   var target: any ResolvableTarget {
-    return .ipv4(host: "127.0.0.1", port: self.port)
+    return .dns(host: "localhost", port: self.port)
   }
 }

--- a/Examples/hello-world/Sources/Subcommands/Greet.swift
+++ b/Examples/hello-world/Sources/Subcommands/Greet.swift
@@ -31,7 +31,7 @@ struct Greet: AsyncParsableCommand {
   func run() async throws {
     try await withGRPCClient(
       transport: .http2NIOPosix(
-        target: .ipv4(host: "127.0.0.1", port: self.port),
+        target: .dns(host: "localhost", port: self.port),
         transportSecurity: .plaintext
       )
     ) { client in

--- a/Examples/route-guide/Sources/Subcommands/GetFeature.swift
+++ b/Examples/route-guide/Sources/Subcommands/GetFeature.swift
@@ -39,7 +39,7 @@ struct GetFeature: AsyncParsableCommand {
   func run() async throws {
     try await withGRPCClient(
       transport: .http2NIOPosix(
-        target: .ipv4(host: "127.0.0.1", port: self.port),
+        target: .dns(host: "localhost", port: self.port),
         transportSecurity: .plaintext
       )
     ) { client in

--- a/Examples/route-guide/Sources/Subcommands/ListFeatures.swift
+++ b/Examples/route-guide/Sources/Subcommands/ListFeatures.swift
@@ -53,7 +53,7 @@ struct ListFeatures: AsyncParsableCommand {
   func run() async throws {
     try await withGRPCClient(
       transport: .http2NIOPosix(
-        target: .ipv4(host: "127.0.0.1", port: self.port),
+        target: .dns(host: "localhost", port: self.port),
         transportSecurity: .plaintext
       )
     ) { client in

--- a/Examples/route-guide/Sources/Subcommands/RecordRoute.swift
+++ b/Examples/route-guide/Sources/Subcommands/RecordRoute.swift
@@ -32,7 +32,7 @@ struct RecordRoute: AsyncParsableCommand {
   func run() async throws {
     try await withGRPCClient(
       transport: .http2NIOPosix(
-        target: .ipv4(host: "127.0.0.1", port: self.port),
+        target: .dns(host: "localhost", port: self.port),
         transportSecurity: .plaintext
       )
     ) { client in

--- a/Examples/route-guide/Sources/Subcommands/RouteChat.swift
+++ b/Examples/route-guide/Sources/Subcommands/RouteChat.swift
@@ -32,7 +32,7 @@ struct RouteChat: AsyncParsableCommand {
   func run() async throws {
     try await withGRPCClient(
       transport: .http2NIOPosix(
-        target: .ipv4(host: "127.0.0.1", port: self.port),
+        target: .dns(host: "localhost", port: self.port),
         transportSecurity: .plaintext
       )
     ) { client in


### PR DESCRIPTION
Motivation:

The examples use the '.ipv4(host:)' target to resolve. We renamed this to '.ipv4(address:)' which is more accurate. However, the examples should most likely use '.dns(host:)' with "localhost" rather than the IPv4 address automatically as '.dns(host:)' is more likely to be used in real world applications.

Modifications:

- Change example clients from using '.ipv4(host: "127.0.0.1")' to
  '.dns(host: "localhost)'.

Result:

Fewer warnings, better examples