### PR TITLE
Feat: Add predicate-based Subject and sugar syntax

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -50,7 +50,7 @@ let dependencies: [Package.Dependency] = [
 
 // This adds some build settings which allow us to map "@available(gRPCSwift 2.x, *)" to
 // the appropriate OS platforms.
-let nextMinorVersion = 1
+let nextMinorVersion = 2
 let availabilitySettings: [SwiftSetting] = (0 ... nextMinorVersion).map { minor in
   let name = "gRPCSwift"
   let version = "2.\(minor)"


### PR DESCRIPTION
## Motivation

When using `ConditionalInterceptor.Subject` it's currently only possible to target `.all`, `.services`, or `.methods`.
This makes it difficult to express common cases like "apply this interceptor to all methods except a small set" without manually listing every included method or service. For example applying authentication everywhere except health check and authentication services.

## Modifications

- Refactored the internal representation of `ConditionalInterceptor.Subject` to store a single `predicate` closure instead of an enum of cases.  
  This simplifies the matching mechanism: every variant is now expressed as a `predicate` over `MethodDescriptor`.
- Re-implemented existing subjects (`.all`, `.services`, `.methods`) as convenience "sugar" static functions that construct the appropriate `predicate`.
- Added new subjects:
  - `.only(services:methods:)` — applies only to the given services and/or methods.
  - `.allExcluding(services:methods:)` — applies to all except the given services and/or methods.
  - `.allMatching(_:)` — applies to all methods satisfying a user-provided predicate.

## Result

Users can now express inclusion/exclusion rules more naturally:

```swift
.apply(requestCounterInterceptor, to: .only(services: countedServices, methods: countedMethods))
.apply(credentialsInterceptor, to: .allExcluding(services: [CredentialsService.descriptor], methods: []))
.apply(specialInterceptor, to: .allMatching { $0.method == "special" })
```

Fixes #14 