### PR TITLE
Return deadlineExceeded when client timeout fires.

### DIFF
--- a/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor+HedgingExecutor.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor+HedgingExecutor.swift
@@ -122,6 +122,9 @@ extension ClientRPCExecutor.HedgingExecutor {
           switch result {
           case .success:
             group.cancelAll()
+            return Result<R, any Error>.failure(
+              RPCError(code: .deadlineExceeded, message: "RPC timed out before completing")
+            )
           case .failure:
             ()  // Cancelled, ignore and keep looping.
           }

--- a/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor+OneShotExecutor.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor+OneShotExecutor.swift
@@ -69,7 +69,7 @@ extension ClientRPCExecutor.OneShotExecutor {
       var request = request
       request.metadata.timeout = ContinuousClock.now.duration(to: deadline)
       let immutableRequest = request
-      result = await withDeadline(deadline) {
+      result = try await withDeadline(deadline) {
         await self._execute(
           request: immutableRequest,
           method: method,
@@ -137,8 +137,8 @@ extension ClientRPCExecutor.OneShotExecutor {
 func withDeadline<Result: Sendable>(
   _ deadline: ContinuousClock.Instant,
   execute: @Sendable @escaping () async -> Result
-) async -> Result {
-  return await withTaskGroup(of: _DeadlineChildTaskResult<Result>.self) { group in
+) async throws -> Result {
+  return try await withThrowingTaskGroup(of: _DeadlineChildTaskResult<Result>.self) { group in
     group.addTask {
       do {
         try await Task.sleep(until: deadline, tolerance: .zero)
@@ -153,11 +153,12 @@ func withDeadline<Result: Sendable>(
       return .taskCompleted(result)
     }
 
-    while let next = await group.next() {
+    while let next = try await group.next() {
       switch next {
       case .deadlinePassed:
-        // Timeout expired; cancel the work.
+        // Timeout expired, cancel and return deadline exceeded.
         group.cancelAll()
+        throw RPCError(code: .deadlineExceeded, message: "RPC timed out before completing")
 
       case .timeoutCancelled:
         ()  // Wait for more tasks to finish.

--- a/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor+RetryExecutor.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor+RetryExecutor.swift
@@ -173,8 +173,17 @@ extension ClientRPCExecutor.RetryExecutor {
 
                 break loop  // from the while loop so another attempt can be started.
 
-              case .timedOut(.success), .outboundFinished(.failure):
-                // Timeout task fired successfully or failed to process the outbound stream. Cancel and
+              case .timedOut(.success):
+                // Timeout task fired successfully, cancel and return deadline exceeded.
+                group.cancelAll()
+                return Optional.some(
+                  .failure(
+                    RPCError(code: .deadlineExceeded, message: "RPC timed out before completing")
+                  )
+                )
+
+              case .outboundFinished(.failure):
+                // Failed to process the outbound stream. Cancel and
                 // wait for a usable response (which is likely to be an error).
                 group.cancelAll()
 

--- a/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor+RetryExecutor.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor+RetryExecutor.swift
@@ -176,10 +176,8 @@ extension ClientRPCExecutor.RetryExecutor {
               case .timedOut(.success):
                 // Timeout task fired successfully, cancel and return deadline exceeded.
                 group.cancelAll()
-                return Optional.some(
-                  .failure(
+                return .failure(
                     RPCError(code: .deadlineExceeded, message: "RPC timed out before completing")
-                  )
                 )
 
               case .outboundFinished(.failure):

--- a/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor+RetryExecutor.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor+RetryExecutor.swift
@@ -177,7 +177,7 @@ extension ClientRPCExecutor.RetryExecutor {
                 // Timeout task fired successfully, cancel and return deadline exceeded.
                 group.cancelAll()
                 return .failure(
-                    RPCError(code: .deadlineExceeded, message: "RPC timed out before completing")
+                  RPCError(code: .deadlineExceeded, message: "RPC timed out before completing")
                 )
 
               case .outboundFinished(.failure):

--- a/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTests+Hedging.swift
+++ b/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTests+Hedging.swift
@@ -184,6 +184,27 @@ extension ClientRPCExecutorTests {
       XCTAssertEqual(harness.serverStreamsAccepted, 1)
     }
   }
+
+  func testHedgingWithDeadlineExceeded() async throws {
+    let harness = ClientRPCExecutorTestHarness(
+      server: .sleepFor(duration: .milliseconds(200), then: .echo)
+    )
+
+    var options = CallOptions.hedge(nonFatalCodes: [.unavailable])
+    options.timeout = .milliseconds(50)
+
+    await XCTAssertThrowsErrorAsync {
+      try await harness.bidirectional(
+        request: StreamingClientRequest {
+          try await $0.write([0])
+        },
+        options: options
+      ) { _ in }
+    } errorHandler: { error in
+      let rpcError = error as? RPCError
+      XCTAssertEqual(rpcError?.code, .deadlineExceeded)
+    }
+  }
 }
 
 @available(gRPCSwift 2.0, *)

--- a/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTests+Retries.swift
+++ b/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTests+Retries.swift
@@ -158,7 +158,8 @@ extension ClientRPCExecutorTests {
         XCTFail("Response not expected to be handled")
       }
     } errorHandler: { error in
-      XCTAssert(error is CancellationError)
+      let rpcError = error as? RPCError
+      XCTAssertEqual(rpcError?.code, .deadlineExceeded)
     }
   }
 
@@ -179,7 +180,8 @@ extension ClientRPCExecutorTests {
         XCTFail("Response not expected to be handled")
       }
     } errorHandler: { error in
-      XCTAssert(error is CancellationError)
+      let rpcError = error as? RPCError
+      XCTAssertEqual(rpcError?.code, .deadlineExceeded)
     }
   }
 
@@ -203,7 +205,8 @@ extension ClientRPCExecutorTests {
         XCTFail("Response not expected to be handled")
       }
     } errorHandler: { error in
-      XCTAssert(error is CancellationError)
+      let rpcError = error as? RPCError
+      XCTAssertEqual(rpcError?.code, .deadlineExceeded)
     }
   }
 

--- a/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTests.swift
+++ b/Tests/GRPCCoreTests/Call/Client/Internal/ClientRPCExecutorTests.swift
@@ -332,4 +332,23 @@ final class ClientRPCExecutorTests: XCTestCase {
       }
     }
   }
+
+  func testUnaryDeadlineExceeded() async throws {
+    let harness = ClientRPCExecutorTestHarness(
+      server: .sleepFor(duration: .milliseconds(200), then: .echo)
+    )
+
+    var options = CallOptions.defaults
+    options.timeout = .milliseconds(50)
+
+    await XCTAssertThrowsErrorAsync {
+      try await harness.unary(
+        request: ClientRequest(message: [1, 2, 3]),
+        options: options
+      ) { _ in }
+    } errorHandler: { error in
+      let rpcError = error as? RPCError
+      XCTAssertEqual(rpcError?.code, .deadlineExceeded)
+    }
+  }
 }


### PR DESCRIPTION
- Previously, when a client-configured timeout expired, the task cancellation surfaced as `RPCError(.unknown)` instead of `RPCError(.deadlineExceeded)`. This made it difficult for callers to distinguish a timeout from other failures.
- This change adds logic to ensure that when timeout Task fires before the execution completes, it would return deadline exceeded status code.