### PR TITLE
Use vendored protoc

### DIFF
--- a/Examples/echo-metadata/Package.swift
+++ b/Examples/echo-metadata/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
   platforms: [.macOS("15.0")],
   dependencies: [
     .package(url: "https://github.com/grpc/grpc-swift-2.git", from: "2.0.0"),
-    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "2.0.0"),
+    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "2.4.0"),
     .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "2.0.0"),
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0"),
   ],

--- a/Examples/echo-metadata/README.md
+++ b/Examples/echo-metadata/README.md
@@ -19,28 +19,19 @@ by the client. The request's metadata will be echoed both in the initial and the
 
 The tool uses the [SwiftNIO](https://github.com/grpc/grpc-swift-nio-transport) HTTP/2 transport.
 
-## Prerequisites
-
-You must have the Protocol Buffers compiler (`protoc`) installed. You can find
-the instructions for doing this in the [gRPC Swift Protobuf documentation][0].
-The `swift` commands below are all prefixed with `PROTOC_PATH=$(which protoc)`,
-this is to let the build system know where `protoc` is located so that it can
-generate stubs for you. You can read more about it in the [gRPC Swift Protobuf
-documentation][1].
-
 ## Usage
 
 Build and run the server using the CLI:
 
 ```console
-$ PROTOC_PATH=$(which protoc) swift run echo-metadata serve
+$ swift run echo-metadata serve
 Echo-Metadata listening on [ipv4]127.0.0.1:1234
 ```
 
 Use the CLI to run the client and make a `get` (unary) request:
 
 ```console
-$ PROTOC_PATH=$(which protoc) swift run echo-metadata get --message "hello"
+$ swift run echo-metadata get --message "hello"
 get → metadata: [("echo-message", "hello")]
 get → message: hello
 get ← initial metadata: [("echo-message", "hello")]
@@ -51,8 +42,5 @@ get ← trailing metadata: [("echo-message", "hello")]
 Get help with the CLI by running:
 
 ```console
-$ PROTOC_PATH=$(which protoc) swift run echo-metadata --help
+$ swift run echo-metadata --help
 ```
-
-[0]: https://swiftpackageindex.com/grpc/grpc-swift-protobuf/documentation/grpcprotobuf/installing-protoc
-[1]: https://swiftpackageindex.com/grpc/grpc-swift-protobuf/documentation/grpcprotobuf/generating-stubs

--- a/Examples/echo/Package.swift
+++ b/Examples/echo/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
   platforms: [.macOS("15.0")],
   dependencies: [
     .package(url: "https://github.com/grpc/grpc-swift-2.git", from: "2.0.0"),
-    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "2.0.0"),
+    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "2.4.0"),
     .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "2.0.0"),
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0"),
   ],

--- a/Examples/echo/README.md
+++ b/Examples/echo/README.md
@@ -12,28 +12,19 @@ the four RPC types.
 The tool uses the [SwiftNIO](https://github.com/grpc/grpc-swift-nio-transport)
 HTTP/2 transport.
 
-## Prerequisites
-
-You must have the Protocol Buffers compiler (`protoc`) installed. You can find
-the instructions for doing this in the [gRPC Swift Protobuf documentation][0].
-The `swift` commands below are all prefixed with `PROTOC_PATH=$(which protoc)`,
-this is to let the build system know where `protoc` is located so that it can
-generate stubs for you. You can read more about it in the [gRPC Swift Protobuf
-documentation][1].
-
 ## Usage
 
 Build and run the server using the CLI:
 
 ```console
-$ PROTOC_PATH=$(which protoc) swift run echo serve
+$ swift run echo serve
 Echo listening on [ipv4]127.0.0.1:1234
 ```
 
 Use the CLI to make a unary 'Get' request against it:
 
 ```console
-$ PROTOC_PATH=$(which protoc) swift run echo get --message "Hello"
+$ swift run echo get --message "Hello"
 get → Hello
 get ← Hello
 ```
@@ -41,7 +32,7 @@ get ← Hello
 Use the CLI to make a bidirectional streaming 'Update' request:
 
 ```console
-$ PROTOC_PATH=$(which protoc) swift run echo update --message "Hello World"
+$ swift run echo update --message "Hello World"
 update → Hello
 update → World
 update ← Hello
@@ -51,8 +42,5 @@ update ← World
 Get help with the CLI by running:
 
 ```console
-$ PROTOC_PATH=$(which protoc) swift run echo --help
+$ swift run echo --help
 ```
-
-[0]: https://swiftpackageindex.com/grpc/grpc-swift-protobuf/documentation/grpcprotobuf/installing-protoc
-[1]: https://swiftpackageindex.com/grpc/grpc-swift-protobuf/documentation/grpcprotobuf/generating-stubs

--- a/Examples/error-details/Package.swift
+++ b/Examples/error-details/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
   platforms: [.macOS(.v15)],
   dependencies: [
     .package(url: "https://github.com/grpc/grpc-swift-2.git", from: "2.0.0"),
-    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "2.0.0"),
+    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "2.4.0"),
   ],
   targets: [
     .executableTarget(

--- a/Examples/error-details/README.md
+++ b/Examples/error-details/README.md
@@ -10,21 +10,12 @@ described in more detailed in the [gRPC Error
 Guide](https://grpc.io/docs/guides/error/) and is made available via the
 [grpc-swift-protobuf](https://github.com/grpc-swift-protobuf) package.
 
-## Prerequisites
-
-You must have the Protocol Buffers compiler (`protoc`) installed. You can find
-the instructions for doing this in the [gRPC Swift Protobuf documentation][0].
-The `swift` commands below are all prefixed with `PROTOC_PATH=$(which protoc)`,
-this is to let the build system know where `protoc` is located so that it can
-generate stubs for you. You can read more about it in the [gRPC Swift Protobuf
-documentation][1].
-
 ## Usage
 
 Build and run the example using the CLI:
 
 ```console
-$ PROTOC_PATH=$(which protoc) swift run
+$ swift run
 Error code: resourceExhausted
 Error message: The greeter has temporarily run out of greetings.
 Error details:
@@ -33,6 +24,3 @@ Error details:
 - Help links:
    - https://en.wikipedia.org/wiki/Caffeine (A Wikipedia page about caffeine including its properties and effects.)
 ```
-
-[0]: https://swiftpackageindex.com/grpc/grpc-swift-protobuf/documentation/grpcprotobuf/installing-protoc
-[1]: https://swiftpackageindex.com/grpc/grpc-swift-protobuf/documentation/grpcprotobuf/generating-stubs

--- a/Examples/hello-world/Package.swift
+++ b/Examples/hello-world/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
   platforms: [.macOS("15.0")],
   dependencies: [
     .package(url: "https://github.com/grpc/grpc-swift-2.git", from: "2.0.0"),
-    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "2.0.0"),
+    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "2.4.0"),
     .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "2.0.0"),
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0"),
   ],

--- a/Examples/hello-world/README.md
+++ b/Examples/hello-world/README.md
@@ -10,37 +10,25 @@ service which allows you to start a server and to make requests against it.
 The tool uses the [SwiftNIO](https://github.com/grpc/grpc-swift-nio-transport)
 HTTP/2 transport.
 
-## Prerequisites
-
-You must have the Protocol Buffers compiler (`protoc`) installed. You can find
-the instructions for doing this in the [gRPC Swift Protobuf documentation][0].
-The `swift` commands below are all prefixed with `PROTOC_PATH=$(which protoc)`,
-this is to let the build system know where `protoc` is located so that it can
-generate stubs for you. You can read more about it in the [gRPC Swift Protobuf
-documentation][1].
-
 ## Usage
 
 Build and run the server using the CLI:
 
 ```console
-$ PROTOC_PATH=$(which protoc) swift run hello-world serve
+$ swift run hello-world serve
 Greeter listening on [ipv4]127.0.0.1:31415
 ```
 
 Use the CLI to send a request to the service:
 
 ```console
-$ PROTOC_PATH=$(which protoc) swift run hello-world greet
+$ swift run hello-world greet
 Hello, stranger
 ```
 
 Send the name of the greetee in the request by specifying a `--name`:
 
 ```console
-$ PROTOC_PATH=$(which protoc) swift run hello-world greet --name "PanCakes 🐶"
+$ swift run hello-world greet --name "PanCakes 🐶"
 Hello, PanCakes 🐶
 ```
-
-[0]: https://swiftpackageindex.com/grpc/grpc-swift-protobuf/documentation/grpcprotobuf/installing-protoc
-[1]: https://swiftpackageindex.com/grpc/grpc-swift-protobuf/documentation/grpcprotobuf/generating-stubs

--- a/Examples/reflection-server/Package.swift
+++ b/Examples/reflection-server/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
   platforms: [.macOS(.v15)],
   dependencies: [
     .package(url: "https://github.com/grpc/grpc-swift-2.git", from: "2.0.0"),
-    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "2.0.0"),
+    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "2.4.0"),
     .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "2.0.0"),
     .package(url: "https://github.com/grpc/grpc-swift-extras.git", from: "2.0.0"),
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0"),

--- a/Examples/reflection-server/README.md
+++ b/Examples/reflection-server/README.md
@@ -23,15 +23,6 @@ protoc --descriptor_set_out=path/to/output.pb path/to/input.proto \
   --include_imports
 ```
 
-## Prerequisites
-
-You must have the Protocol Buffers compiler (`protoc`) installed. You can find
-the instructions for doing this in the [gRPC Swift Protobuf documentation][0].
-The `swift` commands below are all prefixed with `PROTOC_PATH=$(which protoc)`,
-this is to let the build system know where `protoc` is located so that it can
-generate stubs for you. You can read more about it in the [gRPC Swift Protobuf
-documentation][1].
-
 ## Usage
 
 Build and run the server using the CLI:
@@ -68,6 +59,3 @@ $ grpcurl -plaintext -d '{ "text": "Hello" }' 127.0.0.1:31415 echo.Echo.Get
   "text": "Hello"
 }
 ```
-
-[0]: https://swiftpackageindex.com/grpc/grpc-swift-protobuf/documentation/grpcprotobuf/installing-protoc
-[1]: https://swiftpackageindex.com/grpc/grpc-swift-protobuf/documentation/grpcprotobuf/generating-stubs

--- a/Examples/route-guide/Package.swift
+++ b/Examples/route-guide/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
   platforms: [.macOS("15.0")],
   dependencies: [
     .package(url: "https://github.com/grpc/grpc-swift-2.git", from: "2.0.0"),
-    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "2.0.0"),
+    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "2.4.0"),
     .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "2.0.0"),
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0"),
   ],

--- a/Examples/route-guide/README.md
+++ b/Examples/route-guide/README.md
@@ -15,28 +15,19 @@ HTTP/2 transport.
 This example has an accompanying tutorial hosted on the [Swift Package
 Index](https://swiftpackageindex.com/grpc/grpc-swift/main/tutorials/grpccore/route-guide).
 
-## Prerequisites
-
-You must have the Protocol Buffers compiler (`protoc`) installed. You can find
-the instructions for doing this in the [gRPC Swift Protobuf documentation][0].
-The `swift` commands below are all prefixed with `PROTOC_PATH=$(which protoc)`,
-this is to let the build system know where `protoc` is located so that it can
-generate stubs for you. You can read more about it in the [gRPC Swift Protobuf
-documentation][1].
-
 ## Usage
 
 Build and run the server using the CLI:
 
 ```console
-$ PROTOC_PATH=$(which protoc) swift run route-guide serve
+$ swift run route-guide serve
 server listening on [ipv4]127.0.0.1:31415
 ```
 
 Use the CLI to interrogate the different RPCs you can call:
 
 ```console
-$ PROTOC_PATH=$(which protoc) swift run route-guide --help
+$ swift run route-guide --help
 USAGE: route-guide <subcommand>
 
 OPTIONS:
@@ -51,6 +42,3 @@ SUBCOMMANDS:
 
   See 'route-guide help <subcommand>' for detailed help.
 ```
-
-[0]: https://swiftpackageindex.com/grpc/grpc-swift-protobuf/documentation/grpcprotobuf/installing-protoc
-[1]: https://swiftpackageindex.com/grpc/grpc-swift-protobuf/documentation/grpcprotobuf/generating-stubs

--- a/Examples/service-lifecycle/Package.swift
+++ b/Examples/service-lifecycle/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
   platforms: [.macOS(.v15)],
   dependencies: [
     .package(url: "https://github.com/grpc/grpc-swift-2.git", from: "2.0.0"),
-    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "2.0.0"),
+    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "2.4.0"),
     .package(url: "https://github.com/grpc/grpc-swift-extras.git", from: "2.0.0"),
   ],
   targets: [

--- a/Examples/service-lifecycle/README.md
+++ b/Examples/service-lifecycle/README.md
@@ -10,21 +10,12 @@ A "service-lifecycle" command line tool that uses generated stubs for a
 Swift Service Lifecycle. The client makes requests against the server which
 periodically changes its greeting.
 
-## Prerequisites
-
-You must have the Protocol Buffers compiler (`protoc`) installed. You can find
-the instructions for doing this in the [gRPC Swift Protobuf documentation][0].
-The `swift` commands below are all prefixed with `PROTOC_PATH=$(which protoc)`,
-this is to let the build system know where `protoc` is located so that it can
-generate stubs for you. You can read more about it in the [gRPC Swift Protobuf
-documentation][1].
-
 ## Usage
 
 Build and run the server using the CLI:
 
 ```console
-$ PROTOC_PATH=$(which protoc) swift run service-lifecycle
+$ swift run service-lifecycle
 Здравствуйте, request-1!
 नमस्ते, request-2!
 你好, request-3!
@@ -36,6 +27,3 @@ Hello, request-8!
 नमस्ते, request-9!
 Hello, request-10!
 ```
-
-[0]: https://swiftpackageindex.com/grpc/grpc-swift-protobuf/documentation/grpcprotobuf/installing-protoc
-[1]: https://swiftpackageindex.com/grpc/grpc-swift-protobuf/documentation/grpcprotobuf/generating-stubs

--- a/Sources/GRPCCore/Documentation.docc/Tutorials/Hello-World/Hello-World.tutorial
+++ b/Sources/GRPCCore/Documentation.docc/Tutorials/Hello-World/Hello-World.tutorial
@@ -28,28 +28,22 @@
   @Section(title: "Run a gRPC application") {
     Let's start by running the existing Greeter application.
 
-    As a prerequisite you must have the Protocol Buffers compiler (`protoc`) installed. You can
-    find the instructions for doing this in the [gRPC Swift Protobuf
-    documentation](https://swiftpackageindex.com/grpc/grpc-swift-protobuf/documentation/grpcprotobuf/installing-protoc).
-    The remainder of this tutorial assumes you installed `protoc` and it's available in
-    your `$PATH`.
-
-    You may notice that the `swift` commands are all prefixed with `PROTOC_PATH=$(which protoc)`,
-    this is to let the build system know where `protoc` is located so that it can generate stubs
-    for you. You can read more about it in the  [gRPC Swift Protobuf
-    documentation](https://swiftpackageindex.com/grpc/grpc-swift-protobuf/documentation/grpcprotobuf/generating-stubs).
+    The build plugin used by this example generates gRPC Swift stubs at build time using a
+    vendored copy of `protoc` provided by the `swift-protobuf` package, so you don't need to
+    install `protoc` separately. You can read more about the build plugin in the [gRPC Swift
+    Protobuf documentation](https://swiftpackageindex.com/grpc/grpc-swift-protobuf/documentation/grpcprotobuf/generating-stubs).
 
     @Steps {
       @Step {
-        In a terminal run `PROTOC_PATH=$(which protoc) swift run hello-world serve` to start the
-        server. By default it'll start listening on port 31415.
+        In a terminal run `swift run hello-world serve` to start the server. By default it'll
+        start listening on port 31415.
 
         @Code(name: "Console.txt", file: "hello-world-sec02-step01.txt")
       }
 
       @Step {
-        In another terminal run `PROTOC_PATH=$(which protoc) swift run hello-world greet` to create
-        a client, connect to the server you started and send it a request and print the response.
+        In another terminal run `swift run hello-world greet` to create a client, connect to
+        the server you started and send it a request and print the response.
 
         @Code(name: "Console.txt", file: "hello-world-sec02-step02.txt")
       }
@@ -94,7 +88,7 @@
 
     @Steps {
       @Step {
-        Run `PROTOC_PATH=$(which protoc) swift build` to build the example. This will fail
+        Run `swift build` to build the example. This will fail
         because the service no longer implements all of the methods declared in the `.proto` file.
         Let's fix that!
       }
@@ -125,13 +119,13 @@
 
       @Step {
         Just like we did before, open a terminal and start the server by
-        running `PROTOC_PATH=$(which protoc) swift run hello-world serve`
+        running `swift run hello-world serve`
 
         @Code(name: "Console.txt", file: "hello-world-sec04-step05.txt")
       }
 
       @Step {
-        In a separate terminal run `PROTOC_PATH=$(which protoc) swift run hello-world greet` to
+        In a separate terminal run `swift run hello-world greet` to
         call the server.
 
         @Code(name: "Console.txt", file: "hello-world-sec04-step06.txt")

--- a/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec01-step07-description.swift
+++ b/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec01-step07-description.swift
@@ -6,7 +6,7 @@ let package = Package(
   platforms: [.macOS(.v15)],
   dependencies: [
     .package(url: "https://github.com/grpc/grpc-swift-2.git", from: "2.0.0"),
-    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "2.0.0"),
+    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "2.4.0"),
     .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "2.0.0"),
   ],
   targets: []

--- a/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec01-step08-description.swift
+++ b/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec01-step08-description.swift
@@ -6,7 +6,7 @@ let package = Package(
   platforms: [.macOS(.v15)],
   dependencies: [
     .package(url: "https://github.com/grpc/grpc-swift-2.git", from: "2.0.0"),
-    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "2.0.0"),
+    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "2.4.0"),
     .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "2.0.0"),
   ],
   targets: [

--- a/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec01-step09-plugin.swift
+++ b/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec01-step09-plugin.swift
@@ -6,7 +6,7 @@ let package = Package(
   platforms: [.macOS(.v15)],
   dependencies: [
     .package(url: "https://github.com/grpc/grpc-swift-2.git", from: "2.0.0"),
-    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "2.0.0"),
+    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "2.4.0"),
     .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "2.0.0"),
   ],
   targets: [

--- a/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec05-step00-package.swift
+++ b/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec05-step00-package.swift
@@ -6,7 +6,7 @@ let package = Package(
   platforms: [.macOS(.v15)],
   dependencies: [
     .package(url: "https://github.com/grpc/grpc-swift-2.git", from: "2.0.0"),
-    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "2.0.0"),
+    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "2.4.0"),
     .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "2.0.0"),
   ],
   targets: [

--- a/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec05-step01-package.swift
+++ b/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec05-step01-package.swift
@@ -6,7 +6,7 @@ let package = Package(
   platforms: [.macOS(.v15)],
   dependencies: [
     .package(url: "https://github.com/grpc/grpc-swift-2.git", from: "2.0.0"),
-    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "2.0.0"),
+    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "2.4.0"),
     .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "2.0.0"),
   ],
   targets: [

--- a/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec05-step02-package.swift
+++ b/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec05-step02-package.swift
@@ -6,7 +6,7 @@ let package = Package(
   platforms: [.macOS(.v15)],
   dependencies: [
     .package(url: "https://github.com/grpc/grpc-swift-2.git", from: "2.0.0"),
-    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "2.0.0"),
+    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "2.4.0"),
     .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "2.0.0"),
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.0"),
   ],

--- a/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Route-Guide.tutorial
+++ b/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Route-Guide.tutorial
@@ -20,16 +20,10 @@
     Before we can write any code we need to create a new Swift Package and configure it
     to depend on gRPC Swift.
 
-    As a prerequisite you must have the Protocol Buffers compiler (`protoc`) installed. You can
-    find the instructions for doing this in the [gRPC Swift Protobuf
-    documentation](https://swiftpackageindex.com/grpc/grpc-swift-protobuf/documentation/grpcprotobuf/installing-protoc).
-    The remainder of this tutorial assumes you installed `protoc` and it's available in
-    your `$PATH`.
-
-    You may notice that the `swift` commands are all prefixed with `PROTOC_PATH=$(which protoc)`,
-    this is to let the build system know where `protoc` is located so that it can generate stubs
-    for you. You can read more about it in the  [gRPC Swift Protobuf
-    documentation](https://swiftpackageindex.com/grpc/grpc-swift-protobuf/documentation/grpcprotobuf/generating-stubs).
+    The build plugin used by this tutorial generates gRPC Swift stubs at build time using a
+    vendored copy of `protoc` provided by the `swift-protobuf` package, so you don't need to
+    install `protoc` separately. You can read more about the build plugin in the [gRPC Swift
+    Protobuf documentation](https://swiftpackageindex.com/grpc/grpc-swift-protobuf/documentation/grpcprotobuf/generating-stubs).
 
     @Steps {
       @Step {
@@ -204,10 +198,7 @@
 
     @Steps {
       @Step {
-        Build the project using `PROTOC_PATH=$(which protoc) swift build`.
-
-        If you are using Xcode or another IDE then you'll need to set the environment variable
-        appropriately.
+        Build the project using `swift build`.
       }
     }
   }
@@ -479,13 +470,13 @@
 
     @Steps {
       @Step {
-        In one terminal run `PROTOC_PATH=$(which protoc) swift run RouteGuide --server` to start the server.
+        In one terminal run `swift run RouteGuide --server` to start the server.
 
         @Code(name: "Console", file: "route-guide-sec07-step01-server.txt")
       }
 
       @Step {
-        In another terminal run `PROTOC_PATH=$(which protoc) swift run RouteGuide` to run the client program.
+        In another terminal run `swift run RouteGuide` to run the client program.
 
         @Code(name: "Console", file: "route-guide-sec07-step02-client.txt")
       }

--- a/Tests/GRPCCoreTests/Configuration/Generated/code.pb.swift
+++ b/Tests/GRPCCoreTests/Configuration/Generated/code.pb.swift
@@ -29,7 +29,7 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
@@ -41,7 +41,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 /// the most specific error code that applies.  For example, prefer
 /// `OUT_OF_RANGE` over `FAILED_PRECONDITION` if both codes apply.
 /// Similarly prefer `NOT_FOUND` or `ALREADY_EXISTS` over `FAILED_PRECONDITION`.
-enum Google_Rpc_Code: SwiftProtobuf.Enum, Swift.CaseIterable {
+nonisolated enum Google_Rpc_Code: SwiftProtobuf.Enum, Swift.CaseIterable {
   typealias RawValue = Int
 
   /// Not an error; returned on success.
@@ -274,6 +274,6 @@ enum Google_Rpc_Code: SwiftProtobuf.Enum, Swift.CaseIterable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-extension Google_Rpc_Code: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Google_Rpc_Code: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0OK\0\u{1}CANCELLED\0\u{1}UNKNOWN\0\u{1}INVALID_ARGUMENT\0\u{1}DEADLINE_EXCEEDED\0\u{1}NOT_FOUND\0\u{1}ALREADY_EXISTS\0\u{1}PERMISSION_DENIED\0\u{1}RESOURCE_EXHAUSTED\0\u{1}FAILED_PRECONDITION\0\u{1}ABORTED\0\u{1}OUT_OF_RANGE\0\u{1}UNIMPLEMENTED\0\u{1}INTERNAL\0\u{1}UNAVAILABLE\0\u{1}DATA_LOSS\0\u{1}UNAUTHENTICATED\0")
 }

--- a/Tests/GRPCCoreTests/Configuration/Generated/rls.pb.swift
+++ b/Tests/GRPCCoreTests/Configuration/Generated/rls.pb.swift
@@ -29,12 +29,12 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
-struct Grpc_Lookup_V1_RouteLookupRequest: Sendable {
+nonisolated struct Grpc_Lookup_V1_RouteLookupRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -58,7 +58,7 @@ struct Grpc_Lookup_V1_RouteLookupRequest: Sendable {
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// Possible reasons for making a request.
-  enum Reason: SwiftProtobuf.Enum, Swift.CaseIterable {
+  nonisolated enum Reason: SwiftProtobuf.Enum, Swift.CaseIterable {
     typealias RawValue = Int
 
     /// Unused
@@ -105,7 +105,7 @@ struct Grpc_Lookup_V1_RouteLookupRequest: Sendable {
   init() {}
 }
 
-struct Grpc_Lookup_V1_RouteLookupResponse: Sendable {
+nonisolated struct Grpc_Lookup_V1_RouteLookupResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -130,9 +130,9 @@ struct Grpc_Lookup_V1_RouteLookupResponse: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "grpc.lookup.v1"
+fileprivate nonisolated let _protobuf_package = "grpc.lookup.v1"
 
-extension Grpc_Lookup_V1_RouteLookupRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Lookup_V1_RouteLookupRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RouteLookupRequest"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{4}\u{3}target_type\0\u{3}key_map\0\u{1}reason\0\u{3}stale_header_data\0\u{1}extensions\0\u{b}server\0\u{b}path\0\u{c}\u{1}\u{1}\u{c}\u{2}\u{1}")
 
@@ -182,11 +182,11 @@ extension Grpc_Lookup_V1_RouteLookupRequest: SwiftProtobuf.Message, SwiftProtobu
   }
 }
 
-extension Grpc_Lookup_V1_RouteLookupRequest.Reason: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Lookup_V1_RouteLookupRequest.Reason: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0REASON_UNKNOWN\0\u{1}REASON_MISS\0\u{1}REASON_STALE\0")
 }
 
-extension Grpc_Lookup_V1_RouteLookupResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Lookup_V1_RouteLookupResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RouteLookupResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{4}\u{2}header_data\0\u{1}targets\0\u{1}extensions\0\u{b}target\0\u{c}\u{1}\u{1}")
 

--- a/Tests/GRPCCoreTests/Configuration/Generated/rls_config.pb.swift
+++ b/Tests/GRPCCoreTests/Configuration/Generated/rls_config.pb.swift
@@ -29,7 +29,7 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
@@ -38,7 +38,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 /// name).  The name must match one of the names listed in the "name" field.  If
 /// the "required_match" field is true, one of the specified names must be
 /// present for the keybuilder to match.
-struct Grpc_Lookup_V1_NameMatcher: Sendable {
+nonisolated struct Grpc_Lookup_V1_NameMatcher: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -63,7 +63,7 @@ struct Grpc_Lookup_V1_NameMatcher: Sendable {
 }
 
 /// A GrpcKeyBuilder applies to a given gRPC service, name, and headers.
-struct Grpc_Lookup_V1_GrpcKeyBuilder: Sendable {
+nonisolated struct Grpc_Lookup_V1_GrpcKeyBuilder: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -96,7 +96,7 @@ struct Grpc_Lookup_V1_GrpcKeyBuilder: Sendable {
   /// fields are specified as fixed strings.  The service name is required and
   /// includes the proto package name.  The method name may be omitted, in
   /// which case any method on the given service is matched.
-  struct Name: Sendable {
+  nonisolated struct Name: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -116,7 +116,7 @@ struct Grpc_Lookup_V1_GrpcKeyBuilder: Sendable {
   /// If this submessage is specified, the normal host/path fields will be left
   /// unset in the RouteLookupRequest. We are deprecating host/path in the
   /// RouteLookupRequest, so services should migrate to the ExtraKeys approach.
-  struct ExtraKeys: Sendable {
+  nonisolated struct ExtraKeys: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -153,7 +153,7 @@ struct Grpc_Lookup_V1_GrpcKeyBuilder: Sendable {
 /// the id and the second segment as the object. If the host has a subdomain, the
 /// subdomain will be used as the id and the first segment as the object. If
 /// neither pattern matches, no keys will be extracted.
-struct Grpc_Lookup_V1_HttpKeyBuilder: Sendable {
+nonisolated struct Grpc_Lookup_V1_HttpKeyBuilder: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -229,7 +229,7 @@ struct Grpc_Lookup_V1_HttpKeyBuilder: Sendable {
   init() {}
 }
 
-struct Grpc_Lookup_V1_RouteLookupConfig: Sendable {
+nonisolated struct Grpc_Lookup_V1_RouteLookupConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -317,7 +317,7 @@ struct Grpc_Lookup_V1_RouteLookupConfig: Sendable {
 
 /// RouteLookupClusterSpecifier is used in xDS to represent a cluster specifier
 /// plugin for RLS.
-struct Grpc_Lookup_V1_RouteLookupClusterSpecifier: Sendable {
+nonisolated struct Grpc_Lookup_V1_RouteLookupClusterSpecifier: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -341,9 +341,9 @@ struct Grpc_Lookup_V1_RouteLookupClusterSpecifier: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "grpc.lookup.v1"
+fileprivate nonisolated let _protobuf_package = "grpc.lookup.v1"
 
-extension Grpc_Lookup_V1_NameMatcher: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Lookup_V1_NameMatcher: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".NameMatcher"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}key\0\u{1}names\0\u{3}required_match\0")
 
@@ -383,7 +383,7 @@ extension Grpc_Lookup_V1_NameMatcher: SwiftProtobuf.Message, SwiftProtobuf._Mess
   }
 }
 
-extension Grpc_Lookup_V1_GrpcKeyBuilder: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Lookup_V1_GrpcKeyBuilder: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".GrpcKeyBuilder"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}names\0\u{1}headers\0\u{3}extra_keys\0\u{3}constant_keys\0")
 
@@ -432,7 +432,7 @@ extension Grpc_Lookup_V1_GrpcKeyBuilder: SwiftProtobuf.Message, SwiftProtobuf._M
   }
 }
 
-extension Grpc_Lookup_V1_GrpcKeyBuilder.Name: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Lookup_V1_GrpcKeyBuilder.Name: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Grpc_Lookup_V1_GrpcKeyBuilder.protoMessageName + ".Name"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}service\0\u{1}method\0")
 
@@ -467,7 +467,7 @@ extension Grpc_Lookup_V1_GrpcKeyBuilder.Name: SwiftProtobuf.Message, SwiftProtob
   }
 }
 
-extension Grpc_Lookup_V1_GrpcKeyBuilder.ExtraKeys: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Lookup_V1_GrpcKeyBuilder.ExtraKeys: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Grpc_Lookup_V1_GrpcKeyBuilder.protoMessageName + ".ExtraKeys"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}host\0\u{1}service\0\u{1}method\0")
 
@@ -507,7 +507,7 @@ extension Grpc_Lookup_V1_GrpcKeyBuilder.ExtraKeys: SwiftProtobuf.Message, SwiftP
   }
 }
 
-extension Grpc_Lookup_V1_HttpKeyBuilder: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Lookup_V1_HttpKeyBuilder: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".HttpKeyBuilder"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}host_patterns\0\u{3}path_patterns\0\u{3}query_parameters\0\u{1}headers\0\u{3}constant_keys\0\u{1}method\0")
 
@@ -562,7 +562,7 @@ extension Grpc_Lookup_V1_HttpKeyBuilder: SwiftProtobuf.Message, SwiftProtobuf._M
   }
 }
 
-extension Grpc_Lookup_V1_RouteLookupConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Lookup_V1_RouteLookupConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RouteLookupConfig"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}http_keybuilders\0\u{3}grpc_keybuilders\0\u{3}lookup_service\0\u{3}lookup_service_timeout\0\u{3}max_age\0\u{3}stale_age\0\u{3}cache_size_bytes\0\u{3}valid_targets\0\u{3}default_target\0\u{b}request_processing_strategy\0\u{c}\u{a}\u{1}")
 
@@ -636,7 +636,7 @@ extension Grpc_Lookup_V1_RouteLookupConfig: SwiftProtobuf.Message, SwiftProtobuf
   }
 }
 
-extension Grpc_Lookup_V1_RouteLookupClusterSpecifier: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_Lookup_V1_RouteLookupClusterSpecifier: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RouteLookupClusterSpecifier"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}route_lookup_config\0")
 

--- a/Tests/GRPCCoreTests/Configuration/Generated/service_config.pb.swift
+++ b/Tests/GRPCCoreTests/Configuration/Generated/service_config.pb.swift
@@ -43,13 +43,13 @@ import SwiftProtobuf
 // incompatible with the version of SwiftProtobuf to which you are linking.
 // Please ensure that you are building against the same version of the API
 // that was used to generate this file.
-fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
+fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAPIVersionCheck {
   struct _2: SwiftProtobuf.ProtobufAPIVersion_2 {}
   typealias Version = _2
 }
 
 /// Configuration for a method.
-struct Grpc_ServiceConfig_MethodConfig: Sendable {
+nonisolated struct Grpc_ServiceConfig_MethodConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -165,7 +165,7 @@ struct Grpc_ServiceConfig_MethodConfig: Sendable {
 
   /// Only one of retry_policy or hedging_policy may be set. If neither is set,
   /// RPCs will not be retried or hedged.
-  enum OneOf_RetryOrHedgingPolicy: Equatable, Sendable {
+  nonisolated enum OneOf_RetryOrHedgingPolicy: Equatable, Sendable {
     case retryPolicy(Grpc_ServiceConfig_MethodConfig.RetryPolicy)
     case hedgingPolicy(Grpc_ServiceConfig_MethodConfig.HedgingPolicy)
 
@@ -198,7 +198,7 @@ struct Grpc_ServiceConfig_MethodConfig: Sendable {
   /// - { "service": "s" }
   /// - { "service": "s", "method": null }
   /// - { "service": "s", "method": "" }
-  struct Name: Sendable {
+  nonisolated struct Name: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -214,7 +214,7 @@ struct Grpc_ServiceConfig_MethodConfig: Sendable {
   }
 
   /// The retry policy for outgoing RPCs.
-  struct RetryPolicy: Sendable {
+  nonisolated struct RetryPolicy: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -268,7 +268,7 @@ struct Grpc_ServiceConfig_MethodConfig: Sendable {
   /// The hedging policy for outgoing RPCs. Hedged RPCs may execute more than
   /// once on the server, so only idempotent methods should specify a hedging
   /// policy.
-  struct HedgingPolicy: Sendable {
+  nonisolated struct HedgingPolicy: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -317,7 +317,7 @@ struct Grpc_ServiceConfig_MethodConfig: Sendable {
 }
 
 /// Configuration for pick_first LB policy.
-struct Grpc_ServiceConfig_PickFirstConfig: Sendable {
+nonisolated struct Grpc_ServiceConfig_PickFirstConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -333,7 +333,7 @@ struct Grpc_ServiceConfig_PickFirstConfig: Sendable {
 }
 
 /// Configuration for round_robin LB policy.
-struct Grpc_ServiceConfig_RoundRobinConfig: Sendable {
+nonisolated struct Grpc_ServiceConfig_RoundRobinConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -344,7 +344,7 @@ struct Grpc_ServiceConfig_RoundRobinConfig: Sendable {
 }
 
 /// Configuration for weighted_round_robin LB policy.
-struct Grpc_ServiceConfig_WeightedRoundRobinLbConfig: Sendable {
+nonisolated struct Grpc_ServiceConfig_WeightedRoundRobinLbConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -437,7 +437,7 @@ struct Grpc_ServiceConfig_WeightedRoundRobinLbConfig: Sendable {
 }
 
 /// Configuration for outlier_detection LB policy
-struct Grpc_ServiceConfig_OutlierDetectionLoadBalancingConfig: Sendable {
+nonisolated struct Grpc_ServiceConfig_OutlierDetectionLoadBalancingConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -516,7 +516,7 @@ struct Grpc_ServiceConfig_OutlierDetectionLoadBalancingConfig: Sendable {
   /// Parameters for the success rate ejection algorithm.
   /// This algorithm monitors the request success rate for all endpoints and
   /// ejects individual endpoints whose success rates are statistical outliers.
-  struct SuccessRateEjection: Sendable {
+  nonisolated struct SuccessRateEjection: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -589,7 +589,7 @@ struct Grpc_ServiceConfig_OutlierDetectionLoadBalancingConfig: Sendable {
   /// Parameters for the failure percentage algorithm.
   /// This algorithm ejects individual endpoints whose failure rate is greater than
   /// some threshold, independently of any other endpoint.
-  struct FailurePercentageEjection: Sendable {
+  nonisolated struct FailurePercentageEjection: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -664,7 +664,7 @@ struct Grpc_ServiceConfig_OutlierDetectionLoadBalancingConfig: Sendable {
 }
 
 /// Configuration for grpclb LB policy.
-struct Grpc_ServiceConfig_GrpcLbConfig: Sendable {
+nonisolated struct Grpc_ServiceConfig_GrpcLbConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -700,7 +700,7 @@ struct Grpc_ServiceConfig_GrpcLbConfig: Sendable {
 }
 
 /// Configuration for priority LB policy.
-struct Grpc_ServiceConfig_PriorityLoadBalancingPolicyConfig: Sendable {
+nonisolated struct Grpc_ServiceConfig_PriorityLoadBalancingPolicyConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -717,7 +717,7 @@ struct Grpc_ServiceConfig_PriorityLoadBalancingPolicyConfig: Sendable {
   /// The names are used to allow the priority policy to update
   /// existing child policies instead of creating new ones every
   /// time it receives a config update.
-  struct Child: Sendable {
+  nonisolated struct Child: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -736,7 +736,7 @@ struct Grpc_ServiceConfig_PriorityLoadBalancingPolicyConfig: Sendable {
 }
 
 /// Configuration for weighted_target LB policy.
-struct Grpc_ServiceConfig_WeightedTargetLoadBalancingPolicyConfig: Sendable {
+nonisolated struct Grpc_ServiceConfig_WeightedTargetLoadBalancingPolicyConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -745,7 +745,7 @@ struct Grpc_ServiceConfig_WeightedTargetLoadBalancingPolicyConfig: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct Target: Sendable {
+  nonisolated struct Target: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -763,7 +763,7 @@ struct Grpc_ServiceConfig_WeightedTargetLoadBalancingPolicyConfig: Sendable {
 }
 
 /// Config for RLS LB policy.
-struct Grpc_ServiceConfig_RlsLoadBalancingPolicyConfig: @unchecked Sendable {
+nonisolated struct Grpc_ServiceConfig_RlsLoadBalancingPolicyConfig: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -806,7 +806,7 @@ struct Grpc_ServiceConfig_RlsLoadBalancingPolicyConfig: @unchecked Sendable {
 }
 
 /// Configuration for xds_cluster_manager_experimental LB policy.
-struct Grpc_ServiceConfig_XdsClusterManagerLoadBalancingPolicyConfig: Sendable {
+nonisolated struct Grpc_ServiceConfig_XdsClusterManagerLoadBalancingPolicyConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -815,7 +815,7 @@ struct Grpc_ServiceConfig_XdsClusterManagerLoadBalancingPolicyConfig: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct Child: Sendable {
+  nonisolated struct Child: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -831,7 +831,7 @@ struct Grpc_ServiceConfig_XdsClusterManagerLoadBalancingPolicyConfig: Sendable {
 }
 
 /// Configuration for the cds LB policy.
-struct Grpc_ServiceConfig_CdsConfig: Sendable {
+nonisolated struct Grpc_ServiceConfig_CdsConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -848,7 +848,7 @@ struct Grpc_ServiceConfig_CdsConfig: Sendable {
 }
 
 /// Configuration for xds_cluster_impl LB policy.
-struct Grpc_ServiceConfig_XdsClusterImplLoadBalancingPolicyConfig: Sendable {
+nonisolated struct Grpc_ServiceConfig_XdsClusterImplLoadBalancingPolicyConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -920,7 +920,7 @@ struct Grpc_ServiceConfig_XdsClusterImplLoadBalancingPolicyConfig: Sendable {
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// Drop configuration.
-  struct DropCategory: Sendable {
+  nonisolated struct DropCategory: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -942,7 +942,7 @@ struct Grpc_ServiceConfig_XdsClusterImplLoadBalancingPolicyConfig: Sendable {
 }
 
 /// Configuration for ring_hash LB policy.
-struct Grpc_ServiceConfig_RingHashLoadBalancingConfig: Sendable {
+nonisolated struct Grpc_ServiceConfig_RingHashLoadBalancingConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -961,7 +961,7 @@ struct Grpc_ServiceConfig_RingHashLoadBalancingConfig: Sendable {
 }
 
 /// Configuration for the xds_wrr_locality load balancing policy.
-struct Grpc_ServiceConfig_XdsWrrLocalityLoadBalancingPolicyConfig: Sendable {
+nonisolated struct Grpc_ServiceConfig_XdsWrrLocalityLoadBalancingPolicyConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -974,7 +974,7 @@ struct Grpc_ServiceConfig_XdsWrrLocalityLoadBalancingPolicyConfig: Sendable {
 }
 
 /// Configuration for the least_request LB policy.
-struct Grpc_ServiceConfig_LeastRequestLocalityLoadBalancingPolicyConfig: Sendable {
+nonisolated struct Grpc_ServiceConfig_LeastRequestLocalityLoadBalancingPolicyConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -987,7 +987,7 @@ struct Grpc_ServiceConfig_LeastRequestLocalityLoadBalancingPolicyConfig: Sendabl
 }
 
 /// Configuration for the xds_override_host LB policy.
-struct Grpc_ServiceConfig_OverrideHostLoadBalancingPolicyConfig: Sendable {
+nonisolated struct Grpc_ServiceConfig_OverrideHostLoadBalancingPolicyConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1005,7 +1005,7 @@ struct Grpc_ServiceConfig_OverrideHostLoadBalancingPolicyConfig: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum HealthStatus: SwiftProtobuf.Enum, Swift.CaseIterable {
+  nonisolated enum HealthStatus: SwiftProtobuf.Enum, Swift.CaseIterable {
     typealias RawValue = Int
     case unknown // = 0
     case healthy // = 1
@@ -1057,7 +1057,7 @@ struct Grpc_ServiceConfig_OverrideHostLoadBalancingPolicyConfig: Sendable {
 ///   config is invalid.
 /// - If the list doesn't contain any supported policy, the whole service config
 ///   is invalid.
-struct Grpc_ServiceConfig_LoadBalancingConfig: Sendable {
+nonisolated struct Grpc_ServiceConfig_LoadBalancingConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1239,7 +1239,7 @@ struct Grpc_ServiceConfig_LoadBalancingConfig: Sendable {
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// Exactly one LB policy may be configured.
-  enum OneOf_Policy: Equatable, Sendable {
+  nonisolated enum OneOf_Policy: Equatable, Sendable {
     case pickFirst(Grpc_ServiceConfig_PickFirstConfig)
     case roundRobin(Grpc_ServiceConfig_RoundRobinConfig)
     case weightedRoundRobin(Grpc_ServiceConfig_WeightedRoundRobinLbConfig)
@@ -1279,7 +1279,7 @@ struct Grpc_ServiceConfig_LoadBalancingConfig: Sendable {
 
 /// A ServiceConfig represents information about a service but is not specific to
 /// any name resolver.
-struct Grpc_ServiceConfig_ServiceConfig: Sendable {
+nonisolated struct Grpc_ServiceConfig_ServiceConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1333,7 +1333,7 @@ struct Grpc_ServiceConfig_ServiceConfig: Sendable {
   /// returns at least one backend address in addition to the balancer
   /// address(es), the client may fall back to the requested policy if it
   /// is unable to reach any of the grpclb load balancers.
-  enum LoadBalancingPolicy: SwiftProtobuf.Enum, Swift.CaseIterable {
+  nonisolated enum LoadBalancingPolicy: SwiftProtobuf.Enum, Swift.CaseIterable {
     typealias RawValue = Int
     case unspecified // = 0
     case roundRobin // = 1
@@ -1380,7 +1380,7 @@ struct Grpc_ServiceConfig_ServiceConfig: Sendable {
   ///
   /// If token_count is less than or equal to max_tokens / 2, then RPCs will not
   /// be retried and hedged RPCs will not be sent.
-  struct RetryThrottlingPolicy: Sendable {
+  nonisolated struct RetryThrottlingPolicy: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1403,7 +1403,7 @@ struct Grpc_ServiceConfig_ServiceConfig: Sendable {
     init() {}
   }
 
-  struct HealthCheckConfig: Sendable {
+  nonisolated struct HealthCheckConfig: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1433,7 +1433,7 @@ struct Grpc_ServiceConfig_ServiceConfig: Sendable {
 
 /// Represents an xDS server.
 /// Deprecated.
-struct Grpc_ServiceConfig_XdsServer: Sendable {
+nonisolated struct Grpc_ServiceConfig_XdsServer: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1449,7 +1449,7 @@ struct Grpc_ServiceConfig_XdsServer: Sendable {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct ChannelCredentials: Sendable {
+  nonisolated struct ChannelCredentials: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1479,7 +1479,7 @@ struct Grpc_ServiceConfig_XdsServer: Sendable {
 
 /// Configuration for xds_cluster_resolver LB policy.
 /// Deprecated.
-struct Grpc_ServiceConfig_XdsClusterResolverLoadBalancingPolicyConfig: Sendable {
+nonisolated struct Grpc_ServiceConfig_XdsClusterResolverLoadBalancingPolicyConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1501,7 +1501,7 @@ struct Grpc_ServiceConfig_XdsClusterResolverLoadBalancingPolicyConfig: Sendable 
   /// CDS policy.
   /// For aggregate clusters, there will be one DiscoveryMechanism for each
   /// underlying cluster.
-  struct DiscoveryMechanism: @unchecked Sendable {
+  nonisolated struct DiscoveryMechanism: @unchecked Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1596,7 +1596,7 @@ struct Grpc_ServiceConfig_XdsClusterResolverLoadBalancingPolicyConfig: Sendable 
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    enum TypeEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
+    nonisolated enum TypeEnum: SwiftProtobuf.Enum, Swift.CaseIterable {
       typealias RawValue = Int
       case unknown // = 0
       case eds // = 1
@@ -1644,7 +1644,7 @@ struct Grpc_ServiceConfig_XdsClusterResolverLoadBalancingPolicyConfig: Sendable 
 
 /// Configuration for lrs LB policy.
 /// Deprecated.
-struct Grpc_ServiceConfig_LrsLoadBalancingPolicyConfig: Sendable {
+nonisolated struct Grpc_ServiceConfig_LrsLoadBalancingPolicyConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1676,7 +1676,7 @@ struct Grpc_ServiceConfig_LrsLoadBalancingPolicyConfig: Sendable {
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// The locality for which this policy will report load.  Required.
-  struct Locality: Sendable {
+  nonisolated struct Locality: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -1699,7 +1699,7 @@ struct Grpc_ServiceConfig_LrsLoadBalancingPolicyConfig: Sendable {
 
 /// Configuration for eds LB policy.
 /// Deprecated.
-struct Grpc_ServiceConfig_EdsLoadBalancingPolicyConfig: Sendable {
+nonisolated struct Grpc_ServiceConfig_EdsLoadBalancingPolicyConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1747,7 +1747,7 @@ struct Grpc_ServiceConfig_EdsLoadBalancingPolicyConfig: Sendable {
 
 /// Configuration for xds LB policy.
 /// Deprecated.
-struct Grpc_ServiceConfig_XdsConfig: Sendable {
+nonisolated struct Grpc_ServiceConfig_XdsConfig: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1795,9 +1795,9 @@ struct Grpc_ServiceConfig_XdsConfig: Sendable {
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-fileprivate let _protobuf_package = "grpc.service_config"
+fileprivate nonisolated let _protobuf_package = "grpc.service_config"
 
-extension Grpc_ServiceConfig_MethodConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_ServiceConfig_MethodConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".MethodConfig"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{3}wait_for_ready\0\u{1}timeout\0\u{3}max_request_message_bytes\0\u{3}max_response_message_bytes\0\u{3}retry_policy\0\u{3}hedging_policy\0")
 
@@ -1889,7 +1889,7 @@ extension Grpc_ServiceConfig_MethodConfig: SwiftProtobuf.Message, SwiftProtobuf.
   }
 }
 
-extension Grpc_ServiceConfig_MethodConfig.Name: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_ServiceConfig_MethodConfig.Name: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Grpc_ServiceConfig_MethodConfig.protoMessageName + ".Name"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}service\0\u{1}method\0")
 
@@ -1924,7 +1924,7 @@ extension Grpc_ServiceConfig_MethodConfig.Name: SwiftProtobuf.Message, SwiftProt
   }
 }
 
-extension Grpc_ServiceConfig_MethodConfig.RetryPolicy: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_ServiceConfig_MethodConfig.RetryPolicy: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Grpc_ServiceConfig_MethodConfig.protoMessageName + ".RetryPolicy"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}max_attempts\0\u{3}initial_backoff\0\u{3}max_backoff\0\u{3}backoff_multiplier\0\u{3}retryable_status_codes\0")
 
@@ -1978,7 +1978,7 @@ extension Grpc_ServiceConfig_MethodConfig.RetryPolicy: SwiftProtobuf.Message, Sw
   }
 }
 
-extension Grpc_ServiceConfig_MethodConfig.HedgingPolicy: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_ServiceConfig_MethodConfig.HedgingPolicy: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Grpc_ServiceConfig_MethodConfig.protoMessageName + ".HedgingPolicy"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}max_attempts\0\u{3}hedging_delay\0\u{3}non_fatal_status_codes\0")
 
@@ -2022,7 +2022,7 @@ extension Grpc_ServiceConfig_MethodConfig.HedgingPolicy: SwiftProtobuf.Message, 
   }
 }
 
-extension Grpc_ServiceConfig_PickFirstConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_ServiceConfig_PickFirstConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".PickFirstConfig"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}shuffle_address_list\0")
 
@@ -2052,7 +2052,7 @@ extension Grpc_ServiceConfig_PickFirstConfig: SwiftProtobuf.Message, SwiftProtob
   }
 }
 
-extension Grpc_ServiceConfig_RoundRobinConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_ServiceConfig_RoundRobinConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RoundRobinConfig"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap()
 
@@ -2071,7 +2071,7 @@ extension Grpc_ServiceConfig_RoundRobinConfig: SwiftProtobuf.Message, SwiftProto
   }
 }
 
-extension Grpc_ServiceConfig_WeightedRoundRobinLbConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_ServiceConfig_WeightedRoundRobinLbConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".WeightedRoundRobinLbConfig"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}enable_oob_load_report\0\u{3}oob_reporting_period\0\u{3}blackout_period\0\u{3}weight_expiration_period\0\u{3}weight_update_period\0\u{3}error_utilization_penalty\0")
 
@@ -2130,7 +2130,7 @@ extension Grpc_ServiceConfig_WeightedRoundRobinLbConfig: SwiftProtobuf.Message, 
   }
 }
 
-extension Grpc_ServiceConfig_OutlierDetectionLoadBalancingConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_ServiceConfig_OutlierDetectionLoadBalancingConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".OutlierDetectionLoadBalancingConfig"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}interval\0\u{3}base_ejection_time\0\u{3}max_ejection_time\0\u{3}max_ejection_percent\0\u{3}success_rate_ejection\0\u{3}failure_percentage_ejection\0\u{4}\u{7}child_policy\0")
 
@@ -2194,7 +2194,7 @@ extension Grpc_ServiceConfig_OutlierDetectionLoadBalancingConfig: SwiftProtobuf.
   }
 }
 
-extension Grpc_ServiceConfig_OutlierDetectionLoadBalancingConfig.SuccessRateEjection: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_ServiceConfig_OutlierDetectionLoadBalancingConfig.SuccessRateEjection: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Grpc_ServiceConfig_OutlierDetectionLoadBalancingConfig.protoMessageName + ".SuccessRateEjection"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}stdev_factor\0\u{3}enforcement_percentage\0\u{3}minimum_hosts\0\u{3}request_volume\0")
 
@@ -2243,7 +2243,7 @@ extension Grpc_ServiceConfig_OutlierDetectionLoadBalancingConfig.SuccessRateEjec
   }
 }
 
-extension Grpc_ServiceConfig_OutlierDetectionLoadBalancingConfig.FailurePercentageEjection: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_ServiceConfig_OutlierDetectionLoadBalancingConfig.FailurePercentageEjection: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Grpc_ServiceConfig_OutlierDetectionLoadBalancingConfig.protoMessageName + ".FailurePercentageEjection"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}threshold\0\u{3}enforcement_percentage\0\u{3}minimum_hosts\0\u{3}request_volume\0")
 
@@ -2292,7 +2292,7 @@ extension Grpc_ServiceConfig_OutlierDetectionLoadBalancingConfig.FailurePercenta
   }
 }
 
-extension Grpc_ServiceConfig_GrpcLbConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_ServiceConfig_GrpcLbConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".GrpcLbConfig"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}child_policy\0\u{3}service_name\0\u{3}initial_fallback_timeout\0")
 
@@ -2336,7 +2336,7 @@ extension Grpc_ServiceConfig_GrpcLbConfig: SwiftProtobuf.Message, SwiftProtobuf.
   }
 }
 
-extension Grpc_ServiceConfig_PriorityLoadBalancingPolicyConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_ServiceConfig_PriorityLoadBalancingPolicyConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".PriorityLoadBalancingPolicyConfig"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}children\0\u{1}priorities\0")
 
@@ -2371,7 +2371,7 @@ extension Grpc_ServiceConfig_PriorityLoadBalancingPolicyConfig: SwiftProtobuf.Me
   }
 }
 
-extension Grpc_ServiceConfig_PriorityLoadBalancingPolicyConfig.Child: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_ServiceConfig_PriorityLoadBalancingPolicyConfig.Child: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Grpc_ServiceConfig_PriorityLoadBalancingPolicyConfig.protoMessageName + ".Child"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}config\0\u{3}ignore_reresolution_requests\0")
 
@@ -2406,7 +2406,7 @@ extension Grpc_ServiceConfig_PriorityLoadBalancingPolicyConfig.Child: SwiftProto
   }
 }
 
-extension Grpc_ServiceConfig_WeightedTargetLoadBalancingPolicyConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_ServiceConfig_WeightedTargetLoadBalancingPolicyConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".WeightedTargetLoadBalancingPolicyConfig"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}targets\0")
 
@@ -2436,7 +2436,7 @@ extension Grpc_ServiceConfig_WeightedTargetLoadBalancingPolicyConfig: SwiftProto
   }
 }
 
-extension Grpc_ServiceConfig_WeightedTargetLoadBalancingPolicyConfig.Target: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_ServiceConfig_WeightedTargetLoadBalancingPolicyConfig.Target: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Grpc_ServiceConfig_WeightedTargetLoadBalancingPolicyConfig.protoMessageName + ".Target"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}weight\0\u{3}child_policy\0")
 
@@ -2471,7 +2471,7 @@ extension Grpc_ServiceConfig_WeightedTargetLoadBalancingPolicyConfig.Target: Swi
   }
 }
 
-extension Grpc_ServiceConfig_RlsLoadBalancingPolicyConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_ServiceConfig_RlsLoadBalancingPolicyConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RlsLoadBalancingPolicyConfig"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}route_lookup_config\0\u{3}route_lookup_channel_service_config\0\u{3}child_policy\0\u{3}child_policy_config_target_field_name\0")
 
@@ -2562,7 +2562,7 @@ extension Grpc_ServiceConfig_RlsLoadBalancingPolicyConfig: SwiftProtobuf.Message
   }
 }
 
-extension Grpc_ServiceConfig_XdsClusterManagerLoadBalancingPolicyConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_ServiceConfig_XdsClusterManagerLoadBalancingPolicyConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".XdsClusterManagerLoadBalancingPolicyConfig"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}children\0")
 
@@ -2592,7 +2592,7 @@ extension Grpc_ServiceConfig_XdsClusterManagerLoadBalancingPolicyConfig: SwiftPr
   }
 }
 
-extension Grpc_ServiceConfig_XdsClusterManagerLoadBalancingPolicyConfig.Child: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_ServiceConfig_XdsClusterManagerLoadBalancingPolicyConfig.Child: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Grpc_ServiceConfig_XdsClusterManagerLoadBalancingPolicyConfig.protoMessageName + ".Child"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}child_policy\0")
 
@@ -2622,7 +2622,7 @@ extension Grpc_ServiceConfig_XdsClusterManagerLoadBalancingPolicyConfig.Child: S
   }
 }
 
-extension Grpc_ServiceConfig_CdsConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_ServiceConfig_CdsConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".CdsConfig"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}cluster\0\u{3}is_dynamic\0")
 
@@ -2657,7 +2657,7 @@ extension Grpc_ServiceConfig_CdsConfig: SwiftProtobuf.Message, SwiftProtobuf._Me
   }
 }
 
-extension Grpc_ServiceConfig_XdsClusterImplLoadBalancingPolicyConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_ServiceConfig_XdsClusterImplLoadBalancingPolicyConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".XdsClusterImplLoadBalancingPolicyConfig"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}cluster\0\u{3}eds_service_name\0\u{3}lrs_load_reporting_server_name\0\u{3}max_concurrent_requests\0\u{3}drop_categories\0\u{3}child_policy\0\u{3}lrs_load_reporting_server\0\u{3}telemetry_labels\0")
 
@@ -2726,7 +2726,7 @@ extension Grpc_ServiceConfig_XdsClusterImplLoadBalancingPolicyConfig: SwiftProto
   }
 }
 
-extension Grpc_ServiceConfig_XdsClusterImplLoadBalancingPolicyConfig.DropCategory: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_ServiceConfig_XdsClusterImplLoadBalancingPolicyConfig.DropCategory: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Grpc_ServiceConfig_XdsClusterImplLoadBalancingPolicyConfig.protoMessageName + ".DropCategory"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}category\0\u{3}requests_per_million\0")
 
@@ -2761,7 +2761,7 @@ extension Grpc_ServiceConfig_XdsClusterImplLoadBalancingPolicyConfig.DropCategor
   }
 }
 
-extension Grpc_ServiceConfig_RingHashLoadBalancingConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_ServiceConfig_RingHashLoadBalancingConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RingHashLoadBalancingConfig"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}min_ring_size\0\u{3}max_ring_size\0")
 
@@ -2796,7 +2796,7 @@ extension Grpc_ServiceConfig_RingHashLoadBalancingConfig: SwiftProtobuf.Message,
   }
 }
 
-extension Grpc_ServiceConfig_XdsWrrLocalityLoadBalancingPolicyConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_ServiceConfig_XdsWrrLocalityLoadBalancingPolicyConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".XdsWrrLocalityLoadBalancingPolicyConfig"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}child_policy\0")
 
@@ -2826,7 +2826,7 @@ extension Grpc_ServiceConfig_XdsWrrLocalityLoadBalancingPolicyConfig: SwiftProto
   }
 }
 
-extension Grpc_ServiceConfig_LeastRequestLocalityLoadBalancingPolicyConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_ServiceConfig_LeastRequestLocalityLoadBalancingPolicyConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".LeastRequestLocalityLoadBalancingPolicyConfig"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}choice_count\0")
 
@@ -2856,7 +2856,7 @@ extension Grpc_ServiceConfig_LeastRequestLocalityLoadBalancingPolicyConfig: Swif
   }
 }
 
-extension Grpc_ServiceConfig_OverrideHostLoadBalancingPolicyConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_ServiceConfig_OverrideHostLoadBalancingPolicyConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".OverrideHostLoadBalancingPolicyConfig"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}override_host_status\0\u{3}child_policy\0\u{3}cluster_name\0")
 
@@ -2896,11 +2896,11 @@ extension Grpc_ServiceConfig_OverrideHostLoadBalancingPolicyConfig: SwiftProtobu
   }
 }
 
-extension Grpc_ServiceConfig_OverrideHostLoadBalancingPolicyConfig.HealthStatus: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_ServiceConfig_OverrideHostLoadBalancingPolicyConfig.HealthStatus: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0UNKNOWN\0\u{1}HEALTHY\0\u{2}\u{2}DRAINING\0")
 }
 
-extension Grpc_ServiceConfig_LoadBalancingConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_ServiceConfig_LoadBalancingConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".LoadBalancingConfig"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}round_robin\0\u{1}xds\0\u{1}grpclb\0\u{1}pick_first\0\u{1}xds_experimental\0\u{1}cds_experimental\0\u{1}eds_experimental\0\u{1}lrs_experimental\0\u{1}priority_experimental\0\u{1}weighted_target_experimental\0\u{1}xds_cluster_resolver_experimental\0\u{1}xds_cluster_impl_experimental\0\u{1}ring_hash_experimental\0\u{1}xds_cluster_manager_experimental\0\u{5}outlier_detection\0outlier_detection_experimental\0\u{1}xds_wrr_locality_experimental\0\u{1}least_request_experimental\0\u{1}override_host_experimental\0\u{5}rls\0rls_experimental\0\u{1}weighted_round_robin\0")
 
@@ -3273,7 +3273,7 @@ extension Grpc_ServiceConfig_LoadBalancingConfig: SwiftProtobuf.Message, SwiftPr
   }
 }
 
-extension Grpc_ServiceConfig_ServiceConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_ServiceConfig_ServiceConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ServiceConfig"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}load_balancing_policy\0\u{3}method_config\0\u{3}retry_throttling\0\u{3}load_balancing_config\0\u{3}health_check_config\0")
 
@@ -3327,11 +3327,11 @@ extension Grpc_ServiceConfig_ServiceConfig: SwiftProtobuf.Message, SwiftProtobuf
   }
 }
 
-extension Grpc_ServiceConfig_ServiceConfig.LoadBalancingPolicy: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_ServiceConfig_ServiceConfig.LoadBalancingPolicy: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0UNSPECIFIED\0\u{1}ROUND_ROBIN\0")
 }
 
-extension Grpc_ServiceConfig_ServiceConfig.RetryThrottlingPolicy: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_ServiceConfig_ServiceConfig.RetryThrottlingPolicy: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Grpc_ServiceConfig_ServiceConfig.protoMessageName + ".RetryThrottlingPolicy"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}max_tokens\0\u{3}token_ratio\0")
 
@@ -3366,7 +3366,7 @@ extension Grpc_ServiceConfig_ServiceConfig.RetryThrottlingPolicy: SwiftProtobuf.
   }
 }
 
-extension Grpc_ServiceConfig_ServiceConfig.HealthCheckConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_ServiceConfig_ServiceConfig.HealthCheckConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Grpc_ServiceConfig_ServiceConfig.protoMessageName + ".HealthCheckConfig"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}service_name\0")
 
@@ -3400,7 +3400,7 @@ extension Grpc_ServiceConfig_ServiceConfig.HealthCheckConfig: SwiftProtobuf.Mess
   }
 }
 
-extension Grpc_ServiceConfig_XdsServer: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_ServiceConfig_XdsServer: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".XdsServer"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}server_uri\0\u{1}channel_creds\0\u{1}server_features\0")
 
@@ -3440,7 +3440,7 @@ extension Grpc_ServiceConfig_XdsServer: SwiftProtobuf.Message, SwiftProtobuf._Me
   }
 }
 
-extension Grpc_ServiceConfig_XdsServer.ChannelCredentials: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_ServiceConfig_XdsServer.ChannelCredentials: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Grpc_ServiceConfig_XdsServer.protoMessageName + ".ChannelCredentials"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}type\0\u{1}config\0")
 
@@ -3479,7 +3479,7 @@ extension Grpc_ServiceConfig_XdsServer.ChannelCredentials: SwiftProtobuf.Message
   }
 }
 
-extension Grpc_ServiceConfig_XdsClusterResolverLoadBalancingPolicyConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_ServiceConfig_XdsClusterResolverLoadBalancingPolicyConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".XdsClusterResolverLoadBalancingPolicyConfig"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}discovery_mechanisms\0\u{3}xds_lb_policy\0")
 
@@ -3514,7 +3514,7 @@ extension Grpc_ServiceConfig_XdsClusterResolverLoadBalancingPolicyConfig: SwiftP
   }
 }
 
-extension Grpc_ServiceConfig_XdsClusterResolverLoadBalancingPolicyConfig.DiscoveryMechanism: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_ServiceConfig_XdsClusterResolverLoadBalancingPolicyConfig.DiscoveryMechanism: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Grpc_ServiceConfig_XdsClusterResolverLoadBalancingPolicyConfig.protoMessageName + ".DiscoveryMechanism"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}cluster\0\u{3}lrs_load_reporting_server_name\0\u{3}max_concurrent_requests\0\u{1}type\0\u{3}eds_service_name\0\u{3}dns_hostname\0\u{3}lrs_load_reporting_server\0\u{3}outlier_detection\0\u{3}override_host_status\0\u{3}telemetry_labels\0")
 
@@ -3647,11 +3647,11 @@ extension Grpc_ServiceConfig_XdsClusterResolverLoadBalancingPolicyConfig.Discove
   }
 }
 
-extension Grpc_ServiceConfig_XdsClusterResolverLoadBalancingPolicyConfig.DiscoveryMechanism.TypeEnum: SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_ServiceConfig_XdsClusterResolverLoadBalancingPolicyConfig.DiscoveryMechanism.TypeEnum: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0UNKNOWN\0\u{1}EDS\0\u{1}LOGICAL_DNS\0")
 }
 
-extension Grpc_ServiceConfig_LrsLoadBalancingPolicyConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_ServiceConfig_LrsLoadBalancingPolicyConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".LrsLoadBalancingPolicyConfig"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}cluster_name\0\u{3}eds_service_name\0\u{3}lrs_load_reporting_server_name\0\u{1}locality\0\u{3}child_policy\0")
 
@@ -3705,7 +3705,7 @@ extension Grpc_ServiceConfig_LrsLoadBalancingPolicyConfig: SwiftProtobuf.Message
   }
 }
 
-extension Grpc_ServiceConfig_LrsLoadBalancingPolicyConfig.Locality: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_ServiceConfig_LrsLoadBalancingPolicyConfig.Locality: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = Grpc_ServiceConfig_LrsLoadBalancingPolicyConfig.protoMessageName + ".Locality"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}region\0\u{1}zone\0\u{1}subzone\0")
 
@@ -3745,7 +3745,7 @@ extension Grpc_ServiceConfig_LrsLoadBalancingPolicyConfig.Locality: SwiftProtobu
   }
 }
 
-extension Grpc_ServiceConfig_EdsLoadBalancingPolicyConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_ServiceConfig_EdsLoadBalancingPolicyConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".EdsLoadBalancingPolicyConfig"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}cluster\0\u{3}eds_service_name\0\u{3}lrs_load_reporting_server_name\0\u{3}locality_picking_policy\0\u{3}endpoint_picking_policy\0")
 
@@ -3799,7 +3799,7 @@ extension Grpc_ServiceConfig_EdsLoadBalancingPolicyConfig: SwiftProtobuf.Message
   }
 }
 
-extension Grpc_ServiceConfig_XdsConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+nonisolated extension Grpc_ServiceConfig_XdsConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".XdsConfig"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}balancer_name\0\u{3}child_policy\0\u{3}fallback_policy\0\u{3}eds_service_name\0\u{3}lrs_load_reporting_server_name\0")
 


### PR DESCRIPTION
Motivation:

grpc-swift-protobuf 2.4.0 uses a vendored copy of protoc rather than
relying on the system to provide it. This improves UX and simplifies
examples and tutorials.

Modifications:

- Update examples and tutorials to use the vendored protoc

Result:

Simpler