### PR TITLE
Opt out of swift-protobuf default traits

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,8 @@ let dependencies: [Package.Dependency] = [
   // Test-only dependencies:
   .package(
     url: "https://github.com/apple/swift-protobuf.git",
-    from: "1.31.0"
+    from: "1.31.0",
+    traits: []
   ),
 ]
 


### PR DESCRIPTION
swift-protobuf enables BinaryDelimitedStreams and FieldMaskUtilities by default; grpc-swift-2 uses neither (the swift-protobuf dependency is test only).

BinaryDelimitedStreams gates the one file in the SwiftProtobuf target that imports full Foundation (InputStream/OutputStream) instead of FoundationEssentials.

Pass traits: [] so this edge no longer contributes the defaults.

Together with https://github.com/grpc/grpc-swift-protobuf/pull/102 this allows clients of grpc-swift-2 to avoid linking full Foundation and use FoundationEssentials only.