### PR TITLE
Opt out of swift-protobuf default traits

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,8 @@ let dependencies: [Package.Dependency] = [
   // Test-only dependencies:
   .package(
     url: "https://github.com/apple/swift-protobuf.git",
-    from: "1.31.0"
+    from: "1.31.0",
+    traits: []
   ),
 ]
 


### PR DESCRIPTION
`swift-protobuf` enables `BinaryDelimitedStreams` and `FieldMaskUtilities` traits by default; `grpc-swift-2` uses neither.

The `BinaryDelimitedStreams` trait gates the one file in the SwiftProtobuf target that imports full Foundation (InputStream/OutputStream) instead of FoundationEssentials.

Pass traits: [] so this package no longer contributes the defaults.

Relates to: https://github.com/grpc/grpc-swift-protobuf/pull/102 