### PR TITLE
Add process-wide client diagnostics observers

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -51,7 +51,7 @@ let dependencies: [Package.Dependency] = [
 
 // This adds some build settings which allow us to map "@available(gRPCSwift 2.x, *)" to
 // the appropriate OS platforms.
-let nextMinorVersion = 3
+let nextMinorVersion = 5
 let availabilitySettings: [SwiftSetting] = (0 ... nextMinorVersion).map { minor in
   let name = "gRPCSwift"
   let version = "2.\(minor)"

--- a/Sources/GRPCCore/Call/Client/ClientDiagnostics.swift
+++ b/Sources/GRPCCore/Call/Client/ClientDiagnostics.swift
@@ -1,0 +1,526 @@
+/*
+ * Copyright 2026, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+private import Synchronization
+
+/// An identifier for a logical client RPC.
+@available(gRPCSwift 2.5, *)
+public struct GRPCClientCallID: Hashable, Sendable, CustomStringConvertible {
+  /// The process-local numeric value of this identifier.
+  public var rawValue: UInt64
+
+  /// Creates a call identifier from its process-local numeric value.
+  public init(rawValue: UInt64) {
+    self.rawValue = rawValue
+  }
+
+  public var description: String {
+    String(self.rawValue)
+  }
+}
+
+/// An identifier for one physical attempt of a logical client RPC.
+@available(gRPCSwift 2.5, *)
+public struct GRPCClientAttemptID: Hashable, Sendable, CustomStringConvertible {
+  /// The logical call containing this attempt.
+  public var callID: GRPCClientCallID
+
+  /// The one-based attempt number within the logical call.
+  public var attempt: Int
+
+  /// Creates an attempt identifier.
+  public init(callID: GRPCClientCallID, attempt: Int) {
+    self.callID = callID
+    self.attempt = attempt
+  }
+
+  public var description: String {
+    "\(self.callID).\(self.attempt)"
+  }
+}
+
+/// A stable, sendable description of an error observed while executing an RPC.
+@available(gRPCSwift 2.5, *)
+public struct GRPCClientDiagnosticsError: Hashable, Sendable {
+  /// The gRPC error code, when the error could be represented as an ``RPCError``.
+  public var code: RPCError.Code?
+
+  /// A human-readable description of the error.
+  public var message: String
+
+  /// Metadata attached to an ``RPCError``.
+  public var metadata: Metadata
+
+  /// Creates a diagnostics error.
+  public init(code: RPCError.Code?, message: String, metadata: Metadata = [:]) {
+    self.code = code
+    self.message = message
+    self.metadata = metadata
+  }
+
+  @usableFromInline
+  init(_ error: any Error) {
+    if let error = error as? RPCError {
+      self.init(code: error.code, message: error.message, metadata: error.metadata)
+    } else {
+      self.init(code: nil, message: String(describing: error))
+    }
+  }
+}
+
+/// The terminal outcome of one physical RPC attempt.
+@available(gRPCSwift 2.5, *)
+public enum GRPCClientAttemptOutcome: Hashable, Sendable {
+  /// The transport produced a final gRPC status and trailing metadata.
+  case status(Status, trailingMetadata: Metadata)
+
+  /// The attempt failed before producing a final gRPC status.
+  case failed(GRPCClientDiagnosticsError)
+
+  /// The attempt was cancelled before producing a final gRPC status.
+  case cancelled
+}
+
+/// The terminal outcome of a logical client RPC.
+@available(gRPCSwift 2.5, *)
+public enum GRPCClientCallOutcome: Hashable, Sendable {
+  /// The RPC and the response handler completed.
+  case completed
+
+  /// RPC execution or the response handler failed.
+  case failed(GRPCClientDiagnosticsError)
+
+  /// The logical RPC was cancelled.
+  case cancelled
+}
+
+/// A non-message event observed while executing a client RPC.
+@available(gRPCSwift 2.5, *)
+public enum GRPCClientDiagnosticsEvent: Sendable {
+  /// A logical call began after the current observer snapshot was taken.
+  case callStarted(callID: GRPCClientCallID, descriptor: MethodDescriptor)
+
+  /// A physical attempt began.
+  case attemptStarted(attemptID: GRPCClientAttemptID, descriptor: MethodDescriptor)
+
+  /// The transport created a stream for an attempt.
+  case streamCreated(attemptID: GRPCClientAttemptID, context: ClientContext)
+
+  /// Request metadata was accepted by the transport writer.
+  case requestMetadata(attemptID: GRPCClientAttemptID, metadata: Metadata)
+
+  /// The client half-closed its request stream.
+  case requestFinished(attemptID: GRPCClientAttemptID)
+
+  /// Initial response metadata was received from the transport.
+  case responseMetadata(attemptID: GRPCClientAttemptID, metadata: Metadata)
+
+  /// The final status and trailing response metadata were received.
+  case responseStatus(
+    attemptID: GRPCClientAttemptID,
+    status: Status,
+    trailingMetadata: Metadata
+  )
+
+  /// A physical attempt ended. This event is emitted exactly once for each started attempt.
+  case attemptFinished(attemptID: GRPCClientAttemptID, outcome: GRPCClientAttemptOutcome)
+
+  /// A logical call ended. This event is emitted exactly once for each started call.
+  case callFinished(callID: GRPCClientCallID, outcome: GRPCClientCallOutcome)
+}
+
+/// The direction of a serialized message observed by client diagnostics.
+@available(gRPCSwift 2.5, *)
+public enum GRPCClientDiagnosticsMessageDirection: String, Hashable, Sendable {
+  /// A message sent by the client.
+  case outbound
+
+  /// A message received by the client.
+  case inbound
+}
+
+/// Context associated with a serialized request or response message.
+@available(gRPCSwift 2.5, *)
+public struct GRPCClientDiagnosticsMessageContext: Hashable, Sendable {
+  /// The attempt which sent or received this message.
+  public var attemptID: GRPCClientAttemptID
+
+  /// The message direction.
+  public var direction: GRPCClientDiagnosticsMessageDirection
+
+  /// The zero-based sequence number for this direction within the attempt.
+  public var sequenceNumber: Int
+
+  /// Creates message context.
+  public init(
+    attemptID: GRPCClientAttemptID,
+    direction: GRPCClientDiagnosticsMessageDirection,
+    sequenceNumber: Int
+  ) {
+    self.attemptID = attemptID
+    self.direction = direction
+    self.sequenceNumber = sequenceNumber
+  }
+}
+
+/// An observer of process-wide client RPC diagnostics.
+///
+/// Callbacks run synchronously on RPC execution tasks. Implementations should return quickly and
+/// move expensive processing to their own executor. Message bytes are borrowed and are only valid
+/// for the duration of ``observe(message:context:)``; copy them during the callback if needed.
+@available(gRPCSwift 2.5, *)
+public protocol GRPCClientDiagnosticsObserver: AnyObject, Sendable {
+  /// Observe a non-message lifecycle event.
+  func observe(_ event: GRPCClientDiagnosticsEvent)
+
+  /// Observe serialized message bytes before they enter or after they leave the transport.
+  func observe<Bytes: GRPCContiguousBytes>(
+    message: borrowing Bytes,
+    context: GRPCClientDiagnosticsMessageContext
+  )
+}
+
+@available(gRPCSwift 2.5, *)
+extension GRPCClientDiagnosticsObserver {
+  public func observe(_ event: GRPCClientDiagnosticsEvent) {}
+
+  public func observe<Bytes: GRPCContiguousBytes>(
+    message: borrowing Bytes,
+    context: GRPCClientDiagnosticsMessageContext
+  ) {}
+}
+
+/// A registration in the process-wide client diagnostics registry.
+@available(gRPCSwift 2.5, *)
+public final class GRPCClientDiagnosticsRegistration: Sendable {
+  private let isCancelled: Mutex<Bool>
+  private let cancellation: @Sendable () -> Void
+
+  fileprivate init(cancellation: @escaping @Sendable () -> Void) {
+    self.isCancelled = Mutex(false)
+    self.cancellation = cancellation
+  }
+
+  /// Stop including the observer in snapshots for new logical calls.
+  ///
+  /// Calls which already captured the observer continue to deliver their remaining events.
+  public func cancel() {
+    let shouldCancel = self.isCancelled.withLock { isCancelled in
+      if isCancelled {
+        return false
+      } else {
+        isCancelled = true
+        return true
+      }
+    }
+
+    if shouldCancel {
+      self.cancellation()
+    }
+  }
+
+  deinit {
+    self.cancel()
+  }
+}
+
+/// Process-wide registration point for client RPC diagnostics observers.
+///
+/// Observers receive metadata and serialized message contents from every client RPC which starts
+/// while they are registered. Only register trusted observers and avoid enabling payload capture
+/// in environments where that data must not be exposed to another component in the process.
+@available(gRPCSwift 2.5, *)
+public enum GRPCClientDiagnostics {
+  private struct State: Sendable {
+    var nextRegistrationID: UInt64 = 0
+    var nextCallID: UInt64 = 0
+    var observers: [UInt64: any GRPCClientDiagnosticsObserver] = [:]
+  }
+
+  private static let state = Mutex(State())
+  private static let hasObservers = Atomic(false)
+
+  /// Register an observer for logical calls which start after this method returns.
+  ///
+  /// Retain the returned registration for as long as observation should remain active.
+  public static func register(
+    _ observer: any GRPCClientDiagnosticsObserver
+  ) -> GRPCClientDiagnosticsRegistration {
+    let registrationID = self.state.withLock { state in
+      let registrationID = state.nextRegistrationID
+      state.nextRegistrationID &+= 1
+      state.observers[registrationID] = observer
+      self.hasObservers.store(true, ordering: .releasing)
+      return registrationID
+    }
+
+    return GRPCClientDiagnosticsRegistration {
+      self.state.withLock { state in
+        state.observers.removeValue(forKey: registrationID)
+        if state.observers.isEmpty {
+          self.hasObservers.store(false, ordering: .releasing)
+        }
+      }
+    }
+  }
+
+  @usableFromInline
+  static func _beginCall(
+    descriptor: MethodDescriptor
+  ) -> GRPCClientDiagnosticsRecorder? {
+    // Keep the disabled path to one atomic load: it is paid by every RPC in the process.
+    guard self.hasObservers.load(ordering: .acquiring) else { return nil }
+
+    let snapshot = self.state.withLock {
+      state -> (
+        GRPCClientCallID,
+        [any GRPCClientDiagnosticsObserver]
+      ) in
+      let callID = GRPCClientCallID(rawValue: state.nextCallID)
+      state.nextCallID &+= 1
+      return (callID, Array(state.observers.values))
+    }
+
+    guard !snapshot.1.isEmpty else { return nil }
+    return GRPCClientDiagnosticsRecorder(
+      callID: snapshot.0,
+      descriptor: descriptor,
+      observers: snapshot.1
+    )
+  }
+}
+
+@available(gRPCSwift 2.5, *)
+@usableFromInline
+final class GRPCClientDiagnosticsRecorder: Sendable {
+  @usableFromInline
+  let callID: GRPCClientCallID
+
+  @usableFromInline
+  let descriptor: MethodDescriptor
+
+  @usableFromInline
+  let observers: [any GRPCClientDiagnosticsObserver]
+
+  private let isFinished: Mutex<Bool>
+
+  @usableFromInline
+  init(
+    callID: GRPCClientCallID,
+    descriptor: MethodDescriptor,
+    observers: [any GRPCClientDiagnosticsObserver]
+  ) {
+    self.callID = callID
+    self.descriptor = descriptor
+    self.observers = observers
+    self.isFinished = Mutex(false)
+    self.emit(.callStarted(callID: callID, descriptor: descriptor))
+  }
+
+  @usableFromInline
+  func beginAttempt(_ attempt: Int) -> GRPCClientAttemptDiagnosticsRecorder {
+    let attemptID = GRPCClientAttemptID(callID: self.callID, attempt: attempt)
+    self.emit(.attemptStarted(attemptID: attemptID, descriptor: self.descriptor))
+    return GRPCClientAttemptDiagnosticsRecorder(attemptID: attemptID, observers: self.observers)
+  }
+
+  @usableFromInline
+  func finish() {
+    self.finish(with: .completed)
+  }
+
+  @usableFromInline
+  func finish(throwing error: any Error) {
+    if error is CancellationError || (error as? RPCError)?.code == .cancelled {
+      self.finish(with: .cancelled)
+    } else {
+      self.finish(with: .failed(GRPCClientDiagnosticsError(error)))
+    }
+  }
+
+  private func finish(with outcome: GRPCClientCallOutcome) {
+    let shouldEmit = self.isFinished.withLock { isFinished in
+      if isFinished {
+        return false
+      } else {
+        isFinished = true
+        return true
+      }
+    }
+
+    if shouldEmit {
+      self.emit(.callFinished(callID: self.callID, outcome: outcome))
+    }
+  }
+
+  private func emit(_ event: GRPCClientDiagnosticsEvent) {
+    for observer in self.observers {
+      observer.observe(event)
+    }
+  }
+}
+
+@available(gRPCSwift 2.5, *)
+@usableFromInline
+final class GRPCClientAttemptDiagnosticsRecorder: Sendable {
+  private struct State: Sendable {
+    var nextOutboundSequence = 0
+    var nextInboundSequence = 0
+    var pendingOutcome: GRPCClientAttemptOutcome?
+    var hasResponseStatus = false
+    var isFinished = false
+  }
+
+  @usableFromInline
+  let attemptID: GRPCClientAttemptID
+
+  @usableFromInline
+  let observers: [any GRPCClientDiagnosticsObserver]
+
+  private let state: Mutex<State>
+
+  @usableFromInline
+  init(
+    attemptID: GRPCClientAttemptID,
+    observers: [any GRPCClientDiagnosticsObserver]
+  ) {
+    self.attemptID = attemptID
+    self.observers = observers
+    self.state = Mutex(State())
+  }
+
+  @usableFromInline
+  func streamCreated(_ context: ClientContext) {
+    self.emit(.streamCreated(attemptID: self.attemptID, context: context))
+  }
+
+  @usableFromInline
+  func requestMetadata(_ metadata: Metadata) {
+    self.emit(.requestMetadata(attemptID: self.attemptID, metadata: metadata))
+  }
+
+  @usableFromInline
+  func requestMessage<Bytes: GRPCContiguousBytes>(_ bytes: borrowing Bytes) {
+    guard let sequence = self.nextSequence(for: .outbound) else { return }
+    let context = GRPCClientDiagnosticsMessageContext(
+      attemptID: self.attemptID,
+      direction: .outbound,
+      sequenceNumber: sequence
+    )
+    for observer in self.observers {
+      observer.observe(message: bytes, context: context)
+    }
+  }
+
+  @usableFromInline
+  func requestFinished() {
+    self.emit(.requestFinished(attemptID: self.attemptID))
+  }
+
+  @usableFromInline
+  func responseMetadata(_ metadata: Metadata) {
+    self.emit(.responseMetadata(attemptID: self.attemptID, metadata: metadata))
+  }
+
+  @usableFromInline
+  func responseMessage<Bytes: GRPCContiguousBytes>(_ bytes: borrowing Bytes) {
+    guard let sequence = self.nextSequence(for: .inbound) else { return }
+    let context = GRPCClientDiagnosticsMessageContext(
+      attemptID: self.attemptID,
+      direction: .inbound,
+      sequenceNumber: sequence
+    )
+    for observer in self.observers {
+      observer.observe(message: bytes, context: context)
+    }
+  }
+
+  @usableFromInline
+  func responseStatus(_ status: Status, trailingMetadata: Metadata) {
+    let shouldEmit = self.state.withLock { state in
+      guard !state.isFinished && !state.hasResponseStatus else { return false }
+      state.hasResponseStatus = true
+      state.pendingOutcome = .status(status, trailingMetadata: trailingMetadata)
+      return true
+    }
+    guard shouldEmit else { return }
+    self.emit(
+      .responseStatus(
+        attemptID: self.attemptID,
+        status: status,
+        trailingMetadata: trailingMetadata
+      )
+    )
+  }
+
+  @usableFromInline
+  func recordFailure(_ error: any Error) {
+    let outcome: GRPCClientAttemptOutcome
+    if error is CancellationError || (error as? RPCError)?.code == .cancelled {
+      outcome = .cancelled
+    } else {
+      outcome = .failed(GRPCClientDiagnosticsError(error))
+    }
+    self.state.withLock { state in
+      if !state.isFinished && state.pendingOutcome == nil {
+        state.pendingOutcome = outcome
+      }
+    }
+  }
+
+  @usableFromInline
+  func finish(throwing error: any Error) {
+    self.recordFailure(error)
+    self.finishWithoutStatus()
+  }
+
+  @usableFromInline
+  func finishWithoutStatus() {
+    let outcome = self.state.withLock { state -> GRPCClientAttemptOutcome? in
+      if state.isFinished {
+        return nil
+      } else {
+        state.isFinished = true
+        return state.pendingOutcome ?? .cancelled
+      }
+    }
+    if let outcome {
+      self.emit(.attemptFinished(attemptID: self.attemptID, outcome: outcome))
+    }
+  }
+
+  private func nextSequence(
+    for direction: GRPCClientDiagnosticsMessageDirection
+  ) -> Int? {
+    self.state.withLock { state in
+      guard !state.isFinished else { return nil }
+      switch direction {
+      case .outbound:
+        defer { state.nextOutboundSequence &+= 1 }
+        return state.nextOutboundSequence
+      case .inbound:
+        defer { state.nextInboundSequence &+= 1 }
+        return state.nextInboundSequence
+      }
+    }
+  }
+
+  private func emit(_ event: GRPCClientDiagnosticsEvent) {
+    for observer in self.observers {
+      observer.observe(event)
+    }
+  }
+}

--- a/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor+HedgingExecutor.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor+HedgingExecutor.swift
@@ -40,6 +40,8 @@ extension ClientRPCExecutor {
     let deserializer: Deserializer
     @usableFromInline
     let bufferSize: Int
+    @usableFromInline
+    let diagnostics: GRPCClientDiagnosticsRecorder?
 
     @inlinable
     init(
@@ -49,7 +51,8 @@ extension ClientRPCExecutor {
       interceptors: [any ClientInterceptor],
       serializer: Serializer,
       deserializer: Deserializer,
-      bufferSize: Int
+      bufferSize: Int,
+      diagnostics: GRPCClientDiagnosticsRecorder?
     ) {
       self.transport = transport
       self.policy = policy
@@ -58,6 +61,7 @@ extension ClientRPCExecutor {
       self.serializer = serializer
       self.deserializer = deserializer
       self.bufferSize = bufferSize
+      self.diagnostics = diagnostics
     }
   }
 }
@@ -323,8 +327,9 @@ extension ClientRPCExecutor.HedgingExecutor {
     picker: (stream: BroadcastAsyncSequence<Int>, continuation: BroadcastAsyncSequence<Int>.Source),
     responseHandler: @Sendable @escaping (StreamingClientResponse<Output>) async throws -> R
   ) async -> _HedgingAttemptTaskResult<R, Output>.AttemptResult {
+    let attemptDiagnostics = self.diagnostics?.beginAttempt(attempt)
     do {
-      return try await self.transport.withStream(
+      let result = try await self.transport.withStream(
         descriptor: method,
         options: options
       ) { stream, context -> _HedgingAttemptTaskResult<R, Output>.AttemptResult in
@@ -359,6 +364,7 @@ extension ClientRPCExecutor.HedgingExecutor {
                 serializer: self.serializer,
                 deserializer: self.deserializer,
                 interceptors: self.interceptors,
+                diagnostics: attemptDiagnostics,
                 stream: stream
               )
 
@@ -425,7 +431,10 @@ extension ClientRPCExecutor.HedgingExecutor {
           fatalError("Internal inconsistency")
         }
       }
+      attemptDiagnostics?.finishWithoutStatus()
+      return result
     } catch {
+      attemptDiagnostics?.finish(throwing: error)
       return .noStreamAvailable(error)
     }
   }

--- a/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor+OneShotExecutor.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor+OneShotExecutor.swift
@@ -36,6 +36,8 @@ extension ClientRPCExecutor {
     let serializer: Serializer
     @usableFromInline
     let deserializer: Deserializer
+    @usableFromInline
+    let diagnostics: GRPCClientDiagnosticsRecorder?
 
     @inlinable
     init(
@@ -43,13 +45,15 @@ extension ClientRPCExecutor {
       deadline: ContinuousClock.Instant?,
       interceptors: [any ClientInterceptor],
       serializer: Serializer,
-      deserializer: Deserializer
+      deserializer: Deserializer,
+      diagnostics: GRPCClientDiagnosticsRecorder?
     ) {
       self.transport = transport
       self.deadline = deadline
       self.interceptors = interceptors
       self.serializer = serializer
       self.deserializer = deserializer
+      self.diagnostics = diagnostics
     }
   }
 }
@@ -99,9 +103,10 @@ extension ClientRPCExecutor.OneShotExecutor {
     options: CallOptions,
     responseHandler: @Sendable @escaping (StreamingClientResponse<Output>) async throws -> R
   ) async -> Result<R, any Error> {
+    let attemptDiagnostics = self.diagnostics?.beginAttempt(1)
     return await withTaskGroup(of: Void.self, returning: Result<R, any Error>.self) { group in
       do {
-        return try await self.transport.withStream(
+        let result = try await self.transport.withStream(
           descriptor: method,
           options: options
         ) { stream, context in
@@ -113,6 +118,7 @@ extension ClientRPCExecutor.OneShotExecutor {
             serializer: self.serializer,
             deserializer: self.deserializer,
             interceptors: self.interceptors,
+            diagnostics: attemptDiagnostics,
             stream: stream
           )
 
@@ -125,7 +131,10 @@ extension ClientRPCExecutor.OneShotExecutor {
 
           return result
         }
+        attemptDiagnostics?.finishWithoutStatus()
+        return result
       } catch {
+        attemptDiagnostics?.finish(throwing: error)
         return .failure(error)
       }
     }

--- a/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor+RetryExecutor.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor+RetryExecutor.swift
@@ -38,6 +38,8 @@ extension ClientRPCExecutor {
     let deserializer: Deserializer
     @usableFromInline
     let bufferSize: Int
+    @usableFromInline
+    let diagnostics: GRPCClientDiagnosticsRecorder?
 
     @inlinable
     init(
@@ -47,7 +49,8 @@ extension ClientRPCExecutor {
       interceptors: [any ClientInterceptor],
       serializer: Serializer,
       deserializer: Deserializer,
-      bufferSize: Int
+      bufferSize: Int,
+      diagnostics: GRPCClientDiagnosticsRecorder?
     ) {
       self.transport = transport
       self.policy = policy
@@ -56,6 +59,7 @@ extension ClientRPCExecutor {
       self.serializer = serializer
       self.deserializer = deserializer
       self.bufferSize = bufferSize
+      self.diagnostics = diagnostics
     }
   }
 }
@@ -116,6 +120,7 @@ extension ClientRPCExecutor.RetryExecutor {
       var delayIterator = delaySequence.makeIterator()
 
       for attempt in 1 ... self.policy.maxAttempts {
+        let attemptDiagnostics = self.diagnostics?.beginAttempt(attempt)
         do {
           let attemptResult = try await self.transport.withStream(
             descriptor: method,
@@ -135,6 +140,7 @@ extension ClientRPCExecutor.RetryExecutor {
                 retryStream: retry.stream,
                 method: method,
                 attempt: attempt,
+                diagnostics: attemptDiagnostics,
                 responseHandler: responseHandler
               )
             }
@@ -194,10 +200,12 @@ extension ClientRPCExecutor.RetryExecutor {
             return nil
           }
 
+          attemptDiagnostics?.finishWithoutStatus()
           if let attemptResult {
             return attemptResult
           }
         } catch {
+          attemptDiagnostics?.finish(throwing: error)
           return .failure(error)
         }
       }
@@ -218,6 +226,7 @@ extension ClientRPCExecutor.RetryExecutor {
     retryStream: BroadcastAsyncSequence<Input>,
     method: MethodDescriptor,
     attempt: Int,
+    diagnostics: GRPCClientAttemptDiagnosticsRecorder?,
     responseHandler: @Sendable @escaping (StreamingClientResponse<Output>) async throws -> R
   ) async -> _RetryExecutorTask<R> {
     return await withTaskGroup(
@@ -236,6 +245,7 @@ extension ClientRPCExecutor.RetryExecutor {
         serializer: self.serializer,
         deserializer: self.deserializer,
         interceptors: self.interceptors,
+        diagnostics: diagnostics,
         stream: stream
       )
 

--- a/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor.swift
@@ -43,59 +43,72 @@ enum ClientRPCExecutor: Sendable {
     handler: @Sendable @escaping (StreamingClientResponse<Output>) async throws -> Result
   ) async throws -> Result {
     let deadline = options.timeout.map { ContinuousClock.now + $0 }
+    let diagnostics = GRPCClientDiagnostics._beginCall(descriptor: method)
 
-    switch options.executionPolicy?.wrapped {
-    case .none:
-      let oneShotExecutor = OneShotExecutor(
-        transport: transport,
-        deadline: deadline,
-        interceptors: interceptors,
-        serializer: serializer,
-        deserializer: deserializer
-      )
+    do {
+      let result: Result
+      switch options.executionPolicy?.wrapped {
+      case .none:
+        let oneShotExecutor = OneShotExecutor(
+          transport: transport,
+          deadline: deadline,
+          interceptors: interceptors,
+          serializer: serializer,
+          deserializer: deserializer,
+          diagnostics: diagnostics
+        )
 
-      return try await oneShotExecutor.execute(
-        request: request,
-        method: method,
-        options: options,
-        responseHandler: handler
-      )
+        result = try await oneShotExecutor.execute(
+          request: request,
+          method: method,
+          options: options,
+          responseHandler: handler
+        )
 
-    case .retry(let policy):
-      let retryExecutor = RetryExecutor(
-        transport: transport,
-        policy: policy,
-        deadline: deadline,
-        interceptors: interceptors,
-        serializer: serializer,
-        deserializer: deserializer,
-        bufferSize: 64  // TODO: the client should have some control over this.
-      )
+      case .retry(let policy):
+        let retryExecutor = RetryExecutor(
+          transport: transport,
+          policy: policy,
+          deadline: deadline,
+          interceptors: interceptors,
+          serializer: serializer,
+          deserializer: deserializer,
+          bufferSize: 64,  // TODO: the client should have some control over this.
+          diagnostics: diagnostics
+        )
 
-      return try await retryExecutor.execute(
-        request: request,
-        method: method,
-        options: options,
-        responseHandler: handler
-      )
+        result = try await retryExecutor.execute(
+          request: request,
+          method: method,
+          options: options,
+          responseHandler: handler
+        )
 
-    case .hedge(let policy):
-      let hedging = HedgingExecutor(
-        transport: transport,
-        policy: policy,
-        deadline: deadline,
-        interceptors: interceptors,
-        serializer: serializer,
-        deserializer: deserializer,
-        bufferSize: 64  // TODO: the client should have some control over this.
-      )
+      case .hedge(let policy):
+        let hedging = HedgingExecutor(
+          transport: transport,
+          policy: policy,
+          deadline: deadline,
+          interceptors: interceptors,
+          serializer: serializer,
+          deserializer: deserializer,
+          bufferSize: 64,  // TODO: the client should have some control over this.
+          diagnostics: diagnostics
+        )
 
-      return try await hedging.execute(
-        request: request,
-        method: method,
-        options: options,
-        responseHandler: handler
-      )
+        result = try await hedging.execute(
+          request: request,
+          method: method,
+          options: options,
+          responseHandler: handler
+        )
+      }
+
+      diagnostics?.finish()
+      return result
+    } catch {
+      diagnostics?.finish(throwing: error)
+      throw error
     }
   }
 }
@@ -123,6 +136,7 @@ extension ClientRPCExecutor {
     serializer: some MessageSerializer<Input>,
     deserializer: some MessageDeserializer<Output>,
     interceptors: [any ClientInterceptor],
+    diagnostics: GRPCClientAttemptDiagnosticsRecorder?,
     stream: RPCStream<
       RPCAsyncSequence<RPCResponsePart<Bytes>, any Error>,
       RPCWriter<RPCRequestPart<Bytes>>.Closable
@@ -137,6 +151,7 @@ extension ClientRPCExecutor {
         attempt: attempt,
         serializer: serializer,
         deserializer: deserializer,
+        diagnostics: diagnostics,
         stream: stream
       )
     } else {
@@ -153,6 +168,7 @@ extension ClientRPCExecutor {
           attempt: attempt,
           serializer: serializer,
           deserializer: deserializer,
+          diagnostics: diagnostics,
           stream: stream
         )
       }

--- a/Sources/GRPCCore/Call/Client/Internal/ClientStreamExecutor.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/ClientStreamExecutor.swift
@@ -36,22 +36,32 @@ internal enum ClientStreamExecutor: Sendable {
     attempt: Int,
     serializer: some MessageSerializer<Input>,
     deserializer: some MessageDeserializer<Output>,
+    diagnostics: GRPCClientAttemptDiagnosticsRecorder?,
     stream: RPCStream<
       RPCAsyncSequence<RPCResponsePart<Bytes>, any Error>,
       RPCWriter<RPCRequestPart<Bytes>>.Closable
     >
   ) async -> StreamingClientResponse<Output> {
     // Let the server know this is a retry.
-    var metadata = request.metadata
+    var request = request
     if attempt > 1 {
-      metadata.previousRPCAttempts = attempt &- 1
+      request.metadata.previousRPCAttempts = attempt &- 1
     }
+    diagnostics?.streamCreated(context)
 
     group.addTask {
-      await Self._processRequest(on: stream.outbound, request: request, serializer: serializer)
+      await Self._processRequest(
+        on: stream.outbound,
+        request: request,
+        serializer: serializer,
+        diagnostics: diagnostics
+      )
     }
 
-    let part = await Self._waitForFirstResponsePart(on: stream.inbound)
+    let part = await Self._waitForFirstResponsePart(
+      on: stream.inbound,
+      diagnostics: diagnostics
+    )
     // Wait for the first response to determine how to handle the response.
     switch part {
     case .metadata(var metadata, let iterator):
@@ -62,7 +72,8 @@ internal enum ClientStreamExecutor: Sendable {
 
       let bodyParts = RawBodyPartToMessageSequence(
         base: UncheckedAsyncIteratorSequence(iterator.wrappedValue),
-        deserializer: deserializer
+        deserializer: deserializer,
+        diagnostics: diagnostics
       )
 
       // Expected happy case: the server is processing the request.
@@ -90,11 +101,22 @@ internal enum ClientStreamExecutor: Sendable {
   static func _processRequest<Outbound, Bytes: GRPCContiguousBytes>(
     on stream: some ClosableRPCWriterProtocol<RPCRequestPart<Bytes>>,
     request: StreamingClientRequest<Outbound>,
-    serializer: some MessageSerializer<Outbound>
+    serializer: some MessageSerializer<Outbound>,
+    diagnostics: GRPCClientAttemptDiagnosticsRecorder?
   ) async {
     let result = await Result {
       try await stream.write(.metadata(request.metadata))
-      try await request.producer(.map(into: stream) { .message(try serializer.serialize($0)) })
+      if let diagnostics {
+        diagnostics.requestMetadata(request.metadata)
+        let writer = InstrumentedSerializingRPCWriter(
+          base: stream,
+          serializer: serializer,
+          diagnostics: diagnostics
+        )
+        try await request.producer(RPCWriter(wrapping: writer))
+      } else {
+        try await request.producer(.map(into: stream) { .message(try serializer.serialize($0)) })
+      }
     }.castOrConvertRPCError { other in
       RPCError(code: .unknown, message: "Write failed.", cause: other)
     }
@@ -102,8 +124,54 @@ internal enum ClientStreamExecutor: Sendable {
     switch result {
     case .success:
       await stream.finish()
+      diagnostics?.requestFinished()
     case .failure(let error):
       await stream.finish(throwing: error)
+      diagnostics?.recordFailure(error)
+    }
+  }
+
+  @usableFromInline
+  struct InstrumentedSerializingRPCWriter<
+    Base: RPCWriterProtocol<RPCRequestPart<Bytes>>,
+    Bytes: GRPCContiguousBytes,
+    Serializer: MessageSerializer
+  >: RPCWriterProtocol where Serializer.Message: Sendable {
+    @usableFromInline
+    typealias Element = Serializer.Message
+
+    @usableFromInline
+    let base: Base
+    @usableFromInline
+    let serializer: Serializer
+    @usableFromInline
+    let diagnostics: GRPCClientAttemptDiagnosticsRecorder
+
+    @inlinable
+    init(
+      base: Base,
+      serializer: Serializer,
+      diagnostics: GRPCClientAttemptDiagnosticsRecorder
+    ) {
+      self.base = base
+      self.serializer = serializer
+      self.diagnostics = diagnostics
+    }
+
+    @inlinable
+    func write(_ element: Element) async throws {
+      let bytes: Bytes = try self.serializer.serialize(element)
+      try await self.base.write(.message(bytes))
+      self.diagnostics.requestMessage(bytes)
+    }
+
+    @inlinable
+    func write(contentsOf elements: some Sequence<Element>) async throws {
+      let bytes = try elements.map { try self.serializer.serialize($0) as Bytes }
+      try await self.base.write(contentsOf: bytes.lazy.map { .message($0) })
+      for message in bytes {
+        self.diagnostics.requestMessage(message)
+      }
     }
   }
 
@@ -119,7 +187,8 @@ internal enum ClientStreamExecutor: Sendable {
 
   @inlinable  // would be private
   static func _waitForFirstResponsePart<Bytes: GRPCContiguousBytes>(
-    on stream: RPCAsyncSequence<RPCResponsePart<Bytes>, any Error>
+    on stream: RPCAsyncSequence<RPCResponsePart<Bytes>, any Error>,
+    diagnostics: GRPCClientAttemptDiagnosticsRecorder?
   ) async -> OnFirstResponsePart<Bytes> {
     var iterator = stream.makeAsyncIterator()
     let result = await Result<OnFirstResponsePart, any Error> {
@@ -164,8 +233,17 @@ internal enum ClientStreamExecutor: Sendable {
 
     switch result {
     case .success(let firstPart):
+      switch firstPart {
+      case .metadata(let metadata, _):
+        diagnostics?.responseMetadata(metadata)
+      case .status(let status, let metadata):
+        diagnostics?.responseStatus(status, trailingMetadata: metadata)
+      case .failed(let error):
+        diagnostics?.recordFailure(error)
+      }
       return firstPart
     case .failure(let error):
+      diagnostics?.recordFailure(error)
       return .failed(error)
     }
   }
@@ -185,16 +263,27 @@ internal enum ClientStreamExecutor: Sendable {
     let base: Base
     @usableFromInline
     let deserializer: Deserializer
+    @usableFromInline
+    let diagnostics: GRPCClientAttemptDiagnosticsRecorder?
 
     @inlinable
-    init(base: Base, deserializer: Deserializer) {
+    init(
+      base: Base,
+      deserializer: Deserializer,
+      diagnostics: GRPCClientAttemptDiagnosticsRecorder?
+    ) {
       self.base = base
       self.deserializer = deserializer
+      self.diagnostics = diagnostics
     }
 
     @inlinable
     func makeAsyncIterator() -> AsyncIterator {
-      AsyncIterator(base: self.base.makeAsyncIterator(), deserializer: self.deserializer)
+      AsyncIterator(
+        base: self.base.makeAsyncIterator(),
+        deserializer: self.deserializer,
+        diagnostics: self.diagnostics
+      )
     }
 
     @usableFromInline
@@ -206,18 +295,32 @@ internal enum ClientStreamExecutor: Sendable {
       var base: Base.AsyncIterator
       @usableFromInline
       let deserializer: Deserializer
+      @usableFromInline
+      let diagnostics: GRPCClientAttemptDiagnosticsRecorder?
 
       @inlinable
-      init(base: Base.AsyncIterator, deserializer: Deserializer) {
+      init(
+        base: Base.AsyncIterator,
+        deserializer: Deserializer,
+        diagnostics: GRPCClientAttemptDiagnosticsRecorder?
+      ) {
         self.base = base
         self.deserializer = deserializer
+        self.diagnostics = diagnostics
       }
 
       @inlinable
       mutating func next(
         isolation actor: isolated (any Actor)?
       ) async throws(any Error) -> StreamingClientResponse<Message>.Contents.BodyPart? {
-        guard let part = try await self.base.next(isolation: `actor`) else { return nil }
+        let part: RPCResponsePart<Bytes>?
+        do {
+          part = try await self.base.next(isolation: `actor`)
+        } catch {
+          self.diagnostics?.recordFailure(error)
+          throw error
+        }
+        guard let part else { return nil }
 
         switch part {
         case .metadata(let metadata):
@@ -228,13 +331,21 @@ internal enum ClientStreamExecutor: Sendable {
               transport specific bug. Metadata received: '\(metadata)'.
               """
           )
+          self.diagnostics?.recordFailure(error)
           throw error
 
         case .message(let bytes):
-          let message = try self.deserializer.deserialize(bytes)
-          return .message(message)
+          self.diagnostics?.responseMessage(bytes)
+          do {
+            let message = try self.deserializer.deserialize(bytes)
+            return .message(message)
+          } catch {
+            self.diagnostics?.recordFailure(error)
+            throw error
+          }
 
         case .status(let status, let metadata):
+          self.diagnostics?.responseStatus(status, trailingMetadata: metadata)
           if let error = RPCError(status: status, metadata: metadata) {
             throw error
           } else {

--- a/Sources/GRPCCore/Documentation.docc/Documentation.md
+++ b/Sources/GRPCCore/Documentation.docc/Documentation.md
@@ -97,6 +97,14 @@ Resources for developers working on gRPC Swift:
 - ``ServerContext``
 - ``ConditionalInterceptor``
 
+### Client diagnostics
+
+- ``GRPCClientDiagnostics``
+- ``GRPCClientDiagnosticsObserver``
+- ``GRPCClientDiagnosticsRegistration``
+- ``GRPCClientDiagnosticsEvent``
+- ``GRPCClientDiagnosticsMessageContext``
+
 ### RPC descriptors
 
 - ``MethodDescriptor``

--- a/Tests/GRPCCoreTests/Call/Client/ClientDiagnosticsTests.swift
+++ b/Tests/GRPCCoreTests/Call/Client/ClientDiagnosticsTests.swift
@@ -1,0 +1,334 @@
+/*
+ * Copyright 2026, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+private import Synchronization
+import XCTest
+
+@testable import GRPCCore
+
+@available(gRPCSwift 2.0, *)
+final class ClientDiagnosticsTests: XCTestCase {
+  func testCapturesUnaryLifecycleMetadataAndSerializedMessages() async throws {
+    let observer = RecordingClientDiagnosticsObserver()
+    let registration = GRPCClientDiagnostics.register(observer)
+    defer { registration.cancel() }
+
+    let harness = ClientRPCExecutorTestHarness(server: .echo)
+    try await harness.unary(
+      request: ClientRequest(message: [1, 2, 3], metadata: ["request": "metadata"])
+    ) { response in
+      XCTAssertEqual(try response.message, [1, 2, 3])
+    }
+
+    let snapshot = observer.snapshot
+    XCTAssertEqual(snapshot.messages.count, 2)
+    XCTAssertEqual(snapshot.messages[0].direction, .outbound)
+    XCTAssertEqual(snapshot.messages[0].sequenceNumber, 0)
+    XCTAssertEqual(snapshot.messages[0].bytes, [1, 2, 3])
+    XCTAssertEqual(snapshot.messages[1].direction, .inbound)
+    XCTAssertEqual(snapshot.messages[1].sequenceNumber, 0)
+    XCTAssertEqual(snapshot.messages[1].bytes, [1, 2, 3])
+
+    XCTAssertEqual(snapshot.eventNames.count, 9)
+    XCTAssertEqual(
+      Array(snapshot.eventNames.prefix(3)),
+      [
+        "callStarted", "attemptStarted", "streamCreated",
+      ]
+    )
+    XCTAssertEqual(
+      Array(snapshot.eventNames.suffix(3)),
+      [
+        "responseStatus", "attemptFinished", "callFinished",
+      ]
+    )
+    XCTAssertEqual(snapshot.eventNames.filter { $0 == "requestMetadata" }.count, 1)
+    XCTAssertEqual(snapshot.eventNames.filter { $0 == "requestFinished" }.count, 1)
+    XCTAssertEqual(snapshot.eventNames.filter { $0 == "responseMetadata" }.count, 1)
+    XCTAssertEqual(snapshot.attemptsStarted, [1])
+    XCTAssertEqual(snapshot.attemptsFinished, [1])
+    XCTAssertEqual(snapshot.responseStatusCodes, [.ok])
+
+    let requestMetadata = snapshot.events.compactMap { event -> Metadata? in
+      if case .requestMetadata(_, let metadata) = event { return metadata }
+      return nil
+    }
+    XCTAssertEqual(requestMetadata, [["request": "metadata"]])
+  }
+
+  func testRetryAttemptsShareCallIDAndHaveDistinctAttemptNumbers() async throws {
+    let observer = RecordingClientDiagnosticsObserver()
+    let registration = GRPCClientDiagnostics.register(observer)
+    defer { registration.cancel() }
+
+    let harness = ClientRPCExecutorTestHarness(
+      server: .attemptBased { attempt in
+        if attempt < 3 {
+          return .reject(
+            withError: RPCError(code: .unavailable, message: "retry"),
+            consumeInbound: true
+          )
+        } else {
+          return .echo
+        }
+      }
+    )
+
+    let retryPolicy = RetryPolicy(
+      maxAttempts: 5,
+      initialBackoff: .milliseconds(10),
+      maxBackoff: .milliseconds(100),
+      backoffMultiplier: 1.6,
+      retryableStatusCodes: [.unavailable]
+    )
+    var options = CallOptions.defaults
+    options.executionPolicy = .retry(retryPolicy)
+
+    try await harness.bidirectional(
+      request: StreamingClientRequest {
+        try await $0.write([42])
+      },
+      options: options
+    ) { response in
+      let messages = try await response.messages.collect()
+      XCTAssertEqual(messages, [[42]])
+    }
+
+    let snapshot = observer.snapshot
+    XCTAssertEqual(snapshot.callIDs.count, 1)
+    XCTAssertEqual(snapshot.attemptsStarted, [1, 2, 3])
+    XCTAssertEqual(snapshot.attemptsFinished.sorted(), [1, 2, 3])
+    XCTAssertEqual(snapshot.responseStatusCodes, [.unavailable, .unavailable, .ok])
+
+    let messageAttemptNumbers = snapshot.messages.map { $0.attemptID.attempt }
+    XCTAssertEqual(messageAttemptNumbers.filter { $0 == 1 }.count, 1)
+    XCTAssertEqual(messageAttemptNumbers.filter { $0 == 2 }.count, 1)
+    XCTAssertEqual(messageAttemptNumbers.filter { $0 == 3 }.count, 2)
+  }
+
+  func testCapturesBidirectionalStreamingMessageSequences() async throws {
+    let observer = RecordingClientDiagnosticsObserver()
+    let registration = GRPCClientDiagnostics.register(observer)
+    defer { registration.cancel() }
+
+    let harness = ClientRPCExecutorTestHarness(server: .echo)
+    try await harness.bidirectional(
+      request: StreamingClientRequest {
+        try await $0.write([0])
+        try await $0.write([1])
+        try await $0.write([2])
+      }
+    ) { response in
+      let messages = try await response.messages.collect()
+      XCTAssertEqual(messages, [[0], [1], [2]])
+    }
+
+    let messages = observer.snapshot.messages
+    let outbound = messages.filter { $0.direction == .outbound }
+    let inbound = messages.filter { $0.direction == .inbound }
+    XCTAssertEqual(outbound.map(\.sequenceNumber), [0, 1, 2])
+    XCTAssertEqual(outbound.map(\.bytes), [[0], [1], [2]])
+    XCTAssertEqual(inbound.map(\.sequenceNumber), [0, 1, 2])
+    XCTAssertEqual(inbound.map(\.bytes), [[0], [1], [2]])
+  }
+
+  func testHedgedAttemptsHaveDistinctAttemptNumbersAndTerminalEvents() async throws {
+    let observer = RecordingClientDiagnosticsObserver()
+    let registration = GRPCClientDiagnostics.register(observer)
+    defer { registration.cancel() }
+
+    let harness = ClientRPCExecutorTestHarness(
+      server: .attemptBased { attempt in
+        if attempt == 3 {
+          return .echo
+        } else {
+          return .sleepFor(
+            duration: .seconds(60),
+            then: .reject(withError: RPCError(code: .unavailable, message: "hedged"))
+          )
+        }
+      }
+    )
+    let policy = HedgingPolicy(
+      maxAttempts: 3,
+      hedgingDelay: .milliseconds(5),
+      nonFatalStatusCodes: [.unavailable]
+    )
+    var options = CallOptions.defaults
+    options.executionPolicy = .hedge(policy)
+
+    try await harness.bidirectional(
+      request: StreamingClientRequest {
+        try await $0.write([7])
+      },
+      options: options
+    ) { response in
+      let messages = try await response.messages.collect()
+      XCTAssertEqual(messages, [[7]])
+    }
+
+    let snapshot = observer.snapshot
+    XCTAssertEqual(snapshot.callIDs.count, 1)
+    XCTAssertEqual(snapshot.attemptsStarted, [1, 2, 3])
+    XCTAssertEqual(snapshot.attemptsFinished.sorted(), [1, 2, 3])
+    XCTAssertEqual(snapshot.eventNames.filter { $0 == "attemptFinished" }.count, 3)
+    XCTAssertEqual(snapshot.responseStatusCodes, [.ok])
+  }
+
+  func testStreamCreationFailureFinishesAttemptAndCallExactlyOnce() async throws {
+    let observer = RecordingClientDiagnosticsObserver()
+    let registration = GRPCClientDiagnostics.register(observer)
+    defer { registration.cancel() }
+
+    let harness = ClientRPCExecutorTestHarness(
+      transport: .throwsOnStreamCreation(code: .aborted),
+      server: .failTest
+    )
+
+    await XCTAssertThrowsRPCErrorAsync {
+      try await harness.unary(request: ClientRequest(message: [1])) { _ in }
+    } errorHandler: { error in
+      XCTAssertEqual(error.code, .aborted)
+    }
+
+    let snapshot = observer.snapshot
+    XCTAssertEqual(snapshot.attemptsStarted, [1])
+    XCTAssertEqual(snapshot.attemptsFinished, [1])
+    XCTAssertEqual(snapshot.eventNames.filter { $0 == "callFinished" }.count, 1)
+
+    let attemptOutcomes = snapshot.events.compactMap { event -> GRPCClientAttemptOutcome? in
+      if case .attemptFinished(_, let outcome) = event { return outcome }
+      return nil
+    }
+    guard case .failed(let error) = attemptOutcomes.first else {
+      return XCTFail("Expected a failed attempt")
+    }
+    XCTAssertEqual(error.code, .aborted)
+  }
+
+  func testCancelledRegistrationDoesNotObserveNewCalls() async throws {
+    let observer = RecordingClientDiagnosticsObserver()
+    let registration = GRPCClientDiagnostics.register(observer)
+    registration.cancel()
+
+    let harness = ClientRPCExecutorTestHarness(server: .echo)
+    try await harness.unary(request: ClientRequest(message: [1])) { response in
+      XCTAssertEqual(try response.message, [1])
+    }
+
+    XCTAssertTrue(observer.snapshot.events.isEmpty)
+    XCTAssertTrue(observer.snapshot.messages.isEmpty)
+  }
+}
+
+@available(gRPCSwift 2.0, *)
+private final class RecordingClientDiagnosticsObserver: GRPCClientDiagnosticsObserver, Sendable {
+  struct Message: Sendable {
+    var attemptID: GRPCClientAttemptID
+    var direction: GRPCClientDiagnosticsMessageDirection
+    var sequenceNumber: Int
+    var bytes: [UInt8]
+  }
+
+  struct Snapshot: Sendable {
+    var events: [GRPCClientDiagnosticsEvent]
+    var messages: [Message]
+
+    var eventNames: [String] {
+      self.events.map { event in
+        switch event {
+        case .callStarted: "callStarted"
+        case .attemptStarted: "attemptStarted"
+        case .streamCreated: "streamCreated"
+        case .requestMetadata: "requestMetadata"
+        case .requestFinished: "requestFinished"
+        case .responseMetadata: "responseMetadata"
+        case .responseStatus: "responseStatus"
+        case .attemptFinished: "attemptFinished"
+        case .callFinished: "callFinished"
+        }
+      }
+    }
+
+    var callIDs: Set<GRPCClientCallID> {
+      Set(
+        self.events.compactMap { event in
+          switch event {
+          case .callStarted(let callID, _), .callFinished(let callID, _):
+            callID
+          default:
+            nil
+          }
+        }
+      )
+    }
+
+    var attemptsStarted: [Int] {
+      self.events.compactMap { event in
+        if case .attemptStarted(let attemptID, _) = event { return attemptID.attempt }
+        return nil
+      }
+    }
+
+    var attemptsFinished: [Int] {
+      self.events.compactMap { event in
+        if case .attemptFinished(let attemptID, _) = event { return attemptID.attempt }
+        return nil
+      }
+    }
+
+    var responseStatusCodes: [Status.Code] {
+      self.events.compactMap { event in
+        if case .responseStatus(_, let status, _) = event { return status.code }
+        return nil
+      }
+    }
+  }
+
+  private struct State: Sendable {
+    var events: [GRPCClientDiagnosticsEvent] = []
+    var messages: [Message] = []
+  }
+
+  private let state = Mutex(State())
+
+  var snapshot: Snapshot {
+    self.state.withLock { state in
+      Snapshot(events: state.events, messages: state.messages)
+    }
+  }
+
+  func observe(_ event: GRPCClientDiagnosticsEvent) {
+    self.state.withLock { $0.events.append(event) }
+  }
+
+  func observe<Bytes: GRPCContiguousBytes>(
+    message: borrowing Bytes,
+    context: GRPCClientDiagnosticsMessageContext
+  ) {
+    let bytes = message.withUnsafeBytes { Array($0) }
+    self.state.withLock { state in
+      state.messages.append(
+        Message(
+          attemptID: context.attemptID,
+          direction: context.direction,
+          sequenceNumber: context.sequenceNumber,
+          bytes: bytes
+        )
+      )
+    }
+  }
+}


### PR DESCRIPTION
Related to #50.

## Summary

- adds an opt-in process-wide client diagnostics registry with cancellable registrations and per-call observer snapshots
- emits logical call and physical retry or hedge attempt lifecycle, peers, post-interceptor metadata, serialized messages, statuses, cancellation, and failures
- uses synchronous generic borrowed-byte callbacks so observers only copy payloads when needed
- keeps observer callbacks outside registry locks and gives the disabled path an atomic fast check
- proposes the public API for gRPC-Swift 2.5

## Implementation

Instrumentation sits in ClientRPCExecutor and ClientStreamExecutor, after client interceptors and serialization but before transport compression and TLS. Attempt terminal events are finalized after outbound and inbound work stops, so payload events cannot arrive after attemptFinished.

## Safety

Registration is explicit and process-local. Documentation warns that observers receive potentially sensitive metadata and serialized payloads and must return quickly from synchronous callbacks.

## Testing

- unary lifecycle, metadata, and exact serialized request and response bytes
- bidirectional-streaming message order and sequence numbers
- retries and hedges sharing one call ID with distinct attempt numbers and terminal events
- registration cancellation
- stream-creation failures and exactly-once terminal events
- full Swift test suite
- format, import-visibility, and license checks
- temporary integration verification against both official NIOPosix and NIOTransportServices HTTP/2 transports
- ad-hoc release throughput comparison over 50,000 in-process unary RPCs with no observer; paired median overhead measured about 0.4 percent, under the proposed 1 percent budget

This remains a draft for maintainer feedback on the API and whether a gRFC or a repository-owned benchmark target is required.