### PR TITLE
Add WASI support to GRPCCore and GRPCInProcessTransport

### DIFF
--- a/Sources/GRPCCore/Call/Client/Internal/RetryDelaySequence.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/RetryDelaySequence.swift
@@ -23,6 +23,8 @@ public import Glibc  // should be @usableFromInline
 public import Musl  // should be @usableFromInline
 #elseif canImport(ucrt)
 public import ucrt  // should be @usableFromInline
+#elseif canImport(WASILibc)
+public import WASILibc  // should be @usableFromInline
 #else
 #error("Unsupported OS")
 #endif

--- a/Sources/GRPCCore/Timeout.swift
+++ b/Sources/GRPCCore/Timeout.swift
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-internal import Dispatch
-
 /// A timeout for a gRPC call.
 ///
 /// It's a combination of an amount (expressed as an integer of at maximum 8 digits), and a unit, which is

--- a/Sources/GRPCInProcessTransport/InProcessTransport.swift
+++ b/Sources/GRPCInProcessTransport/InProcessTransport.swift
@@ -26,7 +26,7 @@ public struct InProcessTransport: Sendable {
   /// - Parameters:
   ///   - serviceConfig: Configuration describing how methods should be executed.
   public init(serviceConfig: ServiceConfig = ServiceConfig()) {
-    let peer = "in-process:\(System.pid())"
+    let peer = System.pid().map { "in-process:\($0)" } ?? "in-process"
     self.server = Self.Server(peer: peer)
     self.client = Self.Client(server: self.server, serviceConfig: serviceConfig, peer: peer)
   }

--- a/Sources/GRPCInProcessTransport/Syscalls.swift
+++ b/Sources/GRPCInProcessTransport/Syscalls.swift
@@ -24,12 +24,16 @@ private import Glibc  // should be @usableFromInline
 private import Musl  // should be @usableFromInline
 #elseif canImport(ucrt)
 private import ucrt  // should be @usableFromInline
+#elseif canImport(WASILibc)
+// No libc import needed: `pid()` returns `nil` on WASI (no process model).
 #else
 #error("Unsupported OS")
 #endif
 
 enum System {
-  static func pid() -> Int {
+  /// The current process identifier, or `nil` on platforms without a process
+  /// model (e.g. WASI preview 1).
+  static func pid() -> Int? {
     #if canImport(Darwin)
     let pid = Darwin.getpid()
     return Int(pid)
@@ -46,7 +50,7 @@ enum System {
     let pid = ucrt._getpid()
     return Int(pid)
     #else
-    return 0
+    return nil
     #endif
   }
 }


### PR DESCRIPTION
GRPCCore and the in-process transport are transport-agnostic and already compile cleanly for `wasm32-wasi` except for three platform guards:

- `RetryDelaySequence` imports a libc for `pow()`: add the `WASILibc` branch to the import chain.
- `Timeout.swift` has `internal import Dispatch`, which doesn't exist on WASI — and no `Dispatch` symbol is referenced in the file — so the import is guarded with `canImport(Dispatch)`.
- The in-process transport's `System.pid()`: WASI preview 1 has no process model, so report a constant.

With these three changes, `GRPCCore` + generated service stubs + `GRPCInProcessTransport` build and **run** under wasm32-wasi — verified with a greeter service round trip (SwiftWasm 6.3.2, executed on wasmtime):

```
greeter-inprocess: Hey Universal UI! [seq=1 tags=grpc-swift-2,in-process]
```

This makes gRPC service/client logic shareable with wasm and browser targets; socket transports (NIO) remain platform-specific, as expected. Happy to adjust if you'd prefer a different pid strategy or to drop the unused Dispatch import outright.