### PR TITLE
docs/fixes and footguns

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,4 +20,4 @@ more information about gRPC.
 
 ### Run CI checks locally
 
-You can run the GitHub Actions workflows locally using [act](https://github.com/nektos/act) or in some cases calling scripts directly. For detailed steps on how to do this please see [https://github.com/swiftlang/github-workflows?tab=readme-ov-file#running-workflows-locally](https://github.com/swiftlang/github-workflows?tab=readme-ov-file#running-workflows-locally).
+You can run the GitHub Actions workflows locally using [act](https://github.com/nektos/act) or, in some cases, calling scripts directly. For detailed steps on how to do this, please see [https://github.com/swiftlang/github-workflows?tab=readme-ov-file#running-workflows-locally](https://github.com/swiftlang/github-workflows?tab=readme-ov-file#running-workflows-locally).

--- a/Examples/echo-metadata/README.md
+++ b/Examples/echo-metadata/README.md
@@ -2,20 +2,20 @@
 
 This example demonstrates how to interact with `Metadata` on RPCs: how to set and read it on unary 
 and streaming requests, as well as how to set and read both initial and trailing metadata on unary 
-and streaming responses. This is done using a simple 'echo' server and client and the SwiftNIO 
-based HTTP/2 transport.
+and streaming responses. This is done using a simple `echo` server and client, and the SwiftNIO-based 
+HTTP/2 transport.
 
 ## Overview
 
-An `echo-metadata` command line tool that uses generated stubs for an 'echo-metadata' service
-which allows you to start a server and to make requests against it. 
+An `echo-metadata` command line tool that uses generated stubs for the `echo`
+service, which allows you to start a server and to make requests against it. 
 
-You can use any of the client's subcommands (`get`, `collect`, `expand` and `update`) to send the
-provided `message` as both the request's message, and as the value for the `echo-message` key in
-the request's metadata.
+You can use any of the client’s subcommands (`get`, `collect`, `expand`, and `update`) to send the
+provided `message` as both the request’s message and as the value for the `echo-message` key in
+the request’s metadata.
 
-The server will then echo back the message and the metadata's `echo-message` key-value pair sent
-by the client. The request's metadata will be echoed both in the initial and the trailing metadata.
+The server will then echo back the message and the metadata’s `echo-message` key-value pair sent
+by the client. The request’s metadata will be echoed in both the initial and the trailing metadata.
 
 The tool uses the [SwiftNIO](https://github.com/grpc/grpc-swift-nio-transport) HTTP/2 transport.
 

--- a/Examples/echo/README.md
+++ b/Examples/echo/README.md
@@ -1,11 +1,11 @@
 # Echo
 
-This example demonstrates all four RPC types using a simple 'echo' service and
-client and the SwiftNIO based HTTP/2 transport.
+This example demonstrates all four RPC types using a simple `echo` service and
+client, and the SwiftNIO-based HTTP/2 transport.
 
 ## Overview
 
-An "echo" command line tool that uses generated stubs for an 'echo' service
+An `echo` command line tool that uses generated stubs for an `echo` service,
 which allows you to start a server and to make requests against it for each of
 the four RPC types.
 
@@ -21,7 +21,7 @@ $ swift run echo serve
 Echo listening on [ipv4]127.0.0.1:1234
 ```
 
-Use the CLI to make a unary 'Get' request against it:
+Use the CLI to make a unary `Get` request against it:
 
 ```console
 $ swift run echo get --message "Hello"
@@ -29,7 +29,7 @@ get → Hello
 get ← Hello
 ```
 
-Use the CLI to make a bidirectional streaming 'Update' request:
+Use the CLI to make a bidirectional streaming `Update` request:
 
 ```console
 $ swift run echo update --message "Hello World"

--- a/Examples/error-details/README.md
+++ b/Examples/error-details/README.md
@@ -6,7 +6,7 @@ This example demonstrates how to create and unpack detailed errors.
 
 A command line tool that demonstrates how a detailed error can be thrown by a
 service and unpacked and inspected by a client. The detailed error model is
-described in more detailed in the [gRPC Error
+described in more detail in the [gRPC Error
 Guide](https://grpc.io/docs/guides/error/) and is made available via the
 [grpc-swift-protobuf](https://github.com/grpc-swift-protobuf) package.
 

--- a/Examples/hello-world/README.md
+++ b/Examples/hello-world/README.md
@@ -1,11 +1,11 @@
 # Hello World
 
-This example demonstrates the canonical "Hello World" in gRPC.
+This example demonstrates the canonical “Hello World” in gRPC.
 
 ## Overview
 
-A "hello-world" command line tool that uses generated stubs for the 'Greeter'
-service which allows you to start a server and to make requests against it.
+A `hello-world` command line tool that uses generated stubs for the `Greeter`
+service, which allows you to start a server and to make requests against it.
 
 The tool uses the [SwiftNIO](https://github.com/grpc/grpc-swift-nio-transport)
 HTTP/2 transport.

--- a/Examples/reflection-server/README.md
+++ b/Examples/reflection-server/README.md
@@ -1,16 +1,16 @@
 # Reflection Server
 
-This example demonstrates the gRPC Reflection service which is described in more
+This example demonstrates the gRPC Reflection service, which is described in more
 detail in the [gRPC documentation](https://github.com/grpc/grpc/blob/6fa8043bf9befb070b846993b59a3348248e6566/doc/server-reflection.md).
 
 ## Overview
 
-A 'reflection-server' command line tool that uses the reflection service implementation
+A `reflection-server` command line tool that uses the reflection service implementation
 from [grpc/grpc-swift-extras](https://github.com/grpc/grpc-swift-extras) and the
-Echo service (see the 'echo' example).
+Echo service (see the `echo` example).
 
 The reflection service requires you to initialize it with a set of Protobuf file
-descriptors for the services you're offering. You can use `protoc` to create a
+descriptors for the services you’re offering. You can use `protoc` to create a
 descriptor set including dependencies and source information for each service.
 
 The following command will generate a descriptor set at `path/to/output.pb` from
@@ -32,8 +32,8 @@ $ swift run reflection-server
 Reflection server listening on [ipv4]127.0.0.1:31415
 ```
 
-You can use 'grpcurl' to query the reflection service. If you don't already have
-it installed follow the instructions in the 'grpcurl' project's
+You can use `grpcurl` to query the reflection service. If you don’t already have
+it installed, follow the instructions in the `grpcurl` project’s
 [README](https://github.com/fullstorydev/grpcurl).
 
 You can list all services with:
@@ -43,7 +43,7 @@ $ grpcurl -plaintext 127.0.0.1:31415 list
 echo.Echo
 ```
 
-And describe the 'Get' method in the 'echo.Echo' service:
+And describe the `Get` method in the `echo.Echo` service:
 
 ```console
 $ grpcurl -plaintext 127.0.0.1:31415 describe echo.Echo.Get
@@ -52,7 +52,7 @@ echo.Echo.Get is a method:
 rpc Get ( .echo.EchoRequest ) returns ( .echo.EchoResponse );
 ```
 
-You can also call the 'echo.Echo.Get' method:
+You can also call the `echo.Echo.Get` method:
 ```console
 $ grpcurl -plaintext -d '{ "text": "Hello" }' 127.0.0.1:31415 echo.Echo.Get
 {

--- a/Examples/route-guide/README.md
+++ b/Examples/route-guide/README.md
@@ -1,13 +1,13 @@
 # Route Guide
 
-This example demonstrates all four RPC types using a 'Route Guide' service and
+This example demonstrates all four RPC types using a “Route Guide” service and
 client.
 
 ## Overview
 
-A "route-guide" command line tool that uses generated stubs for a 'Route Guide'
-service allows you to start a server and to make requests against it for
-each of the four RPC types.
+A `route-guide` command line tool that uses generated stubs for a “Route Guide”
+service, which allows you to start a server and to make requests against it
+for each of the four RPC types.
 
 The tool uses the [SwiftNIO](https://github.com/grpc/grpc-swift-nio-transport)
 HTTP/2 transport.

--- a/Examples/service-lifecycle/README.md
+++ b/Examples/service-lifecycle/README.md
@@ -1,14 +1,14 @@
 # Service Lifecycle
 
-This example demonstrates gRPC Swift's integration with Swift Service Lifecycle
+This example demonstrates gRPC Swift’s integration with Swift Service Lifecycle,
 which is provided by the gRPC Swift Extras package.
 
 ## Overview
 
-A "service-lifecycle" command line tool that uses generated stubs for a
-'greeter' service starts an in-process client and server orchestrated using
-Swift Service Lifecycle. The client makes requests against the server which
-periodically changes its greeting.
+A `service-lifecycle` command line tool that uses generated stubs for a
+`Greeter` service, which starts an in-process client and server orchestrated
+using Swift Service Lifecycle. The client makes requests against the server,
+which periodically changes its greeting.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The following snippet contains a Swift Package manifest to use gRPC Swift v2.x w
 the SwiftNIO based transport and SwiftProtobuf serialization:
 
 ```swift
-// swift-tools-version: 6.0
+// swift-tools-version: 6.1
 import PackageDescription
 
 let package = Package(

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 This repository contains a gRPC implementation for Swift. You can read more
 about gRPC on the [gRPC project's website][grpcio].
 
-- 📚 **Documentation** and **tutorials** are available on the [Swift Package Index][spi-grpc-swift]
-- 💻 **Examples** are available in the [Examples](Examples) directory
-- 🚀 **Contributions** are welcome, please see [CONTRIBUTING.md](CONTRIBUTING.md)
-- 🪪 **License** is Apache 2.0, repeated in [LICENSE](License)
-- 🔒 **Security** issues should be reported via the process in [SECURITY.md](SECURITY.md)
+- 📚 **Documentation** and **tutorials** are available on the [Swift Package Index][spi-grpc-swift].
+- 💻 **Examples** are available in the [Examples](Examples) directory.
+- 🚀 **Contributions** are welcome; please see [CONTRIBUTING.md](CONTRIBUTING.md).
+- 🪪 **License** is Apache 2.0; see [LICENSE](LICENSE) for the full text.
+- 🔒 **Security** issues should be reported via the process in [SECURITY.md](SECURITY.md).
 - 🔀 **Related Repositories**:
   - [`grpc-swift-nio-transport`][grpc-swift-nio-transport] contains
     high-performance HTTP/2 client and server transport implementations for gRPC
@@ -21,7 +21,7 @@ about gRPC on the [gRPC project's website][grpcio].
 ## Quick Start
 
 The following snippet contains a Swift Package manifest to use gRPC Swift v2.x with
-the SwiftNIO based transport and SwiftProtobuf serialization:
+the SwiftNIO-based transport and SwiftProtobuf serialization:
 
 ```swift
 // swift-tools-version: 6.1

--- a/Sources/GRPCCodeGen/CodeGenError.swift
+++ b/Sources/GRPCCodeGen/CodeGenError.swift
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-/// A error thrown by the ``SourceGenerator`` to signal errors in the ``CodeGenerationRequest`` object.
+/// An error thrown by the ``SourceGenerator`` to signal errors in the ``CodeGenerationRequest`` object.
 @available(gRPCSwift 2.0, *)
 public struct CodeGenError: Error, Hashable, Sendable {
   /// The code indicating the domain of the error.
   public var code: Code
-  /// A message providing more details about the error which may include details specific to this
+  /// A message providing more details about the error, which may include details specific to this
   /// instance of the error.
   public var message: String
 
@@ -48,7 +48,7 @@ extension CodeGenError {
       self.value = value
     }
 
-    /// The same name is used for two services that are either in the same namespace or don't have a namespace.
+    /// The same name is used for two services that either are in the same namespace or don't have a namespace.
     public static var nonUniqueServiceName: Self {
       Self(.nonUniqueServiceName)
     }

--- a/Sources/GRPCCodeGen/CodeGenerationRequest.swift
+++ b/Sources/GRPCCodeGen/CodeGenerationRequest.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-/// Describes the services, dependencies and trivia from an IDL file,
+/// Describes the services, dependencies, and trivia from an IDL file,
 /// and the IDL itself through its specific serializer and deserializer.
 @available(gRPCSwift 2.0, *)
 public struct CodeGenerationRequest {
@@ -22,12 +22,15 @@ public struct CodeGenerationRequest {
   public var fileName: String
 
   /// Any comments at the top of the file such as documentation and copyright headers.
+  ///
   /// They will be placed at the top of the generated file. They are already formatted,
-  /// meaning they contain  "///" and new lines.
+  /// meaning they contain "///" and new lines.
   public var leadingTrivia: String
 
-  /// The Swift imports that the generated file depends on. The gRPC specific imports aren't required
-  /// as they will be added by default in the generated file.
+  /// The Swift imports that the generated file depends on.
+  ///
+  /// The gRPC-specific imports aren't required as they will be added by default in the generated
+  /// file.
   ///
   /// - SeeAlso: ``Dependency``.
   public var dependencies: [Dependency]
@@ -38,7 +41,7 @@ public struct CodeGenerationRequest {
   public var services: [ServiceDescriptor]
 
   /// Closure that receives a message type as a `String` and returns a code snippet to
-  /// initialise a `MessageSerializer` for that type as a `String`.
+  /// initialize a `MessageSerializer` for that type as a `String`.
   ///
   /// The result is inserted in the generated code, where clients serialize RPC inputs and
   /// servers serialize RPC outputs.
@@ -57,7 +60,7 @@ public struct CodeGenerationRequest {
   /// The result is inserted in the generated code, where clients deserialize RPC outputs and
   /// servers deserialize RPC inputs.
   ///
-  /// For example, to serialize Protobuf messages you could specify a serializer as:
+  /// For example, to deserialize Protobuf messages you could specify a deserializer as:
   /// ```swift
   /// request.makeDeserializerCodeSnippet = { messageType in
   ///   "ProtobufDeserializer<\(messageType)>()"
@@ -128,6 +131,7 @@ extension CodeGenerationRequest {
 @available(gRPCSwift 2.0, *)
 public struct Dependency: Equatable, Sendable {
   /// If the dependency is an item, the property's value is the item representation.
+  ///
   /// If the dependency is a module, this property is nil.
   public var item: Item?
 
@@ -139,7 +143,7 @@ public struct Dependency: Equatable, Sendable {
 
   /// The name of the private interface for an `@_spi` import.
   ///
-  /// For example, if `spi` was "Secret" and the module name was "Foo" then the import
+  /// For example, if `spi` was "Secret" and the module name was "Foo", then the import
   /// would be `@_spi(Secret) import Foo`.
   public var spi: String?
 
@@ -162,7 +166,7 @@ public struct Dependency: Equatable, Sendable {
 
   /// Represents an item imported from a module.
   public struct Item: Equatable, Sendable {
-    /// The keyword that specifies the item's kind (e.g. `func`, `struct`).
+    /// The keyword that specifies the item's kind (for example, `func`, `struct`).
     public var kind: Kind
 
     /// The name of the imported item.
@@ -270,7 +274,8 @@ public struct Dependency: Equatable, Sendable {
 @available(gRPCSwift 2.0, *)
 public struct ServiceDescriptor: Hashable, Sendable {
   /// Documentation from comments above the IDL service description.
-  /// It is already formatted, meaning it contains  "///" and new lines.
+  ///
+  /// It is already formatted, meaning it contains "///" and new lines.
   public var documentation: String
 
   /// The name of the service.
@@ -328,7 +333,8 @@ extension ServiceDescriptor {
 @available(gRPCSwift 2.0, *)
 public struct MethodDescriptor: Hashable, Sendable {
   /// Documentation from comments above the IDL method description.
-  /// It is already formatted, meaning it contains  "///" and new lines.
+  ///
+  /// It is already formatted, meaning it contains "///" and new lines.
   public var documentation: String
 
   /// Method name in different formats.
@@ -392,7 +398,7 @@ extension MethodDescriptor {
 
 @available(gRPCSwift 2.0, *)
 public struct ServiceName: Hashable, Sendable {
-  /// The identifying name as used in the service/method descriptors including any namespace.
+  /// The identifying name as used in the service/method descriptors, including any namespace.
   ///
   /// This value is also used to identify the service to the remote peer, usually as part of the
   /// ":path" pseudoheader if doing gRPC over HTTP/2.
@@ -401,12 +407,12 @@ public struct ServiceName: Hashable, Sendable {
   /// value should be "foo.bar.Baz".
   public var identifyingName: String
 
-  /// The name as used on types including any namespace.
+  /// The name as used on types, including any namespace.
   ///
   /// This is used to generate a namespace for each service which contains a number of client and
   /// server protocols and concrete types.
   ///
-  /// If the service is declared in package "foo.bar" and the service is called "Baz" then this
+  /// If the service is declared in package "foo.bar" and the service is called "Baz", then this
   /// value should be "Foo\_Bar\_Baz".
   public var typeName: String
 
@@ -414,7 +420,7 @@ public struct ServiceName: Hashable, Sendable {
   ///
   /// This is used to provide a convenience getter for a descriptor of the service.
   ///
-  /// If the service is declared in package "foo.bar" and the service is called "Baz" then this
+  /// If the service is declared in package "foo.bar" and the service is called "Baz", then this
   /// value should be "foo\_bar\_Baz".
   public var propertyName: String
 
@@ -435,7 +441,7 @@ public struct MethodName: Hashable, Sendable {
   /// This value typically starts with an uppercase character, for example "Get".
   public var identifyingName: String
 
-  /// The name as used on types including any namespace.
+  /// The name as used on types, including any namespace.
   ///
   /// This is used to generate a namespace for each method which contains information about
   /// the method.
@@ -445,7 +451,7 @@ public struct MethodName: Hashable, Sendable {
 
   /// The name as used as a property.
   ///
-  /// This value typically starts with an lowercase character, for example "get".
+  /// This value typically starts with a lowercase character, for example "get".
   public var functionName: String
 
   public init(identifyingName: String, typeName: String, functionName: String) {
@@ -455,25 +461,27 @@ public struct MethodName: Hashable, Sendable {
   }
 }
 
-/// Represents the name associated with a namespace, service or a method, in three different formats.
+/// Represents the name associated with a namespace, a service, or a method, in three different formats.
 @available(*, deprecated, message: "Use ServiceName/MethodName instead.")
 @available(gRPCSwift 2.0, *)
 public struct Name: Hashable, Sendable {
   /// The base name is the name used for the namespace/service/method in the IDL file, so it should follow
   /// the specific casing of the IDL.
   ///
-  /// The base name is also used in the descriptors that identify a specific method or service :
+  /// The base name is also used in the descriptors that identify a specific method or service:
   /// `<service_namespace_baseName>.<service_baseName>.<method_baseName>`.
   public var base: String
 
-  /// The `generatedUpperCase` name is used in the generated code. It is expected
-  /// to be the UpperCamelCase version of the base name
+  /// The `generatedUpperCase` name is used in the generated code.
+  ///
+  /// It is expected to be the UpperCamelCase version of the base name.
   ///
   /// For example, if `base` is "fooBar", then `generatedUpperCase` is "FooBar".
   public var generatedUpperCase: String
 
-  /// The `generatedLowerCase` name is used in the generated code. It is expected
-  /// to be the lowerCamelCase version of the base name
+  /// The `generatedLowerCase` name is used in the generated code.
+  ///
+  /// It is expected to be the lowerCamelCase version of the base name.
   ///
   /// For example, if `base` is "FooBar", then `generatedLowerCase` is "fooBar".
   public var generatedLowerCase: String

--- a/Sources/GRPCCodeGen/CodeGenerator.swift
+++ b/Sources/GRPCCodeGen/CodeGenerator.swift
@@ -22,7 +22,7 @@ public typealias SourceGenerator = CodeGenerator
 /// in a ``CodeGenerationRequest`` object.
 @available(gRPCSwift 2.0, *)
 public struct CodeGenerator: Sendable {
-  /// The options regarding the access level, indentation for the generated code
+  /// The options regarding the access level, indentation for the generated code,
   /// and whether to generate server and client code.
   public var config: Config
 
@@ -79,22 +79,22 @@ public struct CodeGenerator: Sendable {
         case `package`
       }
 
-      /// The generated code will have `internal` access level.
+      /// The generated code will have an `internal` access level.
       public static var `internal`: Self { Self(level: .`internal`) }
 
-      /// The generated code will have `public` access level.
+      /// The generated code will have a `public` access level.
       public static var `public`: Self { Self(level: .`public`) }
 
-      /// The generated code will have `package` access level.
+      /// The generated code will have a `package` access level.
       public static var `package`: Self { Self(level: .`package`) }
     }
 
     // The availability that generated code is annotated with.
     public struct AvailabilityAnnotations: Sendable, Hashable {
       public struct Platform: Sendable, Hashable {
-        /// The name of the OS, e.g. 'macOS'.
+        /// The name of the OS, for example, "macOS".
         public var os: String
-        /// The version of the OS, e.g. '15.0'.
+        /// The version of the OS, for example, "15.0".
         public var version: String
 
         public init(os: String, version: String) {
@@ -134,7 +134,7 @@ public struct CodeGenerator: Sendable {
     }
   }
 
-  /// Transforms a ``CodeGenerationRequest`` object  into a ``SourceFile`` object containing
+  /// Transforms a ``CodeGenerationRequest`` object into a ``SourceFile`` object containing
   /// the generated code.
   public func generate(
     _ request: CodeGenerationRequest

--- a/Sources/GRPCCodeGen/Documentation.docc/Documentation.md
+++ b/Sources/GRPCCodeGen/Documentation.docc/Documentation.md
@@ -1,0 +1,52 @@
+# ``GRPCCodeGen``
+
+Transport-agnostic Swift source generation for gRPC services.
+
+## Overview
+
+``GRPCCodeGen`` generates Swift client and server code for RPC services described by a
+language-neutral intermediate representation. It builds a structured Swift representation of
+the generated code and renders that representation to text; it doesn't itself parse any
+interface definition language (IDL), such as Protocol Buffers.
+
+Consumers construct a ``CodeGenerationRequest`` describing the services, methods, and
+dependencies parsed from an IDL file, and pass it to ``CodeGenerator/generate(_:)`` to produce
+a ``SourceFile`` containing the generated Swift source. For example, `protoc-gen-grpc-swift-2`
+in [`grpc-swift-protobuf`](https://github.com/grpc/grpc-swift-protobuf) parses `.proto` files
+and uses this module to generate the corresponding Swift source.
+
+``CodeGenerator/generate(_:)`` throws a ``CodeGenError`` if the request is invalid, for
+example if a service or method name isn't unique within its scope.
+
+## Topics
+
+### Code generation
+
+- ``CodeGenerator``
+- ``CodeGenerator/Config``
+- ``CodeGenerator/Config/AccessLevel``
+- ``CodeGenerator/Config/AvailabilityAnnotations``
+- ``CodeGenerator/Config/AvailabilityAnnotations/Platform``
+- ``SourceFile``
+
+### Service descriptors
+
+- ``CodeGenerationRequest``
+- ``ServiceDescriptor``
+- ``MethodDescriptor``
+- ``ServiceName``
+- ``MethodName``
+- ``Dependency``
+- ``Dependency/Item``
+- ``Dependency/Item/Kind``
+- ``Dependency/PreconcurrencyRequirement``
+
+### Errors
+
+- ``CodeGenError``
+- ``CodeGenError/Code``
+
+### Deprecated
+
+- ``SourceGenerator``
+- ``Name``

--- a/Sources/GRPCCodeGen/Documentation.docc/Documentation.md
+++ b/Sources/GRPCCodeGen/Documentation.docc/Documentation.md
@@ -15,8 +15,8 @@ a ``SourceFile`` containing the generated Swift source. For example, `protoc-gen
 in [`grpc-swift-protobuf`](https://github.com/grpc/grpc-swift-protobuf) parses `.proto` files
 and uses this module to generate the corresponding Swift source.
 
-``CodeGenerator/generate(_:)`` throws a ``CodeGenError`` if the request is invalid, for
-example if a service or method name isn't unique within its scope.
+``CodeGenerator/generate(_:)`` throws a ``CodeGenError`` if the request is invalid — for
+example, if a service or method name isn't unique within its scope.
 
 ## Topics
 

--- a/Sources/GRPCCodeGen/Documentation.docc/reference/CodeGenError.md
+++ b/Sources/GRPCCodeGen/Documentation.docc/reference/CodeGenError.md
@@ -1,0 +1,14 @@
+# ``CodeGenError``
+
+## Topics
+
+### Creating an error
+
+- ``init(code:message:)``
+
+### Inspecting an error
+
+- ``code``
+- ``message``
+- ``description``
+- ``Code``

--- a/Sources/GRPCCodeGen/Documentation.docc/reference/CodeGenerationRequest.md
+++ b/Sources/GRPCCodeGen/Documentation.docc/reference/CodeGenerationRequest.md
@@ -1,0 +1,28 @@
+# ``CodeGenerationRequest``
+
+## Topics
+
+### Creating a request
+
+- ``init(fileName:leadingTrivia:dependencies:services:makeSerializerCodeSnippet:makeDeserializerCodeSnippet:)``
+
+### Identifying the source file
+
+- ``fileName``
+- ``leadingTrivia``
+
+### Describing the IDL contents
+
+- ``dependencies``
+- ``services``
+
+### Locating message serializers
+
+- ``makeSerializerCodeSnippet``
+- ``makeDeserializerCodeSnippet``
+
+### Deprecated
+
+- ``lookupSerializer``
+- ``lookupDeserializer``
+- ``init(fileName:leadingTrivia:dependencies:services:lookupSerializer:lookupDeserializer:)``

--- a/Sources/GRPCCodeGen/Documentation.docc/reference/CodeGenerator.Config.AvailabilityAnnotations.md
+++ b/Sources/GRPCCodeGen/Documentation.docc/reference/CodeGenerator.Config.AvailabilityAnnotations.md
@@ -1,0 +1,9 @@
+# ``CodeGenerator/Config/AvailabilityAnnotations``
+
+## Topics
+
+### Creating availability annotations
+
+- ``default``
+- ``custom(_:)``
+- ``Platform``

--- a/Sources/GRPCCodeGen/Documentation.docc/reference/CodeGenerator.Config.md
+++ b/Sources/GRPCCodeGen/Documentation.docc/reference/CodeGenerator.Config.md
@@ -1,0 +1,28 @@
+# ``CodeGenerator/Config``
+
+## Topics
+
+### Creating a configuration
+
+- ``init(accessLevel:accessLevelOnImports:client:server:indentation:)``
+
+### Setting the access level
+
+- ``accessLevel``
+- ``AccessLevel``
+
+### Choosing what to generate
+
+- ``client``
+- ``server``
+
+### Formatting generated code
+
+- ``accessLevelOnImports``
+- ``indentation``
+- ``grpcCoreModuleName``
+
+### Annotating availability
+
+- ``availability``
+- ``AvailabilityAnnotations``

--- a/Sources/GRPCCodeGen/Documentation.docc/reference/CodeGenerator.md
+++ b/Sources/GRPCCodeGen/Documentation.docc/reference/CodeGenerator.md
@@ -1,0 +1,16 @@
+# ``CodeGenerator``
+
+## Topics
+
+### Creating a code generator
+
+- ``init(config:)``
+
+### Configuring code generation
+
+- ``config``
+- ``Config``
+
+### Generating source
+
+- ``generate(_:)``

--- a/Sources/GRPCCodeGen/Documentation.docc/reference/Dependency.Item.md
+++ b/Sources/GRPCCodeGen/Documentation.docc/reference/Dependency.Item.md
@@ -1,0 +1,13 @@
+# ``Dependency/Item``
+
+## Topics
+
+### Creating an item
+
+- ``init(kind:name:)``
+
+### Naming and typing the item
+
+- ``name``
+- ``kind``
+- ``Kind``

--- a/Sources/GRPCCodeGen/Documentation.docc/reference/Dependency.md
+++ b/Sources/GRPCCodeGen/Documentation.docc/reference/Dependency.md
@@ -1,0 +1,26 @@
+# ``Dependency``
+
+## Topics
+
+### Creating a dependency
+
+- ``init(item:module:spi:preconcurrency:accessLevel:)``
+
+### Naming the imported module
+
+- ``module``
+- ``spi``
+
+### Importing a specific item
+
+- ``item``
+- ``Item``
+
+### Setting the access level
+
+- ``accessLevel``
+
+### Requiring preconcurrency
+
+- ``preconcurrency``
+- ``PreconcurrencyRequirement``

--- a/Sources/GRPCCodeGen/SourceFile.swift
+++ b/Sources/GRPCCodeGen/SourceFile.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-/// Representation of the file to be created by the code generator, that contains the
+/// Representation of the file to be created by the code generator that contains the
 /// generated Swift source code.
 @available(gRPCSwift 2.0, *)
 public struct SourceFile: Sendable, Hashable {

--- a/Sources/GRPCCore/Call/Client/CallOptions.swift
+++ b/Sources/GRPCCore/Call/Client/CallOptions.swift
@@ -41,6 +41,9 @@ public struct CallOptions: Sendable {
   ///
   /// If `false` the RPC will abort immediately if there is a transient failure connecting to
   /// the server. Otherwise gRPC will attempt to connect until the deadline is exceeded.
+  ///
+  /// If left unset, transports conventionally treat this the same as `false`, so RPCs fail fast
+  /// on a transient connection failure rather than queuing until the connection is ready.
   public var waitForReady: Bool?
 
   /// The maximum allowed payload size in bytes for an individual request message.

--- a/Sources/GRPCCore/Call/Client/CallOptions.swift
+++ b/Sources/GRPCCore/Call/Client/CallOptions.swift
@@ -25,21 +25,21 @@
 public struct CallOptions: Sendable {
   /// The default timeout for the RPC.
   ///
-  /// If no reply is received in the specified amount of time the request is aborted
+  /// If no reply is received in the specified amount of time, the request is aborted
   /// with an ``RPCError`` with code ``RPCError/Code/deadlineExceeded``.
   ///
   /// The actual deadline used will be the minimum of the value specified here
-  /// and the value set by the application by the client API. If either one isn't set
-  /// then the other value is used. If neither is set then the request has no deadline.
+  /// and the value set by the application by the client API. If either one isn't set,
+  /// then the other value is used. If neither is set, then the request has no deadline.
   ///
   /// The timeout applies to the overall execution of an RPC. If, for example, a retry
-  /// policy is set then the timeout begins when the first attempt is started and _isn't_ reset
+  /// policy is set, then the timeout begins when the first attempt is started and _isn't_ reset
   /// when subsequent attempts start.
   public var timeout: Duration?
 
   /// Whether RPCs for this method should wait until the connection is ready.
   ///
-  /// If `false` the RPC will abort immediately if there is a transient failure connecting to
+  /// If `false`, the RPC will abort immediately if there is a transient failure connecting to
   /// the server. Otherwise gRPC will attempt to connect until the deadline is exceeded.
   ///
   /// If left unset, transports conventionally treat this the same as `false`, so RPCs fail fast
@@ -87,11 +87,11 @@ public struct CallOptions: Sendable {
   /// controls the compression used by the client for request messages.
   ///
   /// Note that this configuration is advisory: not all transports support compression and may
-  /// ignore this configuration. Transports which support compression will use this configuration
+  /// ignore this configuration. Transports that support compression will use this configuration
   /// in preference to the algorithm configured at a transport level. If the transport hasn't
-  /// enabled the use of the algorithm then compression won't be used for the call.
+  /// enabled the use of the algorithm, then compression won't be used for the call.
   ///
-  /// If `nil` the value configured on the transport will be used instead.
+  /// If `nil`, the value configured on the transport will be used instead.
   public var compression: CompressionAlgorithm?
 
   internal init(

--- a/Sources/GRPCCore/Call/Client/ClientContext.swift
+++ b/Sources/GRPCCore/Call/Client/ClientContext.swift
@@ -25,7 +25,7 @@ public struct ClientContext: Sendable {
   /// The format of the description should follow the pattern "<transport>:<address>" where
   /// "<transport>" indicates the underlying network transport (such as "ipv4", "unix", or
   /// "in-process"). This is a guideline for how descriptions should be formatted; different
-  /// implementations may not follow this format so you shouldn't make assumptions based on it.
+  /// implementations may not follow this format, so you shouldn't make assumptions based on it.
   ///
   /// Some examples include:
   /// - "ipv4:127.0.0.1:31415",
@@ -38,7 +38,7 @@ public struct ClientContext: Sendable {
   /// The format of the description should follow the pattern "<transport>:<address>" where
   /// "<transport>" indicates the underlying network transport (such as "ipv4", "unix", or
   /// "in-process"). This is a guideline for how descriptions should be formatted; different
-  /// implementations may not follow this format so you shouldn't make assumptions based on it.
+  /// implementations may not follow this format, so you shouldn't make assumptions based on it.
   ///
   /// Some examples include:
   /// - "ipv4:127.0.0.1:31415",
@@ -46,7 +46,7 @@ public struct ClientContext: Sendable {
   /// - "in-process:27182".
   public var localPeer: String
 
-  /// Create a new client interceptor context.
+  /// Creates a new client interceptor context.
   ///
   /// - Parameters:
   ///   - descriptor: A description of the method being called.

--- a/Sources/GRPCCore/Call/Client/ClientInterceptor.swift
+++ b/Sources/GRPCCore/Call/Client/ClientInterceptor.swift
@@ -16,10 +16,10 @@
 
 // - FIXME: Update example and documentation to show how to register an interceptor.
 
-/// A type that intercepts requests and response for clients.
+/// A type that intercepts requests and responses for clients.
 ///
 /// Interceptors allow you to inspect and modify requests and responses. Requests are intercepted
-/// before they are handed to a transport and responses are intercepted after they have been
+/// before they are handed to a transport, and responses are intercepted after they have been
 /// received from the transport. They are typically used for cross-cutting concerns like injecting
 /// metadata, validating messages, logging additional data, and tracing.
 ///
@@ -88,7 +88,7 @@
 /// }
 /// ```
 ///
-/// For server-side interceptors see ``ServerInterceptor``.
+/// For server-side interceptors, see ``ServerInterceptor``.
 @available(gRPCSwift 2.0, *)
 public protocol ClientInterceptor: Sendable {
   /// Intercept a request object.

--- a/Sources/GRPCCore/Call/Client/ClientRequest.swift
+++ b/Sources/GRPCCore/Call/Client/ClientRequest.swift
@@ -19,7 +19,7 @@
 /// This is used for unary and server-streaming RPCs.
 ///
 /// See ``StreamingClientRequest`` for streaming requests and ``ServerRequest`` for the
-/// servers representation of a single-message request.
+/// server's representation of a single-message request.
 ///
 /// ## Creating requests
 ///
@@ -34,15 +34,15 @@ public struct ClientRequest<Message: Sendable>: Sendable {
   ///
   /// Both gRPC Swift and its transport layer may insert additional metadata. Keys prefixed with
   /// "grpc-" are prohibited and may result in undefined behaviour. Transports may also insert
-  /// their own metadata, you should avoid using key names which may clash with transport specific
-  /// metadata. Note that transports may also impose limits in the amount of metadata which may
+  /// their own metadata; you should avoid using key names that may clash with transport-specific
+  /// metadata. Note that transports may also impose limits on the amount of metadata that may
   /// be sent.
   public var metadata: Metadata
 
   /// The message to send to the server.
   public var message: Message
 
-  /// Create a new single client request.
+  /// Creates a new single client request.
   ///
   /// - Parameters:
   ///   - message: The message to send to the server.
@@ -61,31 +61,31 @@ public struct ClientRequest<Message: Sendable>: Sendable {
 /// This is used for client-streaming and bidirectional-streaming RPCs.
 ///
 /// See ``ClientRequest`` for single-message requests and ``StreamingServerRequest`` for the
-/// servers representation of a streaming-message request.
+/// server's representation of a streaming-message request.
 @available(gRPCSwift 2.0, *)
 public struct StreamingClientRequest<Message: Sendable>: Sendable {
   /// Caller-specified metadata sent to the server at the start of the RPC.
   ///
   /// Both gRPC Swift and its transport layer may insert additional metadata. Keys prefixed with
   /// "grpc-" are prohibited and may result in undefined behaviour. Transports may also insert
-  /// their own metadata, you should avoid using key names which may clash with transport specific
-  /// metadata. Note that transports may also impose limits in the amount of metadata which may
+  /// their own metadata; you should avoid using key names that may clash with transport-specific
+  /// metadata. Note that transports may also impose limits on the amount of metadata that may
   /// be sent.
   public var metadata: Metadata
 
-  /// A closure which, when called, writes messages in the writer.
+  /// A closure that, when called, writes messages to the writer.
   ///
   /// The producer will only be consumed once by gRPC and therefore isn't required to be
-  /// idempotent. If the producer throws an error then the RPC will be cancelled. Once the
-  /// producer returns the request stream is closed.
+  /// idempotent. If the producer throws an error, then the RPC will be cancelled. Once the
+  /// producer returns, the request stream is closed.
   public var producer: @Sendable (RPCWriter<Message>) async throws -> Void
 
-  /// Create a new streaming client request.
+  /// Creates a new streaming client request.
   ///
   /// - Parameters:
-  ///   - messageType: The type of message contained in this request, defaults to `Message.self`.
+  ///   - messageType: The type of message contained in this request defaults to `Message.self`.
   ///   - metadata: Metadata to send to the server at the start of the request. Defaults to empty.
-  ///   - producer: A closure which writes messages to send to the server. The closure is called
+  ///   - producer: A closure that writes messages to send to the server. The closure is called
   ///       at most once and may not be called.
   public init(
     of messageType: Message.Type = Message.self,

--- a/Sources/GRPCCore/Call/Client/ClientResponse.swift
+++ b/Sources/GRPCCore/Call/Client/ClientResponse.swift
@@ -16,7 +16,7 @@
 
 /// A response for a single message received by a client.
 ///
-/// Single responses are used for unary and client-streaming RPCs. For streaming responses
+/// Single responses are used for unary and client-streaming RPCs. For streaming responses,
 /// see ``StreamingClientResponse``.
 ///
 /// A single response captures every part of the response stream and distinguishes successful
@@ -26,12 +26,12 @@
 ///
 /// The `failure` case indicates that the server chose not to process the RPC, or the processing
 /// of the RPC failed, or the client failed to execute the request. The failure case contains
-/// an ``RPCError`` describing why the RPC failed, including an error code, error message and any
+/// an ``RPCError`` describing why the RPC failed, including an error code, error message, and any
 /// metadata sent by the server.
 ///
 /// ### Using responses
 ///
-/// Each response has a ``accepted`` property which contains all RPC information. You can create
+/// Each response has an ``accepted`` property that contains all RPC information. You can create
 /// one by calling ``init(accepted:)`` or one of the two convenience initializers:
 /// - ``init(message:metadata:trailingMetadata:)`` to create a successful response, or
 /// - ``init(of:error:)`` to create a failed response.
@@ -73,18 +73,18 @@ public struct ClientResponse<Message: Sendable>: Sendable {
   public struct Contents: Sendable {
     /// Metadata received from the server at the beginning of the response.
     ///
-    /// The metadata may contain transport-specific information in addition to any application
-    /// level metadata provided by the service.
+    /// The metadata may contain transport-specific information in addition to any application-level
+    /// metadata provided by the service.
     public var metadata: Metadata
 
-    /// The response message received from the server, or an error of the RPC failed with a
+    /// The response message received from the server, or an error if the RPC failed with a
     /// non-ok status.
     public var message: Result<Message, RPCError>
 
     /// Metadata received from the server at the end of the response.
     ///
-    /// The metadata may contain transport-specific information in addition to any application
-    /// level metadata provided by the service.
+    /// The metadata may contain transport-specific information in addition to any application-level
+    /// metadata provided by the service.
     public var trailingMetadata: Metadata
 
     /// Creates a `Contents`.
@@ -136,27 +136,27 @@ public struct ClientResponse<Message: Sendable>: Sendable {
 /// A response for a stream of messages received by a client.
 ///
 /// Stream responses are used for server-streaming and bidirectional-streaming RPCs. For single
-/// responses see ``ClientResponse``.
+/// responses, see ``ClientResponse``.
 ///
 /// A stream response captures every part of the response stream over time and distinguishes
 /// accepted and rejected requests via the ``accepted`` property. An "accepted" request is one
-/// where the the server responds with initial metadata and attempts to process the request. A
+/// where the server responds with initial metadata and attempts to process the request. A
 /// "rejected" request is one where the server responds with a status as the first and only
 /// response part and doesn't process the request body.
 ///
-/// The value for the `success` case contains the initial metadata and a ``RPCAsyncSequence`` of
+/// The value for the `success` case contains the initial metadata and an ``RPCAsyncSequence`` of
 /// message parts (messages followed by a single status). If the sequence completes without
-/// throwing then the response implicitly has an ``Status/Code-swift.struct/ok`` status code.
+/// throwing, then the response implicitly has an ``Status/Code-swift.struct/ok`` status code.
 /// However, the response sequence may also throw an ``RPCError`` if the server fails to complete
 /// processing the request.
 ///
 /// The `failure` case indicates that the server chose not to process the RPC or the client failed
 /// to execute the request. The failure case contains an ``RPCError`` describing why the RPC
-/// failed, including an error code, error message and any metadata sent by the server.
+/// failed, including an error code, error message, and any metadata sent by the server.
 ///
 /// ### Using streaming responses
 ///
-/// Each response has a ``accepted`` property which contains RPC information. You can create
+/// Each response has an ``accepted`` property that contains RPC information. You can create
 /// one by calling ``init(accepted:)`` or one of the two convenience initializers:
 /// - ``init(of:metadata:bodyParts:)`` to create an accepted response, or
 /// - ``init(of:error:)`` to create a failed response.
@@ -164,7 +164,7 @@ public struct ClientResponse<Message: Sendable>: Sendable {
 /// You can interrogate a response by inspecting the ``accepted`` property directly or by using
 /// its convenience properties:
 /// - ``metadata`` extracts the initial metadata,
-/// - ``messages`` extracts the sequence of response message, or throws if the response failed.
+/// - ``messages`` extracts the sequence of response messages, or throws if the response failed.
 ///
 /// The following example demonstrates how you can use the API:
 ///
@@ -204,14 +204,14 @@ public struct StreamingClientResponse<Message: Sendable>: Sendable {
   public struct Contents: Sendable {
     /// Metadata received from the server at the beginning of the response.
     ///
-    /// The metadata may contain transport-specific information in addition to any application
-    /// level metadata provided by the service.
+    /// The metadata may contain transport-specific information in addition to any application-level
+    /// metadata provided by the service.
     public var metadata: Metadata
 
     /// A sequence of stream parts received from the server ending with metadata if the RPC
     /// succeeded.
     ///
-    /// If the RPC fails then the sequence will throw an ``RPCError``.
+    /// If the RPC fails, then the sequence will throw an ``RPCError``.
     ///
     /// The sequence may only be iterated once.
     public var bodyParts: RPCAsyncSequence<BodyPart, any Error>
@@ -220,7 +220,9 @@ public struct StreamingClientResponse<Message: Sendable>: Sendable {
     public enum BodyPart: Sendable {
       /// A response message.
       case message(Message)
-      /// Metadata. Must be the final value of the sequence unless the stream throws an error.
+      /// Metadata.
+      ///
+      /// Must be the final value of the sequence unless the stream throws an error.
       case trailingMetadata(Metadata)
     }
 
@@ -241,7 +243,7 @@ public struct StreamingClientResponse<Message: Sendable>: Sendable {
   /// Whether the RPC was accepted or rejected.
   ///
   /// The `success` case indicates the RPC was accepted by the server for
-  /// processing, however, the RPC may still fail by throwing an error from its
+  /// processing; however, the RPC may still fail by throwing an error from its
   /// `messages` sequence. The `failure` case indicates that the RPC was
   /// rejected by the server.
   public var accepted: Result<Contents, RPCError>
@@ -295,7 +297,7 @@ extension ClientResponse {
 
   /// Returns metadata received from the server at the start of the response.
   ///
-  /// For rejected RPCs (in other words, where ``accepted`` is `failure`) the metadata is empty.
+  /// For rejected RPCs (in other words, where ``accepted`` is `failure`), the metadata is empty.
   public var metadata: Metadata {
     switch self.accepted {
     case let .success(contents):
@@ -355,7 +357,7 @@ extension StreamingClientResponse {
 
   /// Returns metadata received from the server at the start of the response.
   ///
-  /// For rejected RPCs (in other words, where ``accepted`` is `failure`) the metadata is empty.
+  /// For rejected RPCs (in other words, where ``accepted`` is `failure`), the metadata is empty.
   public var metadata: Metadata {
     switch self.accepted {
     case let .success(contents):
@@ -367,7 +369,7 @@ extension StreamingClientResponse {
 
   /// Returns the messages received from the server.
   ///
-  /// For rejected RPCs (in other words, where ``accepted`` is `failure`), the `RPCAsyncSequence` throws a ``RPCError``.
+  /// For rejected RPCs (in other words, where ``accepted`` is `failure`), the `RPCAsyncSequence` throws an ``RPCError``.
   public var messages: RPCAsyncSequence<Message, any Error> {
     switch self.accepted {
     case let .success(contents):
@@ -387,9 +389,9 @@ extension StreamingClientResponse {
     }
   }
 
-  /// Returns the body parts (i.e. `messages` and `trailingMetadata`) returned from the server.
+  /// Returns the body parts (that is, `messages` and `trailingMetadata`) returned from the server.
   ///
-  /// For rejected RPCs (in other words, where ``accepted`` is `failure`), the `RPCAsyncSequence` throws a ``RPCError``.
+  /// For rejected RPCs (in other words, where ``accepted`` is `failure`), the `RPCAsyncSequence` throws an ``RPCError``.
   public var bodyParts: RPCAsyncSequence<Contents.BodyPart, any Error> {
     switch self.accepted {
     case let .success(contents):

--- a/Sources/GRPCCore/Call/ConditionalInterceptor.swift
+++ b/Sources/GRPCCore/Call/ConditionalInterceptor.swift
@@ -17,7 +17,7 @@
 /// Describes the conditions under which an interceptor should be applied.
 ///
 /// You can configure interceptors to be applied to:
-/// - all RPCs and services;
+/// - all RPCs and services; or
 /// - requests directed only to specific services; or
 /// - requests directed only to specific methods (of a specific service); or
 /// - requests directed only to specific services or methods (of a specific service); or
@@ -93,7 +93,7 @@ public struct ConditionalInterceptor<Interceptor: Sendable>: Sendable {
     ///   The predicate is evaluated the first time a given method is encountered, and that result
     ///   is reused for subsequent RPCs of the same method for the lifetime of the client.
     ///   As a consequence, the `predicate` closure should be **deterministic**.
-    ///   Do **not** base it on dynamic state (time, session, feature flags, etc.).
+    ///   Do **not** base it on dynamic state, such as time, session, or feature flags.
     ///   If you need per-call decisions, put that logic inside the interceptor itself.
     ///
     /// - Parameters:
@@ -133,7 +133,7 @@ public struct ConditionalInterceptor<Interceptor: Sendable>: Sendable {
 
 @available(gRPCSwift 2.0, *)
 extension ConditionalInterceptor where Interceptor == any ClientInterceptor {
-  /// Create an operation, specifying which ``ClientInterceptor`` to apply and to which ``Subject``.
+  /// Creates an operation, specifying which ``ClientInterceptor`` to apply and to which ``Subject``.
   /// - Parameters:
   ///   - interceptor: The ``ClientInterceptor`` to register with the client.
   ///   - subject: The ``Subject`` to which the `interceptor` applies.
@@ -147,7 +147,7 @@ extension ConditionalInterceptor where Interceptor == any ClientInterceptor {
 
 @available(gRPCSwift 2.0, *)
 extension ConditionalInterceptor where Interceptor == any ServerInterceptor {
-  /// Create an operation, specifying which ``ServerInterceptor`` to apply and to which ``Subject``.
+  /// Creates an operation, specifying which ``ServerInterceptor`` to apply and to which ``Subject``.
   /// - Parameters:
   ///   - interceptor: The ``ServerInterceptor`` to register with the server.
   ///   - subject: The ``Subject`` to which the `interceptor` applies.

--- a/Sources/GRPCCore/Call/Server/RPCRouter.swift
+++ b/Sources/GRPCCore/Call/Server/RPCRouter.swift
@@ -16,8 +16,8 @@
 
 /// Stores and provides handlers for RPCs.
 ///
-/// The router stores a handler for each RPC it knows about. Each handler encapsulate the business
-/// logic for the RPC which is typically implemented by service owners. To register a handler you
+/// The router stores a handler for each RPC it knows about. Each handler encapsulates the business
+/// logic for the RPC that is typically implemented by service owners. To register a handler, you
 /// can call ``registerHandler(forMethod:deserializer:serializer:handler:)``. You can check whether
 /// the router has a handler for a method with ``hasHandler(forMethod:)`` or get a list of all
 /// methods with handlers registered by calling ``methods``. You can also remove the handler for a
@@ -25,11 +25,11 @@
 /// You can also register any interceptors that you want applied to registered handlers via the
 /// ``registerInterceptors(pipeline:)`` method.
 ///
-/// In most cases you won't need to interact with the router directly. Instead you should register
-/// your services with ``GRPCServer/init(transport:services:interceptors:)`` which will in turn
+/// In most cases, you won't need to interact with the router directly. Instead, you should register
+/// your services with ``GRPCServer/init(transport:services:interceptors:)``, which will in turn
 /// register each method with the router.
 ///
-/// You may wish to not serve all methods from your service in which case you can either:
+/// You may wish to not serve all methods from your service, in which case you can either:
 ///
 /// 1. Remove individual methods by calling ``removeHandler(forMethod:)``, or
 /// 2. Implement ``RegistrableRPCService/registerMethods(with:)`` to register only the methods you
@@ -140,7 +140,7 @@ public struct RPCRouter<Transport: ServerTransport>: Sendable {
 
   /// Registers a handler with the router.
   ///
-  /// - Note: if a handler already exists for a given method then it will be replaced.
+  /// - Note: If a handler already exists for a given method, then it will be replaced.
   ///
   /// - Parameters:
   ///   - descriptor: A descriptor for the method to register a handler for.

--- a/Sources/GRPCCore/Call/Server/RegistrableRPCService.swift
+++ b/Sources/GRPCCore/Call/Server/RegistrableRPCService.swift
@@ -18,13 +18,13 @@
 ///
 /// You typically won't have to implement this protocol yourself as the generated service code
 /// provides conformance for your generated service type. However, if you need to customise which
-/// methods your service offers or how the methods are registered then you can override the
+/// methods your service offers or how the methods are registered, then you can override the
 /// generated conformance by implementing ``registerMethods(with:)`` manually by calling
 /// ``RPCRouter/registerHandler(forMethod:deserializer:serializer:handler:)`` for each method
 /// you want to register with the router.
 @available(gRPCSwift 2.0, *)
 public protocol RegistrableRPCService: Sendable {
-  /// Registers methods to server with the provided ``RPCRouter``.
+  /// Registers the service's methods with the provided ``RPCRouter``.
   ///
   /// - Parameter router: The router to register methods with.
   func registerMethods<Transport: ServerTransport>(with router: inout RPCRouter<Transport>)

--- a/Sources/GRPCCore/Call/Server/ServerContext+RPCCancellationHandle.swift
+++ b/Sources/GRPCCore/Call/Server/ServerContext+RPCCancellationHandle.swift
@@ -22,6 +22,11 @@ extension ServerContext {
   internal static var rpcCancellation: RPCCancellationHandle?
 
   /// A handle for the cancellation status of the RPC.
+  ///
+  /// gRPC signals cancellation through this handle, not by cancelling your handler's `Task`. If
+  /// you don't check ``isCancelled`` or use ``withRPCCancellationHandler(operation:onCancelRPC:)``,
+  /// your handler keeps running after the RPC is cancelled. For a streaming response, this means
+  /// it keeps writing messages the client will never see.
   public struct RPCCancellationHandle: Sendable {
     internal let manager: ServerCancellationManager
 

--- a/Sources/GRPCCore/Call/Server/ServerContext+RPCCancellationHandle.swift
+++ b/Sources/GRPCCore/Call/Server/ServerContext+RPCCancellationHandle.swift
@@ -30,7 +30,7 @@ extension ServerContext {
   public struct RPCCancellationHandle: Sendable {
     internal let manager: ServerCancellationManager
 
-    /// Create a cancellation handle.
+    /// Creates a cancellation handle.
     ///
     /// To create an instance of this handle appropriately bound to a `Task`
     /// use ``withServerContextRPCCancellationHandle(_:)``.
@@ -55,7 +55,7 @@ extension ServerContext {
       }
     }
 
-    /// Signal that the RPC should be cancelled.
+    /// Signals that the RPC should be cancelled.
     ///
     /// This is idempotent: calling it more than once has no effect.
     public func cancel() {
@@ -64,13 +64,13 @@ extension ServerContext {
   }
 }
 
-/// Execute an operation with an RPC cancellation handler that's immediately invoked
-/// if the RPC is canceled.
+/// Executes an operation with an RPC cancellation handler that's immediately invoked
+/// if the RPC is cancelled.
 ///
 /// RPCs can be cancelled for a number of reasons including:
 /// 1. The RPC was taking too long to process and a timeout passed.
 /// 2. The remote peer closed the underlying stream, either because they were no longer
-///    interested in the result or due to a broken connection.
+///    interested in the result or because of a broken connection.
 /// 3. The server began shutting down.
 ///
 /// - Important: This only applies to RPCs on the server.
@@ -105,7 +105,7 @@ public func withRPCCancellationHandler<Result, Failure: Error>(
 /// - Important: This function is intended for use when implementing
 ///   a ``ServerTransport``.
 ///
-/// If you want to be notified about RPCs being cancelled
+/// If you want to be notified about RPCs being cancelled,
 /// use ``withRPCCancellationHandler(operation:onCancelRPC:)``.
 ///
 /// - Parameter operation: The operation to execute with the handle.

--- a/Sources/GRPCCore/Call/Server/ServerContext.swift
+++ b/Sources/GRPCCore/Call/Server/ServerContext.swift
@@ -18,7 +18,7 @@
 @available(gRPCSwift 2.0, *)
 public struct ServerContext: Sendable {
 
-  /// Protocol used to help identify transport specific context fields
+  /// Protocol used to help identify transport-specific context fields.
   public protocol TransportSpecific: Sendable {}
 
   /// A description of the method being called.
@@ -26,43 +26,43 @@ public struct ServerContext: Sendable {
 
   /// A description of the remote peer.
   ///
-  /// The format of the description should follow the pattern "<transport>:<address>" where
-  /// "<transport>" indicates the underlying network transport (such as "ipv4", "unix", or
-  /// "in-process"). This is a guideline for how descriptions should be formatted; different
+  /// The format of the description should follow the pattern `<transport>:<address>` where
+  /// `<transport>` indicates the underlying network transport (such as `ipv4`, `unix`, or
+  /// `in-process`). This is a guideline for how descriptions should be formatted; different
   /// implementations may not follow this format so you shouldn't make assumptions based on it.
   ///
   /// Some examples include:
-  /// - "ipv4:127.0.0.1:31415",
-  /// - "ipv6:[::1]:443",
-  /// - "in-process:27182".
+  /// - `ipv4:127.0.0.1:31415`,
+  /// - `ipv6:[::1]:443`,
+  /// - `in-process:27182`.
   public var remotePeer: String
 
   /// A description of the local peer.
   ///
-  /// The format of the description should follow the pattern "<transport>:<address>" where
-  /// "<transport>" indicates the underlying network transport (such as "ipv4", "unix", or
-  /// "in-process"). This is a guideline for how descriptions should be formatted; different
+  /// The format of the description should follow the pattern `<transport>:<address>` where
+  /// `<transport>` indicates the underlying network transport (such as `ipv4`, `unix`, or
+  /// `in-process`). This is a guideline for how descriptions should be formatted; different
   /// implementations may not follow this format so you shouldn't make assumptions based on it.
   ///
   /// Some examples include:
-  /// - "ipv4:127.0.0.1:31415",
-  /// - "ipv6:[::1]:443",
-  /// - "in-process:27182".
+  /// - `ipv4:127.0.0.1:31415`,
+  /// - `ipv6:[::1]:443`,
+  /// - `in-process:27182`.
   public var localPeer: String
 
-  /// An optional field for transports to store specific data
+  /// An optional field for transports to store specific data.
   ///
   /// Refer to the transport documentation to understand what type of
   /// value this field will contain, if any.
   ///
-  /// An example of what this field can be used for, would be to store
-  /// things like a peer certificate from a mTLS connection
+  /// An example of what this field can be used for would be to store
+  /// things like a peer certificate from an mTLS connection.
   public var transportSpecific: (any TransportSpecific)?
 
   /// A handle for checking the cancellation status of an RPC.
   public var cancellation: RPCCancellationHandle
 
-  /// Create a new server context.
+  /// Creates a new server context.
   ///
   /// - Parameters:
   ///   - descriptor: A description of the method being called.

--- a/Sources/GRPCCore/Call/Server/ServerInterceptor.swift
+++ b/Sources/GRPCCore/Call/Server/ServerInterceptor.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-/// A type that intercepts requests and response for server.
+/// A type that intercepts requests and responses for a server.
 ///
 /// Interceptors allow you to inspect and modify requests and responses. Requests are intercepted
 /// after they have been received by the transport and responses are intercepted after they have
@@ -30,7 +30,7 @@
 /// ## RPC filtering
 ///
 /// A common use of server-side interceptors is to filter requests from clients. Interceptors can
-/// reject requests which are invalid without service code being called. The following example
+/// reject requests that are invalid without service code being called. The following example
 /// demonstrates this.
 ///
 /// ```swift
@@ -59,7 +59,7 @@
 /// }
 /// ```
 ///
-/// For client-side interceptors see ``ClientInterceptor``.
+/// For client-side interceptors, see ``ClientInterceptor``.
 @available(gRPCSwift 2.0, *)
 public protocol ServerInterceptor: Sendable {
   /// Intercept a request object.

--- a/Sources/GRPCCore/Call/Server/ServerRequest.swift
+++ b/Sources/GRPCCore/Call/Server/ServerRequest.swift
@@ -19,14 +19,14 @@
 public struct ServerRequest<Message: Sendable>: Sendable {
   /// Metadata received from the client at the start of the RPC.
   ///
-  /// The metadata contains gRPC and transport specific entries in addition to user-specified
+  /// The metadata contains gRPC and transport-specific entries in addition to user-specified
   /// metadata.
   public var metadata: Metadata
 
   /// The message received from the client.
   public var message: Message
 
-  /// Create a new single server request.
+  /// Creates a new single server request.
   ///
   /// - Parameters:
   ///   - metadata: Metadata received from the client.
@@ -42,7 +42,7 @@ public struct ServerRequest<Message: Sendable>: Sendable {
 public struct StreamingServerRequest<Message: Sendable>: Sendable {
   /// Metadata received from the client at the start of the RPC.
   ///
-  /// The metadata contains gRPC and transport specific entries in addition to user-specified
+  /// The metadata contains gRPC and transport-specific entries in addition to user-specified
   /// metadata.
   public var metadata: Metadata
 
@@ -51,7 +51,7 @@ public struct StreamingServerRequest<Message: Sendable>: Sendable {
   /// The sequence may be iterated at most once.
   public var messages: RPCAsyncSequence<Message, any Error>
 
-  /// Create a new streaming request.
+  /// Creates a new streaming request.
   ///
   /// - Parameters:
   ///   - metadata: Metadata received from the client.

--- a/Sources/GRPCCore/Call/Server/ServerResponse.swift
+++ b/Sources/GRPCCore/Call/Server/ServerResponse.swift
@@ -16,21 +16,21 @@
 
 /// A response for a single message sent by a server.
 ///
-/// Single responses are used for unary and client-streaming RPCs. For streaming responses
+/// Single responses are used for unary and client-streaming RPCs. For streaming responses,
 /// see ``StreamingServerResponse``.
 ///
 /// A single response captures every part of the response stream and distinguishes successful
 /// and unsuccessful responses via the ``accepted`` property. The value for the `success` case
-/// contains the initial metadata, response message, and the trailing metadata and implicitly
-/// has an ``Status/Code-swift.struct/ok`` status code.
+/// contains the initial metadata, response message, and the trailing metadata. It also
+/// implicitly has an ``Status/Code-swift.struct/ok`` status code.
 ///
 /// The `failure` case indicates that the server chose not to process the RPC, or the processing
 /// of the RPC failed. The failure case contains an ``RPCError`` describing why the RPC failed,
-/// including an error code, error message and any metadata sent by the server.
+/// including an error code, error message, and any metadata sent by the server.
 ///
 /// ### Using responses
 ///
-/// Each response has an ``accepted`` property which contains all RPC information. You can create
+/// Each response has an ``accepted`` property, which contains all RPC information. You can create
 /// one by calling ``init(accepted:)`` or one of the two convenience initializers:
 /// - ``init(message:metadata:trailingMetadata:)`` to create a successful response, or
 /// - ``init(of:error:)`` to create a failed response.
@@ -74,9 +74,9 @@ public struct ServerResponse<Message: Sendable>: Sendable {
     ///
     /// Both gRPC Swift and its transport layer may insert additional metadata. Keys prefixed with
     /// "grpc-" are prohibited and may result in undefined behaviour. Transports may also insert
-    /// their own metadata, you should avoid using key names which may clash with transport
-    /// specific metadata. Note that transports may also impose limits in the amount of metadata
-    /// which may be sent.
+    /// their own metadata; you should avoid using key names that may clash with transport-specific
+    /// metadata. Note that transports may also impose limits on the amount of metadata
+    /// that may be sent.
     public var metadata: Metadata
 
     /// The message to send to the client.
@@ -86,15 +86,15 @@ public struct ServerResponse<Message: Sendable>: Sendable {
     ///
     /// Both gRPC Swift and its transport layer may insert additional metadata. Keys prefixed with
     /// "grpc-" are prohibited and may result in undefined behaviour. Transports may also insert
-    /// their own metadata, you should avoid using key names which may clash with transport
-    /// specific metadata. Note that transports may also impose limits in the amount of metadata
-    /// which may be sent.
+    /// their own metadata; you should avoid using key names that may clash with transport-specific
+    /// metadata. Note that transports may also impose limits on the amount of metadata
+    /// that may be sent.
     public var trailingMetadata: Metadata
 
-    /// Create a new single client request.
+    /// Creates a new single response.
     ///
     /// - Parameters:
-    ///   - message: The message to send to the server.
+    ///   - message: The message to send to the client.
     ///   - metadata: Metadata to send to the client at the start of the response. Defaults to
     ///       empty.
     ///   - trailingMetadata: Metadata to send to the client at the end of the response. Defaults
@@ -112,10 +112,10 @@ public struct ServerResponse<Message: Sendable>: Sendable {
 
   /// Whether the RPC was accepted or rejected.
   ///
-  /// The `success` indicates the server accepted the RPC for processing and the RPC completed
-  /// successfully and implies the RPC succeeded with the ``Status/Code-swift.struct/ok`` status
-  /// code. The `failure` case indicates that the service rejected the RPC without processing it
-  /// or could not process it successfully.
+  /// The `success` case indicates that the server accepted the RPC for processing and it
+  /// completed successfully, implying an ``Status/Code-swift.struct/ok`` status code. The
+  /// `failure` case indicates that the server either rejected the RPC without processing it, or
+  /// failed to process it successfully.
   public var accepted: Result<Contents, RPCError>
 
   /// Creates a response.
@@ -129,25 +129,25 @@ public struct ServerResponse<Message: Sendable>: Sendable {
 /// A response for a stream of messages sent by a server.
 ///
 /// Stream responses are used for server-streaming and bidirectional-streaming RPCs. For single
-/// responses see ``ServerResponse``.
+/// responses, see ``ServerResponse``.
 ///
 /// A stream response captures every part of the response stream and distinguishes whether the
 /// request was processed by the server via the ``accepted`` property. The value for the `success`
-/// case contains the initial metadata and a closure which is provided with a message write and
-/// returns trailing metadata. If the closure returns without error then the response implicitly
+/// case contains the initial metadata and a closure which is provided with a message writer and
+/// returns trailing metadata. If the closure returns without error, then the response implicitly
 /// has an ``Status/Code-swift.struct/ok`` status code. You can throw an error from the producer
-/// to indicate that the request couldn't be handled successfully.  If an ``RPCError`` is thrown
+/// to indicate that the request couldn't be handled successfully. If an ``RPCError`` is thrown,
 /// then the client will receive an equivalent error populated with the same code and message. If
-/// an error of any other type is thrown then the client will receive an error with the
+/// an error of any other type is thrown, then the client will receive an error with the
 /// ``Status/Code-swift.struct/unknown`` status code.
 ///
 /// The `failure` case indicates that the server chose not to process the RPC. The failure case
 /// contains an ``RPCError`` describing why the RPC failed, including an error code, error
-/// message and any metadata to send to the client.
+/// message, and any metadata to send to the client.
 ///
 /// ### Using streaming responses
 ///
-/// Each response has an ``accepted`` property which contains all RPC information. You can create
+/// Each response has an ``accepted`` property, which contains all RPC information. You can create
 /// one by calling ``init(accepted:)`` or one of the two convenience initializers:
 /// - ``init(of:metadata:producer:)`` to create a successful response, or
 /// - ``init(of:error:)`` to create a failed response.
@@ -171,7 +171,7 @@ public struct ServerResponse<Message: Sendable>: Sendable {
 /// ```
 @available(gRPCSwift 2.0, *)
 public struct StreamingServerResponse<Message: Sendable>: Sendable {
-  /// The contents of a response to a request which has been accepted for processing.
+  /// The contents of a response to a request that has been accepted for processing.
   public struct Contents: Sendable {
     /// Metadata to send to the client at the beginning of the response stream.
     public var metadata: Metadata
@@ -181,12 +181,12 @@ public struct StreamingServerResponse<Message: Sendable>: Sendable {
     ///
     /// Returning metadata indicates a successful response and gRPC will terminate the RPC with
     /// an ``Status/Code-swift.struct/ok`` status code. Throwing an error will terminate the RPC
-    /// with an appropriate status code. You can control the status code, message and metadata
+    /// with an appropriate status code. You can control the status code, message, and metadata
     /// returned to the client by throwing an ``RPCError``. If the error thrown is a type other
-    /// than ``RPCError`` then a status with code ``Status/Code-swift.struct/unknown`` will
+    /// than ``RPCError``, then a status with code ``Status/Code-swift.struct/unknown`` will
     /// be returned to the client.
     ///
-    /// gRPC will invoke this function at most once therefore it isn't required to be idempotent.
+    /// gRPC will invoke this function at most once; therefore, it isn't required to be idempotent.
     ///
     /// Cancelling the client's call doesn't cancel this closure's `Task`. Task-local values bound
     /// with `withValue(_:operation:)` while building this response aren't visible here either:
@@ -200,11 +200,11 @@ public struct StreamingServerResponse<Message: Sendable>: Sendable {
     /// > ``withRPCCancellationHandler(operation:onCancelRPC:)``.
     public var producer: @Sendable (RPCWriter<Message>) async throws -> Metadata
 
-    /// Create a ``Contents``.
+    /// Creates a ``Contents``.
     ///
     /// - Parameters:
     ///   - metadata: Metadata to send to the client at the start of the response.
-    ///   - producer: A function which produces values
+    ///   - producer: A function that produces values.
     public init(
       metadata: Metadata,
       producer: @escaping @Sendable (RPCWriter<Message>) async throws -> Metadata
@@ -216,7 +216,7 @@ public struct StreamingServerResponse<Message: Sendable>: Sendable {
 
   /// Whether the RPC was accepted or rejected.
   ///
-  /// The `success` case indicates that the service accepted the RPC for processing and will
+  /// The `success` case indicates that the server accepted the RPC for processing and will
   /// send initial metadata back to the client before producing response messages. The RPC may
   /// still result in failure by later throwing an error.
   ///

--- a/Sources/GRPCCore/Call/Server/ServerResponse.swift
+++ b/Sources/GRPCCore/Call/Server/ServerResponse.swift
@@ -187,6 +187,17 @@ public struct StreamingServerResponse<Message: Sendable>: Sendable {
     /// be returned to the client.
     ///
     /// gRPC will invoke this function at most once therefore it isn't required to be idempotent.
+    ///
+    /// Cancelling the client's call doesn't cancel this closure's `Task`. Task-local values bound
+    /// with `withValue(_:operation:)` while building this response aren't visible here either:
+    /// gRPC invokes this closure only after the handler that created the response has already
+    /// returned, by which point any task-local scope established inside the handler has already
+    /// ended.
+    ///
+    /// > Important: If you need this closure to stop producing messages when the RPC is
+    /// > cancelled, capture the ``ServerContext`` passed to your handler and check
+    /// > ``ServerContext/RPCCancellationHandle/isCancelled``, or use
+    /// > ``withRPCCancellationHandler(operation:onCancelRPC:)``.
     public var producer: @Sendable (RPCWriter<Message>) async throws -> Metadata
 
     /// Create a ``Contents``.

--- a/Sources/GRPCCore/Coding/Coding.swift
+++ b/Sources/GRPCCore/Coding/Coding.swift
@@ -17,7 +17,7 @@
 /// Serializes a message into a sequence of bytes.
 ///
 /// Message serializers convert an input message to a sequence of bytes. Serializers are used to
-/// convert messages into a form which is suitable for sending over a network. The reverse
+/// convert messages into a form that is suitable for sending over a network. The reverse
 /// operation, deserialization, is performed by a ``MessageDeserializer``.
 ///
 /// Serializers are used frequently and implementations should take care to ensure that
@@ -37,7 +37,7 @@ public protocol MessageSerializer<Message>: Sendable {
 /// Deserializes a sequence of bytes into a message.
 ///
 /// Message deserializers convert a sequence of bytes into a message. Deserializers are used to
-/// convert bytes received from the network into an application specific message. The reverse
+/// convert bytes received from the network into an application-specific message. The reverse
 /// operation, serialization, is performed by a ``MessageSerializer``.
 ///
 /// Deserializers are used frequently and implementations should take care to ensure that

--- a/Sources/GRPCCore/Coding/CompressionAlgorithm.swift
+++ b/Sources/GRPCCore/Coding/CompressionAlgorithm.swift
@@ -29,17 +29,17 @@ public struct CompressionAlgorithm: Hashable, Sendable {
     self.value = algorithm
   }
 
-  /// No compression, sometimes referred to as 'identity' compression.
+  /// No compression, sometimes referred to as "identity" compression.
   public static var none: Self {
     Self(.none)
   }
 
-  /// The 'deflate' compression algorithm.
+  /// The "deflate" compression algorithm.
   public static var deflate: Self {
     Self(.deflate)
   }
 
-  /// The 'gzip' compression algorithm.
+  /// The "gzip" compression algorithm.
   public static var gzip: Self {
     Self(.gzip)
   }
@@ -58,17 +58,17 @@ public struct CompressionAlgorithmSet: OptionSet, Hashable, Sendable {
     self.rawValue = 1 << value.rawValue
   }
 
-  /// No compression, sometimes referred to as 'identity' compression.
+  /// No compression, sometimes referred to as "identity" compression.
   public static var none: Self {
     return Self(value: .none)
   }
 
-  /// The 'deflate' compression algorithm.
+  /// The "deflate" compression algorithm.
   public static var deflate: Self {
     return Self(value: .deflate)
   }
 
-  /// The 'gzip' compression algorithm.
+  /// The "gzip" compression algorithm.
   public static var gzip: Self {
     return Self(value: .gzip)
   }

--- a/Sources/GRPCCore/Coding/GRPCContiguousBytes.swift
+++ b/Sources/GRPCCore/Coding/GRPCContiguousBytes.swift
@@ -18,7 +18,7 @@
 ///
 /// This protocol is used by the transport protocols (``ClientTransport`` and ``ServerTransport``)
 /// with the serialization protocols (``MessageSerializer`` and ``MessageDeserializer``) so that
-/// messages don't have to be copied to a fixed intermediate bag-of-bytes types.
+/// messages don't have to be copied to a fixed intermediate bag-of-bytes type.
 @available(gRPCSwift 2.0, *)
 public protocol GRPCContiguousBytes {
   /// Initialize the bytes to a repeated value.
@@ -31,13 +31,13 @@ public protocol GRPCContiguousBytes {
   /// Initialize the bag of bytes from a sequence of bytes.
   ///
   /// - Parameters:
-  ///   - sequence: a sequence of `UInt8` from which the bag of bytes should be constructed.
+  ///   - sequence: A sequence of `UInt8` from which the bag of bytes should be constructed.
   init<Bytes: Sequence>(_ sequence: Bytes) where Bytes.Element == UInt8
 
   /// The number of bytes in the bag of bytes.
   var count: Int { get }
 
-  /// Calls the given closure with the contents of underlying storage.
+  /// Calls the given closure with the contents of the underlying storage.
   ///
   /// - Note: Calling `withUnsafeBytes` multiple times does not guarantee that
   ///         the same buffer pointer will be passed in every time.
@@ -45,7 +45,7 @@ public protocol GRPCContiguousBytes {
   ///            outside of the lifetime of the call to the closure.
   func withUnsafeBytes<R>(_ body: (_ buffer: UnsafeRawBufferPointer) throws -> R) rethrows -> R
 
-  /// Calls the given closure with the contents of underlying storage.
+  /// Calls the given closure with the contents of the underlying storage.
   ///
   /// - Note: Calling `withUnsafeBytes` multiple times does not guarantee that
   ///         the same buffer pointer will be passed in every time.

--- a/Sources/GRPCCore/Configuration/MethodConfig.swift
+++ b/Sources/GRPCCore/Configuration/MethodConfig.swift
@@ -69,6 +69,9 @@ public struct MethodConfig: Hashable, Sendable {
   ///
   /// If `false` the RPC will abort immediately if there is a transient failure connecting to
   /// the server. Otherwise gRPC will attempt to connect until the deadline is exceeded.
+  ///
+  /// If left unset, transports conventionally treat this the same as `false`, so RPCs fail fast
+  /// on a transient connection failure rather than queuing until the connection is ready.
   public var waitForReady: Bool?
 
   /// The default timeout for the RPC.

--- a/Sources/GRPCCore/Configuration/MethodConfig.swift
+++ b/Sources/GRPCCore/Configuration/MethodConfig.swift
@@ -23,24 +23,24 @@ public struct MethodConfig: Hashable, Sendable {
   public struct Name: Sendable, Hashable {
     /// The name of the service, including the namespace.
     ///
-    /// If the service is empty then `method` must also be empty and the configuration specifies
+    /// If the service is empty, then `method` must also be empty and the configuration specifies
     /// defaults for all methods.
     ///
-    /// - Precondition: If `service` is empty then `method` must also be empty.
+    /// - Precondition: If `service` is empty, then `method` must also be empty.
     public var service: String {
       didSet { try! self.validate() }
     }
 
     /// The name of the method.
     ///
-    /// If the method is empty then the configuration will be the default for all methods in the
+    /// If the method is empty, then the configuration will be the default for all methods in the
     /// specified service.
     public var method: String
 
-    /// Create a new name.
+    /// Creates a new name.
     ///
-    /// If the service is empty then `method` must also be empty and the configuration specifies
-    /// defaults for all methods. If only `method` is empty then the configuration applies to
+    /// If the service is empty, then `method` must also be empty and the configuration specifies
+    /// defaults for all methods. If only `method` is empty, then the configuration applies to
     /// all methods in the `service`.
     ///
     /// - Parameters:
@@ -68,7 +68,7 @@ public struct MethodConfig: Hashable, Sendable {
   /// Whether RPCs for this method should wait until the connection is ready.
   ///
   /// If `false` the RPC will abort immediately if there is a transient failure connecting to
-  /// the server. Otherwise gRPC will attempt to connect until the deadline is exceeded.
+  /// the server. Otherwise, gRPC will attempt to connect until the deadline is exceeded.
   ///
   /// If left unset, transports conventionally treat this the same as `false`, so RPCs fail fast
   /// on a transient connection failure rather than queuing until the connection is ready.
@@ -76,25 +76,25 @@ public struct MethodConfig: Hashable, Sendable {
 
   /// The default timeout for the RPC.
   ///
-  /// If no reply is received in the specified amount of time the request is aborted
+  /// If no reply is received in the specified amount of time, the request is aborted
   /// with an ``RPCError`` with code ``RPCError/Code/deadlineExceeded``.
   ///
   /// The actual deadline used will be the minimum of the value specified here
-  /// and the value set by the application by the client API. If either one isn't set
-  /// then the other value is used. If neither is set then the request has no deadline.
+  /// and the value set by the application by the client API. If either one isn't set,
+  /// then the other value is used. If neither is set, then the request has no deadline.
   ///
   /// The timeout applies to the overall execution of an RPC. If, for example, a retry
-  /// policy is set then the timeout begins when the first attempt is started and _isn't_ reset
+  /// policy is set, then the timeout begins when the first attempt is started and _isn't_ reset
   /// when subsequent attempts start.
   public var timeout: Duration?
 
   /// The maximum allowed payload size in bytes for an individual message.
   ///
-  /// If a client attempts to send an object larger than this value, it will not be sent and the
+  /// If a client attempts to send an object larger than this value, it will not be sent, and the
   /// client will see an error. Note that 0 is a valid value, meaning that the request message
   /// must be empty.
   ///
-  /// Note that if compression is used the uncompressed message size is validated.
+  /// Note that if compression is used, the uncompressed message size is validated.
   public var maxRequestMessageBytes: Int?
 
   /// The maximum allowed payload size in bytes for an individual response message.
@@ -103,7 +103,7 @@ public struct MethodConfig: Hashable, Sendable {
   /// be sent, and an error will be sent to the client instead. Note that 0 is a valid value,
   /// meaning that the response message must be empty.
   ///
-  /// Note that if compression is used the uncompressed message size is validated.
+  /// Note that if compression is used, the uncompressed message size is validated.
   public var maxResponseMessageBytes: Int?
 
   /// The policy determining how many times, and when, the RPC is executed.
@@ -122,7 +122,7 @@ public struct MethodConfig: Hashable, Sendable {
   /// reported to the client. Hedging is only suitable for idempotent RPCs.
   public var executionPolicy: RPCExecutionPolicy?
 
-  /// Create an execution configuration.
+  /// Creates an execution configuration.
   ///
   /// - Parameters:
   ///   - names: The names of methods this configuration applies to.
@@ -191,12 +191,12 @@ public struct RPCExecutionPolicy: Hashable, Sendable {
     }
   }
 
-  /// Create a new retry policy.``
+  /// Creates a new retry policy.
   public static func retry(_ policy: RetryPolicy) -> Self {
     Self(.retry(policy))
   }
 
-  /// Create a new hedging policy.``
+  /// Creates a new hedging policy.
   public static func hedge(_ policy: HedgingPolicy) -> Self {
     Self(.hedge(policy))
   }
@@ -204,12 +204,12 @@ public struct RPCExecutionPolicy: Hashable, Sendable {
 
 /// Policy for retrying an RPC.
 ///
-/// gRPC retries RPCs when the first response from the server is a status code which matches
+/// gRPC retries RPCs when the first response from the server is a status code that matches
 /// one of the configured retryable status codes. If the server begins processing the RPC and
-/// first responds with metadata and later responds with a retryable status code then the RPC
+/// first responds with metadata and later responds with a retryable status code, then the RPC
 /// won't be retried.
 ///
-/// Execution attempts are limited by ``maxAttempts`` which includes the original attempt. The
+/// Execution attempts are limited by ``maxAttempts``, which includes the original attempt. The
 /// maximum number of attempts is limited to five.
 ///
 /// Subsequent attempts are executed after some delay. The first _retry_, or second attempt, will
@@ -217,13 +217,13 @@ public struct RPCExecutionPolicy: Hashable, Sendable {
 /// the nth retry will happen after a randomly chosen delay between zero
 /// and `min(initialBackoff * backoffMultiplier^(n-1), maxBackoff)`.
 ///
-/// For more information see [gRFC A6 Client
+/// For more information, see [gRFC A6 Client
 /// Retries](https://github.com/grpc/proposal/blob/0e1807a6e30a1a915c0dcadc873bca92b9fa9720/A6-client-retries.md).
 @available(gRPCSwift 2.0, *)
 public struct RetryPolicy: Hashable, Sendable {
   /// The maximum number of RPC attempts, including the original attempt.
   ///
-  /// Must be greater than one, values greater than five are treated as five.
+  /// Must be greater than one. Values greater than five are treated as five.
   public var maxAttempts: Int {
     didSet { self.maxAttempts = try! validateMaxAttempts(self.maxAttempts) }
   }
@@ -244,21 +244,21 @@ public struct RetryPolicy: Hashable, Sendable {
     willSet { try! Self.validateMaxBackoff(newValue) }
   }
 
-  /// The multiplier to apply to backoff.
+  /// The multiplier to apply to the backoff.
   ///
   /// - Precondition: Must be greater than zero.
   public var backoffMultiplier: Double {
     willSet { try! Self.validateBackoffMultiplier(newValue) }
   }
 
-  /// The set of status codes which may be retried.
+  /// The set of status codes that may be retried.
   ///
   /// - Precondition: Must not be empty.
   public var retryableStatusCodes: Set<Status.Code> {
     willSet { try! Self.validateRetryableStatusCodes(newValue) }
   }
 
-  /// Create a new retry policy.
+  /// Creates a new retry policy.
   ///
   /// - Parameters:
   ///   - maxAttempts: The maximum number of attempts allowed for the RPC.
@@ -267,9 +267,10 @@ public struct RetryPolicy: Hashable, Sendable {
   ///   - maxBackoff: The maximum period of time to wait between attempts. Must be greater than
   ///       zero.
   ///   - backoffMultiplier: The exponential backoff multiplier. Must be greater than zero.
-  ///   - retryableStatusCodes: The set of status codes which may be retried. Must not be empty.
-  /// - Precondition: `maxAttempts`, `initialBackoff`, `maxBackoff` and `backoffMultiplier`
-  ///     must be greater than zero.
+  ///   - retryableStatusCodes: The set of status codes that may be retried. Must not be empty.
+  /// - Precondition: `maxAttempts` must be greater than one.
+  /// - Precondition: `initialBackoff`, `maxBackoff`, and `backoffMultiplier` must be greater
+  ///     than zero.
   /// - Precondition: `retryableStatusCodes` must not be empty.
   public init(
     maxAttempts: Int,
@@ -329,13 +330,13 @@ public struct RetryPolicy: Hashable, Sendable {
 
 /// Policy for hedging an RPC.
 ///
-/// Hedged RPCs may execute more than once on a server so only idempotent methods should
+/// Hedged RPCs may execute more than once on a server, so only idempotent methods should
 /// be hedged.
 ///
 /// gRPC executes the RPC at most ``maxAttempts`` times, staggering each attempt
 /// by ``hedgingDelay``.
 ///
-/// For more information see [gRFC A6 Client
+/// For more information, see [gRFC A6 Client
 /// Retries](https://github.com/grpc/proposal/blob/0e1807a6e30a1a915c0dcadc873bca92b9fa9720/A6-client-retries.md).
 @available(gRPCSwift 2.0, *)
 public struct HedgingPolicy: Hashable, Sendable {
@@ -349,26 +350,28 @@ public struct HedgingPolicy: Hashable, Sendable {
   }
 
   /// The first RPC will be sent immediately, but each subsequent RPC will be sent at intervals
-  /// of `hedgingDelay`. Set this to zero to immediately send all RPCs.
+  /// of `hedgingDelay`.
+  ///
+  /// Set this to zero to immediately send all RPCs.
   public var hedgingDelay: Duration {
     willSet { try! Self.validateHedgingDelay(newValue) }
   }
 
-  /// The set of status codes which indicate other hedged RPCs may still succeed.
+  /// The set of status codes that indicate other hedged RPCs may still succeed.
   ///
   /// If a non-fatal status code is returned by the server, hedged RPCs will continue.
   /// Otherwise, outstanding requests will be cancelled and the error returned to the
   /// application layer.
   public var nonFatalStatusCodes: Set<Status.Code>
 
-  /// Create a new hedging policy.
+  /// Creates a new hedging policy.
   ///
   /// - Parameters:
   ///   - maxAttempts: The maximum number of attempts allowed for the RPC.
   ///   - hedgingDelay: The delay between each hedged RPC.
-  ///   - nonFatalStatusCodes: The set of status codes which indicate other hedged RPCs may still
+  ///   - nonFatalStatusCodes: The set of status codes that indicate other hedged RPCs may still
   ///       succeed.
-  /// - Precondition: `maxAttempts` must be greater than zero.
+  /// - Precondition: `maxAttempts` must be greater than one.
   public init(
     maxAttempts: Int,
     hedgingDelay: Duration,

--- a/Sources/GRPCCore/Configuration/ServiceConfig.swift
+++ b/Sources/GRPCCore/Configuration/ServiceConfig.swift
@@ -20,7 +20,7 @@
 /// should behave (for example, the load balancing policy to use).
 ///
 /// The schema is described by [`grpc/service_config/service_config.proto`](https://github.com/grpc/grpc-proto/blob/0b30c8c05277ab78ec72e77c9cbf66a26684673d/grpc/service_config/service_config.proto)
-/// in the `grpc/grpc-proto` GitHub repository although gRPC uses it in its JSON form rather than
+/// in the `grpc/grpc-proto` GitHub repository, although gRPC uses it in its JSON form rather than
 /// the Protobuf form.
 @available(gRPCSwift 2.0, *)
 public struct ServiceConfig: Hashable, Sendable {
@@ -30,7 +30,7 @@ public struct ServiceConfig: Hashable, Sendable {
   /// Load balancing policies.
   ///
   /// The client iterates through the list in order and picks the first configuration it supports.
-  /// If no policies are supported then the configuration is considered to be invalid.
+  /// If no policies are supported, then the configuration is considered to be invalid.
   public var loadBalancingConfig: [LoadBalancingConfig]
 
   /// The policy for throttling retries.
@@ -38,7 +38,7 @@ public struct ServiceConfig: Hashable, Sendable {
   /// If ``RetryThrottling`` is provided, gRPC will automatically throttle retry attempts
   /// and hedged RPCs when the client's ratio of failures to successes exceeds a threshold.
   ///
-  /// For each server name, the gRPC client will maintain a `token_count` which is initially set
+  /// For each server name, the gRPC client will maintain a `token_count` that is initially set
   /// to ``RetryThrottling-swift.struct/maxTokens``. Every outgoing RPC (regardless of service or
   /// method invoked) will change `token_count` as follows:
   ///
@@ -54,7 +54,7 @@ public struct ServiceConfig: Hashable, Sendable {
   ///
   /// - Parameters:
   ///   - methodConfig: Per-method configuration.
-  ///   - loadBalancingConfig: Load balancing policies. Clients use the the first supported
+  ///   - loadBalancingConfig: Load balancing policies. Clients use the first supported
   ///       policy when iterating the list in order.
   ///   - retryThrottling: Policy for throttling retries.
   public init(
@@ -119,7 +119,7 @@ extension ServiceConfig {
       self.value = value
     }
 
-    /// Creates a pick-first load balancing policy.
+    /// Creates a pick-first load balancing policy with the given address-shuffling behavior.
     ///
     /// - Parameter shuffleAddressList: Whether resolved addresses should be shuffled before
     ///     attempting to connect to them.
@@ -127,7 +127,7 @@ extension ServiceConfig {
       Self(.pickFirst(PickFirst(shuffleAddressList: shuffleAddressList)))
     }
 
-    /// Creates a pick-first load balancing policy.
+    /// Creates a pick-first load balancing policy from an existing configuration value.
     ///
     /// - Parameter pickFirst: The pick-first load balancing policy.
     public static func pickFirst(_ pickFirst: PickFirst) -> Self {
@@ -233,15 +233,15 @@ extension ServiceConfig.LoadBalancingConfig: Codable {
 @available(gRPCSwift 2.0, *)
 extension ServiceConfig {
   public struct RetryThrottling: Hashable, Sendable, Codable {
-    /// The initial, and maximum number of tokens.
+    /// The initial and maximum number of tokens.
     ///
     /// - Precondition: Must be greater than zero.
     public var maxTokens: Int
 
     /// The amount of tokens to add on each successful RPC.
     ///
-    /// Typically this will be some number between 0 and 1, e.g., 0.1. Up to three decimal places
-    /// are supported.
+    /// Typically this will be some number between 0 and 1, for example, 0.1. Up to three decimal
+    /// places are supported.
     ///
     /// - Precondition: Must be greater than zero.
     public var tokenRatio: Double
@@ -249,7 +249,7 @@ extension ServiceConfig {
     /// Creates a new retry throttling policy.
     ///
     /// - Parameters:
-    ///   - maxTokens: The initial, and maximum number of tokens. Must be greater than zero.
+    ///   - maxTokens: The initial and maximum number of tokens. Must be greater than zero.
     ///   - tokenRatio: The amount of tokens to add on each successful RPC. Must be greater
     ///       than zero.
     public init(maxTokens: Int, tokenRatio: Double) throws {

--- a/Sources/GRPCCore/Documentation.docc/Articles/Compatibility.md
+++ b/Sources/GRPCCore/Documentation.docc/Articles/Compatibility.md
@@ -8,7 +8,7 @@ over time.
 ### Supported Swift Versions
 
 gRPC Swift supports the **three most recent Swift versions** that are **Swift 6
-or newer**. Within a minor Swift release only the latest patch version is supported.
+or newer**. Within a minor Swift release, only the latest patch version is supported.
 
 | grpc-swift | Minimum Supported Swift version |
 |------------|---------------------------------|
@@ -16,12 +16,12 @@ or newer**. Within a minor Swift release only the latest patch version is suppor
 
 ### Platforms
 
-gRPC Swift aims to support the same platforms as Swift project. These are listed
+gRPC Swift aims to support the same platforms as the Swift project. These are listed
 on [swift.org](https://www.swift.org/platform-support/).
 
 The only known unsupported platform from that list is currently Windows.
 
-Apple platforms have a minimum deployment version. These are as follows for gRPC
+Apple platforms have minimum deployment versions. These are as follows for gRPC
 Swift:
 
 | OS       | Minimum Deployment Version |

--- a/Sources/GRPCCore/Documentation.docc/Articles/Error-handling.md
+++ b/Sources/GRPCCore/Documentation.docc/Articles/Error-handling.md
@@ -4,7 +4,7 @@ Learn about the different error mechanisms in gRPC and how to use them.
 
 ## Overview
 
-gRPC has a well defined error model for RPCs and a common extension to provide
+gRPC has a well-defined error model for RPCs and a common extension to provide
 richer errors when using Protocol Buffers. This article explains both mechanisms
 and offers advice on using and handling RPC errors for service authors and
 clients.
@@ -13,8 +13,8 @@ clients.
 
 gRPC has two widely used error models:
 
-1. A 'standard' error model supported by all client/server gRPC libraries.
-2. A 'rich' error model providing more detailed error information via serialized
+1. A “standard” error model supported by all client/server gRPC libraries.
+2. A “rich” error model providing more detailed error information via serialized
    Protocol Buffers messages.
 
 #### Standard error model
@@ -28,20 +28,20 @@ the status codes guide on the
 [gRPC website](https://grpc.io/docs/guides/status-codes/).
 
 This mechanism is part of the gRPC protocol and is supported by all client/server
-gRPC libraries regardless of the data format (e.g. Protocol Buffers) being used
+gRPC libraries regardless of the data format (for example, Protocol Buffers) being used
 for messages.
 
 #### Rich error model
 
 The standard error model is quite limited and doesn't include the ability to
 communicate details about the error. If you're using the Protocol Buffers data
-format for messages then you may wish to use the "rich" error model.
+format for messages, then you may wish to use the “rich” error model.
 
 The model was developed and used by Google and is described in more detail
 in the [gRPC error guide](https://grpc.io/docs/guides/error/) and
 [Google AIP-193](https://google.aip.dev/193).
 
-While not officially part of gRPC it's a widely used convention with support in
+While not officially part of gRPC, it's a widely used convention with support in
 various client/server gRPC libraries, including gRPC Swift.
 
 It specifies a standard set of error message types covering the most common
@@ -56,24 +56,24 @@ Learn how to use both models in gRPC Swift.
 #### Service authors
 
 Errors thrown from an RPC handler are caught by the gRPC runtime and turned into
-a status. You have a two options to ensure that an appropriate status is sent to
+a status. You have two options to ensure that an appropriate status is sent to
 the client if your RPC handler throws an error:
 
-1. Throw an ``RPCError`` which explicitly sets the desired status code and
+1. Throw an ``RPCError`` that explicitly sets the desired status code and
    message.
-2. Throw an error conforming to ``RPCErrorConvertible`` which the gRPC runtime
+2. Throw an error conforming to ``RPCErrorConvertible`` that the gRPC runtime
    will use to create an ``RPCError``.
 
-Any errors thrown which don't fall into these categories will result in a status
+Any errors thrown that don't fall into these categories will result in a status
 code of `unknown` being sent to the client.
 
-Generally speaking expected failure scenarios should be considered as part of
+Generally speaking, expected failure scenarios should be considered as part of
 the API contract and each RPC should be documented accordingly.
 
 #### Clients
 
 Clients should catch ``RPCError`` if they are interested in the failures from an
-RPC. This is a manifestation of the error sent by the server but in some cases
+RPC. This is a manifestation of the error sent by the server, but in some cases
 it may be synthesized locally. For example, if a client-side timeout fires
 before the RPC completes, the client throws an ``RPCError`` with code
 ``RPCError/Code-swift.struct/deadlineExceeded``. If the calling `Task` is

--- a/Sources/GRPCCore/Documentation.docc/Articles/Error-handling.md
+++ b/Sources/GRPCCore/Documentation.docc/Articles/Error-handling.md
@@ -74,7 +74,23 @@ the API contract and each RPC should be documented accordingly.
 
 Clients should catch ``RPCError`` if they are interested in the failures from an
 RPC. This is a manifestation of the error sent by the server but in some cases
-it may be synthesized locally.
+it may be synthesized locally. For example, if a client-side timeout fires
+before the RPC completes, the client throws an ``RPCError`` with code
+``RPCError/Code-swift.struct/deadlineExceeded``. If the calling `Task` is
+cancelled, the client may instead throw an ``RPCError`` with code `unknown`
+wrapping the underlying `CancellationError` as its `cause` — check `cause` if
+you need to distinguish cancellation from other failures reported as `unknown`.
+
+Failures to serialize a request or deserialize a response also surface as an
+``RPCError``; the exact code and message depend on the serializer/deserializer
+in use. For example, the Protobuf codec provided by `grpc-swift-protobuf` uses
+``RPCError/Code-swift.struct/invalidArgument`` when a message can't be
+serialized or deserialized.
+
+If the transport receives a non-200 HTTP status without an accompanying gRPC
+status (for example because the RPC failed before reaching a gRPC-aware peer),
+the HTTP status is synthesized into a ``Status`` for you to catch as an
+``RPCError``.
 
 For clients using the rich error model, the ``RPCError`` can be caught and a
 detailed error can be extracted from it using `unpackGoogleRPCStatus()`.

--- a/Sources/GRPCCore/Documentation.docc/Articles/Error-handling.md
+++ b/Sources/GRPCCore/Documentation.docc/Articles/Error-handling.md
@@ -79,5 +79,5 @@ it may be synthesized locally.
 For clients using the rich error model, the ``RPCError`` can be caught and a
 detailed error can be extracted from it using `unpackGoogleRPCStatus()`.
 
-See [`error-details`](https://github.com/grpc/grpc-swift/tree/main/Examples/error-details) for
+See [`error-details`](https://github.com/grpc/grpc-swift-2/tree/main/Examples/error-details) for
 an example.

--- a/Sources/GRPCCore/Documentation.docc/Articles/Migration-guide.md
+++ b/Sources/GRPCCore/Documentation.docc/Articles/Migration-guide.md
@@ -10,14 +10,14 @@ and services from 1.x, not the versions using the older `EventLoopFuture` API.
 The guide takes you through a number of steps to migrate your gRPC app
 from 1.x to 2.x. You'll use the following strategy:
 
-1. Setup your package so it depends on a local copy of gRPC Swift 1.x and the
+1. Set up your package so it depends on a local copy of gRPC Swift 1.x and the
    upstream version of 2.x.
 2. Generate code for 2.x alongside generated 1.x code.
 3. Incrementally migrate targets to 2.x.
 4. Remove the code generated for, and the dependency on, 1.x.
 
 You'll do this migration incrementally by staging in a local copy of gRPC Swift
-1.x and migrating client and service code on a per service basis. This approach
+1.x and migrating client and service code on a per-service basis. This approach
 aims to minimise the number of errors and changes required to get the package
 building again. As a practical note, you should commit changes regularly as you
 work through the migration, especially when your package is in a compiling
@@ -28,9 +28,9 @@ state.
 gRPC Swift 2.x has stricter requirements than 1.x. These include:
 
 - Swift 6 or newer.
-- Deployment targets of macOS 15+, iOS 18+, tvOS 18+, watchOS 11+ and visionOS 2+.
+- Deployment targets of macOS 15+, iOS 18+, tvOS 18+, watchOS 11+, and visionOS 2+.
 
-To make the migration easier a script is available to automate a number of
+To make the migration easier, a script is available to automate a number of
 steps. You should download it now using:
 
 ```sh
@@ -52,22 +52,22 @@ temporarily depend on 1.x and 2.x.
 
 The exact version of 1.x you need to depend on must be local as Swift packages
 can't depend on two different major versions of the same package. Create a
-directory in your package called "LocalPackages" and then call `v1_to_v2`:
+directory in your package called “LocalPackages” and then call `v1_to_v2`:
 
 ```sh
 mkdir LocalPackages && ./v1_to_v2 clone-v1 LocalPackages
 ```
 
 This command checks out a copy of 1.x into `LocalPackages` and applies a few
-patches to it which are necessary for the migration. You can remove it once
+patches to it that are necessary for the migration. You can remove it once
 you've finished the migration.
 
 ### Using the local copy of 1.x
 
-Now you need to update your package manifest (`Package.swift`) to use the local
+Now, you need to update your package manifest (`Package.swift`) to use the local
 copy rather than the copy from GitHub. Replace your package dependency on
-"grpc-swift-2" with the local dependency, and update any target dependencies to
-use "grpc-swift-v1" instead of "grpc-swift-2":
+“grpc-swift-2” with the local dependency, and update any target dependencies to
+use “grpc-swift-v1” instead of “grpc-swift-2”:
 
 ```swift
 let package = Package(
@@ -94,7 +94,7 @@ commit the changes you've made so far.
 
 ### Adding a dependency on 2.x
 
-Next you need to add a dependency on 2.x. In order to do this you'll need to
+Next, you need to add a dependency on 2.x. In order to do this, you'll need to
 raise the tools version at the top of the manifest to 6.0 or higher:
 
 ```swift
@@ -117,17 +117,17 @@ let package = Package(
 )
 ```
 
-Note that setting or increasing the platforms is an API breaking change.
+Note that setting or increasing the platforms is an API-breaking change.
 
 Check that your package still builds with `swift build`. If you weren't
-previously using tools version 6.0 then you're likely to have new warnings or
-errors relating to concurrency. You should fix these in the fullness of time
+previously using tools version 6.0, then you're likely to have new warnings or
+errors relating to concurrency. You should fix these in the fullness of time,
 but for now add the `.swiftLanguageMode(.v5)` setting to the `settings` for each
 target.
 
-If there are any other build issues fix them up now and commit the changes.
+If there are any other build issues, fix them up now and commit the changes.
 
-Now add the following package dependencies for gRPC Swift 2.x:
+Now, add the following package dependencies for gRPC Swift 2.x:
 
 ```
 .package(url: "https://github.com/grpc/grpc-swift-2.git", from: "2.0.0"),
@@ -135,7 +135,7 @@ Now add the following package dependencies for gRPC Swift 2.x:
 .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "2.0.0"),
 ```
 
-For each target which was previously importing the `GRPC` module add the
+For each target that was previously importing the `GRPC` module, add the
 following target dependencies:
 
 ```
@@ -150,7 +150,7 @@ great time to commit your changes.
 ## Code generation
 
 Now that you've built your package with dependencies on a lightly modified
-version of 1.x and 2.x you need to consider the generated code. The approach you
+version of 1.x and 2.x, you need to consider the generated code. The approach you
 take here depends on how you're currently generating your gRPC code:
 
 1. Using `protoc` directly, or
@@ -158,18 +158,18 @@ take here depends on how you're currently generating your gRPC code:
 
 ### Using protoc directly
 
-> If you generated your gRPC code with the build plugin then skip this section.
+> If you generated your gRPC code with the build plugin, then skip this section.
 
 Because the names of the files containing generated gRPC code will be the same
-for 1.x and 2.x (and the Swift compiler requires file names to be unique) we need
+for 1.x and 2.x (and the Swift compiler requires file names to be unique), we need
 to rename all of the gRPC code generated by 1.x.
 
 You can use the `v1_to_v2` script to rename all `*.grpc.swift` files to
-`*.grpc.v1.swift` by using the `rename-generated-files` subcommand with the
+`*.grpc.v1.swift` by using the `rename-generated-code` subcommand with the
 directory containing your generated code, for example:
 
 ```sh
-./v1_to_v2 rename-generated-files Sources/
+./v1_to_v2 rename-generated-code Sources/
 ```
 
 One of the patches applied to the local copy of 1.x was to rename
@@ -177,35 +177,35 @@ One of the patches applied to the local copy of 1.x was to rename
 script to generate your code, then run it again, ensuring that the copy of
 `protoc-gen-grpc-swift-2` comes from this package (as it will now be for 2.x).
 
-If you didn't use a script to generate your code then refer to the
+If you didn't use a script to generate your code, then refer to the
 [documentation][3] to learn how to generate gRPC Swift code.
 
 Check that your package still builds and commit any changes.
 
 ### Using the build plugin
 
-> If you generated your gRPC code using `protoc` directly then skip this
+> If you generated your gRPC code using `protoc` directly, then skip this
 > section.
 
 Because you don't have direct control over the names of files generated by the
-build plugin you can't rename them directly. Instead our strategy is to locate
+build plugin, you can't rename them directly. Instead, our strategy is to locate
 the generated gRPC code from the build directory and copy it into the source
 directory and then replace the 1.x plugin with the 2.x plugin.
 
-As you've been building your package regularly the generated files should
+As you've been building your package regularly, the generated files should
 already be in the `.build` directory. You can find them using:
 
 ```sh
 find .build/plugins/outputs -name '*.grpc.swift'
 ```
 
-Move the files for their appropriate directory in `Sources`. Once you've done
-that you can use the `v1_to_v2` script to rename all `*.grpc.swift` files to
-`*.grpc.v1.swift` by using the `rename-generated-files` subcommand with the
+Move the files to their appropriate directories in `Sources`. Once you've done
+that, you can use the `v1_to_v2` script to rename all `*.grpc.swift` files to
+`*.grpc.v1.swift` by using the `rename-generated-code` subcommand with the
 directory containing your generated code, for example:
 
 ```sh
-./v1_to_v2 rename-generated-files Sources/
+./v1_to_v2 rename-generated-code Sources/
 ```
 
 The next step is to use the new build plugin. The build plugin for 2.x can
@@ -222,41 +222,41 @@ for 2.x:
 )
 ```
 
-Finally you need to add a configuration file for the plugin. Take a look at the
+Finally, you need to add a configuration file for the plugin. Take a look at the
 [build plugin documentation][3] for instructions on how to do this.
 
-At this point you should run `swift build` again to check your package still
+At this point, you should run `swift build` again to check your package still
 compiles and commit any changes.
 
 ## Service code migration
 
-> If you only need to migrate clients then skip this section.
+> If you only need to migrate clients, then skip this section.
 
-By now your package should be set up to depend on a patched version of 1.x and 2.x
+By now, your package should be set up to depend on a patched version of 1.x and 2.x
 and have both sets of generated code and still compile. It's time to make some
 code changes, so let's start by migrating a service.
 
 
 A number of these steps can be automated, and the `v1_to_v2` script can do just
-this. However, it might not be sufficient and you should read through the
+this. However, it might not be sufficient, and you should read through the
 steps below to understand what transformations are done.
 
 Find the service you wish to migrate. The first step is to update any imports
 from `GRPC` to `GRPCCore`, which is the base module containing abstractions and
 runtime components for 2.x.
 
-Next let's update the service protocol that your type conforms to. In 2.x each
+Next, let's update the service protocol that your type conforms to. In 2.x each
 service has three protocols generated for it, each offering a different level of
 granularity. You can read more about each version in the [gRPC Swift Protobuf
 documentation][2]. The variant most like 1.x is the `SimpleServiceProtocol`.
-However, it doesn't allow you access metadata. If you need access to metadata
+However, it doesn't allow you to access metadata. If you need access to metadata,
 skip to the section called `ServiceProtocol`.
 
 ### SimpleServiceProtocol
 
-The requirements for each methods are also slightly different; in 2.x the context
+The requirements for each method are also slightly different; in 2.x the context
 type is called `ServerContext` as opposed to `GRPCAsyncServerCallContext` in 1.x.
-It also has different functionality but that will be covered later. The types
+It also has different functionality, but that will be covered later. The types
 for streaming requests and responses are also different:
 - `GRPCAsyncRequestStream<T>` became `RPCAsyncSequence<T, any Error>`, and
 - `GRPCAsyncResponseStreamWriter<T>` became `RPCWriter<T>`.
@@ -268,9 +268,9 @@ an input file. Run it now. Here's an example invocation:
 ./v1_to_v2 patch-service Sources/Server/Service.swift
 ```
 
-If the service was contained to that file then that might be the extent of
+If the service was contained to that file, then that might be the extent of
 changes you need to make for that service. However, it's likely that types leak
-into other files. If that's the case you should continue applying these
+into other files. If that's the case, you should continue applying these
 transformations until your app compiles again. You'll also need to stop
 passing this service to your 1.x server.
 
@@ -279,26 +279,26 @@ Repeat this until you've done all services in your package.
 
 ### ServiceProtocol
 
-> If the `SimpleServiceProtocol` worked then you can skip this section.
+> If the `SimpleServiceProtocol` worked, then you can skip this section.
 
-If you're reading this section then you're likely relying on metadata in your
+If you're reading this section, then you're likely relying on metadata in your
 service. This means you need to implement the `ServiceProtocol` instead of the
-`SimpleServiceProtocol` and the transformations you need to apply are
+`SimpleServiceProtocol`, and the transformations you need to apply
 aren't well suited for automation. The best approach is to conform your
 service to the 1.x protocol and the 2.x protocol. Add conformance to the
 `{Service}.ServiceProtocol` where `{Service}` is the namespaced name of your
 service (if your service is called `Baz` and declared in the `foo.bar` Protocol
-Buffers package then this would be `Foo_Bar_Baz.ServiceProtocol`).
+Buffers package, then this would be `Foo_Bar_Baz.ServiceProtocol`).
 
-Let Xcode generate stubs for the methods which haven't been implemented yet and
-fill each one with a `fatalError` so that you app builds. Each method
+Let Xcode generate stubs for the methods that haven't been implemented yet and
+fill each one with a `fatalError` so that your app builds. Each method
 should take a `ServerRequest` or `StreamingServerRequest` and context as input
 and return a `ServerResponse` or `StreamingServerResponse`. Request metadata is
-available on the request object. For single responses you can set initial and
-trailing metadata when you create the response. For streaming responses you can
+available on the request object. For single responses, you can set initial and
+trailing metadata when you create the response. For streaming responses, you can
 set initial metadata in the initializer and return trailing metadata from the
 closure you provide to the initializer. This is demonstrated in the
-['echo-metadata'](https://github.com/grpc/grpc-swift-2/tree/main/Examples/echo-metadata)
+[`echo-metadata`](https://github.com/grpc/grpc-swift-2/tree/main/Examples/echo-metadata)
 example.
 
 One important difference between this approach and the `SimpleServiceProtocol`
@@ -308,15 +308,15 @@ logic likely lives within the body of the `StreamingServerResponse`.
 
 ## Server migration
 
-With all services updated to use gRPC Swift 2.x you now need to update the
-server. Find where you create the server in your app. In this file
+With all services updated to use gRPC Swift 2.x, you now need to update the
+server. Find where you create the server in your app. In this file,
 you'll need to add imports for `GRPCCore` (which provides the server type) and
 `GRPCNIOTransportHTTP2` (which provides HTTP/2 transports built on top of
 SwiftNIO).
 
 The server object is called `GRPCServer` and you initialize it with a transport,
-any configuration, and a list of services. Importantly you must call `serve()` to start
-the server. This blocks indefinitely so it often makes sense to start it in a
+any configuration, and a list of services. Importantly, you must call `serve()` to start
+the server. This blocks indefinitely, so it often makes sense to start it in a
 task group if you need to run other code concurrently. Here's an example of a
 server configured to use the HTTP/2 transport:
 
@@ -350,7 +350,7 @@ try await withThrowingDiscardingTaskGroup { group in
 }
 ```
 
-With any luck your app should build and your server should run. Yes, you guessed
+With any luck, your app should build, and your server should run. Yes, you guessed
 it, it's time to commit any changes you've made.
 
 ## Client code migration
@@ -365,7 +365,7 @@ created.
 Start by finding a place within the target being migrated where a generated
 client is being used.
 
-Note that the generated client in 2.x is generic over a transport type, any
+Note that the generated client in 2.x is generic over a transport type; any
 types or functions using it will either need to choose a concrete type or
 also become generic. The most similar replacements to 1.x are:
 
@@ -373,19 +373,19 @@ also become generic. The most similar replacements to 1.x are:
 - `HTTP2ClientTransport.TransportServices`.
 
 Changing the type of the client will cause numerous build errors. To keep the
-number of errors manageable you'll migrate one function at a time. How this
+number of errors manageable, you'll migrate one function at a time. How this
 is done depends on whether the generated client is passed in to the function
 or stored on a property.
 
-If the function is passed a generated client then duplicate it, changing the
+If the function is passed a generated client, then duplicate it, changing the
 signature to use a 2.x generated client. The new client is
 named `{Service}.Client` where `{Service}` is the namespaced name of your
 service (if your service is named `Baz` and declared in the `foo.bar`
-Protocol Buffers package then this would be `Foo_Bar_Baz.Client`).
+Protocol Buffers package, then this would be `Foo_Bar_Baz.Client`).
 Change the body of the function using the 1.x client to just `fatalError()`.
-Later you'll remove this function altogether.
+Later, you'll remove this function altogether.
 
-If the generated client is a stored type then add a new computed property
+If the generated client is a stored type, then add a new computed property
 returning an instance of it. The body can just call `fatalError()` for now:
 
 ```swift
@@ -394,9 +394,9 @@ var client: Foo_Bar_Baz.Client {
 }
 ```
 
-Now you need to update the function to use the new client. For unary calls the API
+Now, you need to update the function to use the new client. For unary calls, the API
 is very similar, so you may not have to change any code. An important change to
-highlight is that for RPCs which stream their responses you must handle the
+highlight is that for RPCs that stream their responses, you must handle the
 response stream _within_ the closure passed to the client. By way of example,
 imagine the following server streaming RPC from 1.x:
 
@@ -420,7 +420,7 @@ func serverStreamingEcho(text: String, client: Echo_Echo.Client<Transport>) asyn
 }
 ```
 
-Similarly for client streaming RPCs you must provide any messages within a
+Similarly, for client streaming RPCs, you must provide any messages within a
 closure. Here's an example of 1.x:
 
 ```swift
@@ -446,23 +446,23 @@ func clientStreamingEcho(text: String, client: Echo_Echo.Client<Transport>) asyn
 
 Bidirectional streaming is just a combination of the previous two examples.
 
-Once the new version compiles you can work upwards, updating functions which
+Once the new version compiles, you can work upwards, updating functions that
 pass in the generated client to use the new one instead. You can also remove
 any of the unused functions.
 
 ## Client migration
 
-Once all client call sites have been updates you'll need to update how you
-create the client. Find where you create the client in your app. In this file
+Once all client call sites have been updated, you'll need to update how you
+create the client. Find where you create the client in your app. In this file,
 you'll need to add imports for `GRPCCore` (which provides the client type) and
 `GRPCNIOTransportHTTP2` (which provides HTTP/2 transports built on top of
 SwiftNIO).
 
-The client object is called `GRPCClient` and you initialize it with a transport,
-and any configuration. Importantly you must call `runConnections()` to start the
-client. This runs indefinitely and maintains the connections for the client so
-it makes sense to start it in a task group. Alternatively you can use the
-`withGRPCClient(transport:interceptors:handleClient:)` helper which provides you
+The client object is called `GRPCClient` and you initialize it with a transport
+and any configuration. Importantly, you must call `runConnections()` to start the
+client. This runs indefinitely and maintains the connections for the client, so
+it makes sense to start it in a task group. Alternatively, you can use the
+`withGRPCClient(transport:interceptors:handleClient:)` helper, which provides you
 with scoped access to a running client.
 
 Here's an example of a client configured to use the HTTP/2 transport:
@@ -478,18 +478,18 @@ try await withGRPCClient(
 }
 ```
 
-With any luck your app should build and your server should run. Yes, you guessed
+With any luck, your app should build, and your client should run. Yes, you guessed
 it, it's time to commit any changes you've made.
 
 ## Cleaning up
 
-Once you've migrated you package you can remove the local checkout of gRPC Swift
+Once you've migrated your package, you can remove the local checkout of gRPC Swift
 1.x and remove it from your package manifest.
 
 ## What's missing?
 
 If there were any parts of this guide you felt were unclear or didn't cover enough
-of the migration then please file an issue on GitHub so that we can work on improving
+of the migration, then please file an issue on GitHub so that we can work on improving
 it.
 
 [0]: https://github.com/grpc/grpc-swift-2/tree/main

--- a/Sources/GRPCCore/Documentation.docc/Articles/Migration-guide.md
+++ b/Sources/GRPCCore/Documentation.docc/Articles/Migration-guide.md
@@ -34,7 +34,7 @@ To make the migration easier a script is available to automate a number of
 steps. You should download it now using:
 
 ```sh
-curl https://raw.githubusercontent.com/grpc/grpc-swift/refs/heads/main/dev/v1-to-v2/v1_to_v2.sh -o v1_to_v2
+curl https://raw.githubusercontent.com/grpc/grpc-swift-2/refs/heads/main/dev/v1-to-v2/v1_to_v2.sh -o v1_to_v2
 ```
 
 You'll also need to make the `v1_to_v2` script executable:
@@ -298,7 +298,7 @@ available on the request object. For single responses you can set initial and
 trailing metadata when you create the response. For streaming responses you can
 set initial metadata in the initializer and return trailing metadata from the
 closure you provide to the initializer. This is demonstrated in the
-['echo-metadata'](https://github.com/grpc/grpc-swift/tree/main/Examples/echo-metadata)
+['echo-metadata'](https://github.com/grpc/grpc-swift-2/tree/main/Examples/echo-metadata)
 example.
 
 One important difference between this approach and the `SimpleServiceProtocol`
@@ -492,7 +492,7 @@ If there were any parts of this guide you felt were unclear or didn't cover enou
 of the migration then please file an issue on GitHub so that we can work on improving
 it.
 
-[0]: https://github.com/grpc/grpc-swift/tree/main
+[0]: https://github.com/grpc/grpc-swift-2/tree/main
 [1]: https://github.com/grpc/grpc-swift/tree/release/1.x
 [2]: https://swiftpackageindex.com/grpc/grpc-swift-protobuf/documentation
 [3]: https://swiftpackageindex.com/grpc/grpc-swift-protobuf/documentation/grpcprotobuf/generating-stubs

--- a/Sources/GRPCCore/Documentation.docc/Articles/Public-API.md
+++ b/Sources/GRPCCore/Documentation.docc/Articles/Public-API.md
@@ -10,7 +10,7 @@ projects to declare their public API. This document describes what is and isn't
 part of the public API; commitments the maintainers make relating to the API,
 and guidelines for users.
 
-For clarity, the project is comprised of the following Swift packages:
+For clarity, the project comprises the following Swift packages:
 
 - [grpc/grpc-swift-2][1],
 - [grpc/grpc-swift-nio-transport][2],
@@ -29,8 +29,8 @@ public API. Examples of these include `GRPCCore` and `GRPCProtobuf`.
 
 ### Symbols
 
-All publicly exposed symbols (i.e. symbols which are declared as `public`)
-within public library targets or those which are re-exported from non-public
+All publicly exposed symbols (that is, symbols that are declared as `public`)
+within public library targets or those that are re-exported from non-public
 targets are part of the public API. Examples include `Metadata`,
 `ServiceConfig`, and `GRPCServer`.
 
@@ -42,35 +42,35 @@ targets are part of the public API. Examples include `Metadata`,
 
 ### Configuration and inputs
 
-Any configuration, input, and interfaces to executable products which have
+Any configuration, input, and interfaces to executable products that have
 inputs (such as command line arguments, or configuration files) are considered
 to be public API. Examples of these include the configuration file passed to the
 Swift Package Manager build plugin for generating stubs provided by
 [grpc-swift-protobuf][3].
 
 > Exceptions:
-> - Executable _targets_ which aren't exposed as executable _products_.
+> - Executable _targets_ that aren't exposed as executable _products_.
 
 ## Commitments made by the maintainers
 
 Without releasing a new major version, the gRPC Swift maintainers commit to not
-adding any new types to the global namespace without a "GRPC" prefix.
+adding any new types to the global namespace without a “GRPC” prefix.
 
 To illustrate this, the maintainers may:
 1. Add a new type to an existing module called `GRPCPanCakes` but will not add a
    new type called `PanCakes` to an existing module.
 2. Add a new top-level function to an existing module called `grpcRun()` but
-   won't add a new top-level function called `run()`.
+   will not add a new top-level function called `run()`.
 3. Add a new module called `GRPCFoo`. Any symbols added to the new module at the
-   point the module becomes API aren't required to have a "GRPC" prefix; symbols
+   point the module becomes API aren't required to have a “GRPC” prefix; symbols
    added after that point will be prefixed as required by (1) and (2).
 
-This allows the project to follow Semantic versioning without breaking adopter
+This allows the project to follow Semantic Versioning without breaking adopter
 code in minor and patch releases.
 
 ## Guidelines for users
 
-In order to not have your code broken by a gRPC Swift update you should only use
+In order to not have your code broken by a gRPC Swift update, you should only use
 the public API as described above. There are a number of other guidelines you
 should follow as well:
 
@@ -80,7 +80,7 @@ should follow as well:
    don't own, and you mustn't conform types you don't own to protocols provided
    by gRPC Swift.
 4. You _may_ extend types provided by gRPC Swift at `package`, `internal`,
-   `private` or `fileprivate` level.
+   `private`, or `fileprivate` level.
 5. You _may_ extend types provided by gRPC Swift at `public` access level if
    doing so means that a symbol clash is impossible (such as including a type
    you own in the signature, or prefixing the method with the namespace of your

--- a/Sources/GRPCCore/Documentation.docc/Articles/Public-API.md
+++ b/Sources/GRPCCore/Documentation.docc/Articles/Public-API.md
@@ -12,7 +12,7 @@ and guidelines for users.
 
 For clarity, the project is comprised of the following Swift packages:
 
-- [grpc/grpc-swift][1],
+- [grpc/grpc-swift-2][1],
 - [grpc/grpc-swift-nio-transport][2],
 - [grpc/grpc-swift-protobuf][3], and
 - [grpc/grpc-swift-extras][4].
@@ -87,7 +87,7 @@ should follow as well:
    package in much the same way that gRPC Swift will prefix new symbols).
 
 [0]: https://semver.org
-[1]: https://github.com/grpc/grpc-swift
+[1]: https://github.com/grpc/grpc-swift-2
 [2]: https://github.com/grpc/grpc-swift-nio-transport
 [3]: https://github.com/grpc/grpc-swift-protobuf
 [4]: https://github.com/grpc/grpc-swift-extras

--- a/Sources/GRPCCore/Documentation.docc/Development/Benchmarks.md
+++ b/Sources/GRPCCore/Documentation.docc/Development/Benchmarks.md
@@ -4,11 +4,11 @@ This article discusses benchmarking in `grpc-swift`.
 
 ## Overview
 
-Benchmarks for this package are in a separate Swift Package in the `Performance/Benchmarks`
+Benchmarks for this package are in a separate Swift Package in the `IntegrationTests/Benchmarks`
 subdirectory of the repository.
 
 They use the [`package-benchmark`](https://github.com/ordo-one/package-benchmark) plugin.
-Benchmarks depends on the [`jemalloc`](https://jemalloc.net) memory allocation library, which is
+Benchmarks depend on the [`jemalloc`](https://jemalloc.net) memory allocation library, which is
 used by `package-benchmark` to capture memory allocation statistics.
 
 An installation guide can be found in the [Getting Started article](https://swiftpackageindex.com/ordo-one/package-benchmark/documentation/benchmark/gettingstarted)
@@ -16,22 +16,22 @@ for `package-benchmark`.
 
 ### Running the benchmarks
 
-You can run the benchmarks CLI by going to the `Performance/Benchmarks` subdirectory
-(e.g. `cd Performance/Benchmarks`) and invoking:
+You can run the benchmarks CLI by going to the `IntegrationTests/Benchmarks` subdirectory
+(for example, `cd IntegrationTests/Benchmarks`) and invoking:
 
 ```
 swift package benchmark
 ```
 
-Profiling benchmarks or building the benchmarks in release mode in Xcode with `jemalloc` isn't
-currently supported and requires disabling `jemalloc`.
+Profiling benchmarks, or building them in release mode in Xcode, isn't currently
+supported with `jemalloc` enabled. Disable `jemalloc` to do either.
 
-Make sure you have quit Xcode and then open it from the command line with the `BENCHMARK_DISABLE_JEMALLOC=true`
+Quit Xcode, then open it from the command line with the `BENCHMARK_DISABLE_JEMALLOC=true`
 environment variable set:
 
 ```
 BENCHMARK_DISABLE_JEMALLOC=true xed .
 ```
 
-For more information please refer to `swift package benchmark --help` or the [documentation
+For more information, please refer to `swift package benchmark --help` or the [documentation
 of `package-benchmark`](https://swiftpackageindex.com/ordo-one/package-benchmark/documentation/benchmark).

--- a/Sources/GRPCCore/Documentation.docc/Development/Design.md
+++ b/Sources/GRPCCore/Documentation.docc/Development/Design.md
@@ -9,21 +9,21 @@ The library is split into three broad layers:
 
 The _transport_ layer provides (typically) long-lived bidirectional
 communication between two peers and provides streams of request and response
-parts. On top of the transport is the _call_ layer which is responsible for
+parts. On top of the transport is the _call_ layer, which is responsible for
 mapping a call onto a stream and dealing with serialization. The highest level
-of abstraction is the _stub_ layer which provides client and server interfaces
+of abstraction is the _stub_ layer, which provides client and server interfaces
 generated from an interface definition language (IDL).
 
 ## Overview
 
 ### Transport
 
-The transport layer provides a bidirectional communication channel with a remote
-peer which is typically long-lived.
+The transport layer provides a typically long-lived, bidirectional communication
+channel with a remote peer.
 
 Transports have two main interfaces:
 1. Streams, used by the call layer.
-2. The transport specific communication with its corresponding remote peer.
+2. The transport-specific communication with its corresponding remote peer.
 
 The most common transport in gRPC is HTTP/2. However others such as gRPC-Web,
 HTTP/3 and in-process also exist. (gRPC Swift has transports for HTTP/2 built on
@@ -31,12 +31,11 @@ top of Swift NIO and also provides an in-process transport.)
 
 You shouldn't think of a transport as a single connection, they're more
 abstract. For example, a transport may maintain a set of connections to a
-collection of remote endpoints which change over time. By extension, client
+collection of remote endpoints that change over time. By extension, client
 transports are also responsible for balancing load across multiple connections
 where applicable.
 
-Each peer (client and server) has their own transport protocol, in gRPC Swift
-these are:
+Each peer (client and server) has their own transport protocol; in gRPC Swift, these are:
 1. ``ServerTransport``, and
 2. ``ClientTransport``.
 
@@ -50,12 +49,12 @@ The ``ServerTransport`` is responsible for the server half of a transport. It
 listens for new gRPC streams and then processes them. This is achieved via the
 ``ServerTransport/listen(streamHandler:)`` requirement.
 
-A handler is passed into the `listen` method which is provided by the gRPC
+A handler is passed into the `listen` method, which is provided by the gRPC
 server. It's responsible for routing and handling the stream. The stream is
-executed in the context of the server transport – that is, the `listen` method
+executed in the context of the server transport — that is, the `listen` method
 is an ancestor task of all RPCs handled by the server.
 
-Note that the server transport doesn't include the idea of a "connection". While
+Note that the server transport doesn't include the idea of a “connection”. While
 an HTTP/2 server transport will in all likelihood have multiple connections open
 at any given time, that detail isn't surfaced at this level of abstraction.
 
@@ -63,10 +62,10 @@ at any given time, that detail isn't surfaced at this level of abstraction.
 
 While the server is responsible for handling streams, the ``ClientTransport`` is
 responsible for creating them. Client transports will typically maintain a
-number of connections which may change over a period of time. Maintaining these
+number of connections that may change over a period of time. Maintaining these
 connections and other background work is done in the ``ClientTransport/connect()``
 method. Cancelling the task running this method will result in the transport
-abruptly closing. The transport can be shutdown gracefully by calling
+abruptly closing. The transport can be shut down gracefully by calling
 ``ClientTransport/beginGracefulShutdown()``.
 
 Streams are created using ``ClientTransport/withStream(descriptor:options:_:)``
@@ -78,7 +77,7 @@ doing this doesn't leave the other side waiting indefinitely.
 
 gRPC has mechanisms to deliver method-specific configuration at the transport
 layer which can also change dynamically (see [gRFC A2: ServiceConfig in
-DNS](https://github.com/grpc/proposal/blob/0e1807a6e30a1a915c0dcadc873bca92b9fa9720/A2-service-configs-in-dns.md).)
+DNS](https://github.com/grpc/proposal/blob/0e1807a6e30a1a915c0dcadc873bca92b9fa9720/A2-service-configs-in-dns.md)).
 This configuration is used to determine how clients should interact with servers
 and how methods should be executed, such as the conditions under which they
 may be retried. Some of this is exposed via the ``ClientTransport`` as
@@ -110,28 +109,28 @@ The ``RPCRequestPart`` is made up of ``Metadata`` and messages (as `[UInt8]`). T
 
 ``Metadata`` contains information about an RPC in the form of a list of
 key-value pairs. Keys are strings and values may be strings or binary data (but are
-typically strings). Keys for binary values have a "-bin" suffix. The transport
+typically strings). Keys for binary values have a “-bin” suffix. The transport
 layer may use metadata to propagate transport-specific information about the call to
-its peer. The call layer may attach gRPC specific metadata such as call time out
-information. Users may also make use of metadata to propagate app specific information
+its peer. The call layer may attach gRPC-specific metadata such as call timeout
+information. Users may also make use of metadata to propagate app-specific information
 to the remote peer.
 
-Each message part contains the binary data, typically this would be the serialized
+Each message part contains the binary data; typically this would be the serialized
 representation of a Protocol Buffers message.
 
 The combined ``Status`` and ``Metadata`` part only appears in the ``RPCResponsePart``
 and indicates the final outcome of an RPC. It includes a ``Status/Code-swift.struct``
-and string describing the final outcome while the ``Metadata`` may contain additional
+and a string describing the final outcome, while the ``Metadata`` may contain additional
 information about the RPC.
 
 ### Call
 
-The "call" layer builds on top the transport layer to map higher level RPCs calls on
-to streams. It also implements transport-agnostic functionality, like serialization
+The “call” layer builds on top of the transport layer to map higher-level RPC calls onto
+streams. It also implements transport-agnostic functionality, like serialization
 and deserialization, retries, hedging, and deadlines.
 
 Serialization is pluggable: you have control over the type of messages used although
-most users will use Protocol Buffers. The serialization interface is small, there are
+most users will use Protocol Buffers. The serialization interface is small; there are
 two protocols:
 1. ``MessageSerializer`` for serializing messages to bytes, and
 2. ``MessageDeserializer`` for deserializing messages from bytes.
@@ -147,16 +146,16 @@ This layer also provides client and server interceptors allowing you to modify r
 and responses between the caller and the network. These are implemented as
 ``ClientInterceptor`` and ``ServerInterceptor``, respectively.
 
-As all RPC types are special-cases of bidirectional streaming RPCs, the interceptor
+As all RPC types are special cases of bidirectional streaming RPCs, the interceptor
 APIs follow the shape of the respective client and server bidirectional streaming APIs.
-Naturally, the interceptors APIs are `async`.
+Naturally, the interceptor APIs are `async`.
 
 Interceptors are registered directly with the ``GRPCClient`` and ``GRPCServer`` and
 can either be applied to all RPCs or to specific services.
 
 #### Client
 
-The call layer includes  a concrete ``GRPCClient`` which provides API to execute all
+The call layer includes a concrete ``GRPCClient``, which provides API to execute all
 four types of RPC against a ``ClientTransport``. These methods are:
 
 - ``GRPCClient/unary(request:descriptor:serializer:deserializer:options:onResponse:)``,
@@ -164,17 +163,17 @@ four types of RPC against a ``ClientTransport``. These methods are:
 - ``GRPCClient/serverStreaming(request:descriptor:serializer:deserializer:options:onResponse:)``, and
 - ``GRPCClient/bidirectionalStreaming(request:descriptor:serializer:deserializer:options:onResponse:)``.
 
-As lower level methods they require you to pass in a serializer and
+As lower-level methods, they require you to pass in a serializer and
 deserializer, as well as the descriptor of the method being called. Each method
-has a response handling closure to process the response from the server and the
+has a response-handling closure to process the response from the server, and the
 method won't return until the handler has returned. This enforces structured
 concurrency.
 
-Most users won't use ``GRPCClient`` to execute RPCs directly, instead they will
-use the generated client stubs which wrap the ``GRPCClient``. Users are
+Most users won't use ``GRPCClient`` to execute RPCs directly; instead, they will
+use the generated client stubs that wrap the ``GRPCClient``. Users are
 responsible for creating the client and running it (which starts and runs the
 underlying transport). This is done by calling ``GRPCClient/runConnections()``. The client
-can be shutdown gracefully by calling ``GRPCClient/beginGracefulShutdown()``
+can be shut down gracefully by calling ``GRPCClient/beginGracefulShutdown()``,
 which will stop new RPCs from starting (by failing them with
 ``RPCError/Code-swift.struct/unavailable``) but allow existing ones to continue.
 Existing work can be stopped more abruptly by cancelling the task where
@@ -183,26 +182,25 @@ Existing work can be stopped more abruptly by cancelling the task where
 #### Server
 
 ``GRPCServer`` is provided by the call layer to host services for a given
-transport. Beyond creating the server it has a very limited API surface: it has
-a ``GRPCServer/serve()`` method which runs the underlying transport and is the
-task from which all accepted streams are run under. Much like the client, you
-can initiate graceful shutdown by calling ``GRPCServer/beginGracefulShutdown()``
+transport. Beyond creating the server, it has a very limited API surface: it has
+a ``GRPCServer/serve()`` method, which runs the underlying transport and is the
+task under which all accepted streams run. Much like the client, you
+can initiate graceful shutdown by calling ``GRPCServer/beginGracefulShutdown()``,
 which will stop new RPCs from being handled but will let existing RPCs run to
 completion. Cancelling the task will close the server more abruptly.
 
 ### Stub
 
-The stub layer is the layer which most users interact with. It provides service
-specific interfaces generated from an interface definition language (IDL) such
-as Protobuf. For clients this includes a concrete type per service for invoking
-the methods provided by that service. For services this includes a protocol
-which the service owner implements with the business logic for their service.
+The stub layer is the layer that most users interact with. It provides service-specific interfaces generated from an interface definition language (IDL) such
+as Protobuf. For clients, this includes a concrete type per service for invoking
+the methods provided by that service. For services, this includes a protocol
+that the service owner implements with the business logic for their service.
 
 The purpose of the stub layer is to reduce boilerplate: users generate stubs
-from a single source of truth to native Swift types to remove errors which would
+from a single source of truth into native Swift types to remove errors that would
 otherwise arise from writing them manually.
 
-However, the stub layer is optional, users may choose to not use it and
+However, the stub layer is optional; users may choose not to use it and
 construct clients and services manually. A gRPC proxy, for example, would not
 use the stub layer.
 
@@ -210,14 +208,14 @@ use the stub layer.
 
 Users implement services by conforming a type to a generated service `protocol`.
 Each service has three protocols generated for it:
-1. A "simple" service protocol (_note: this hasn't been implemented yet_),
-2. A "regular" service protocol, and
-3. A "streaming" service protocol.
+1. A “simple” service protocol,
+2. A “regular” service protocol, and
+3. A “streaming” service protocol.
 
-The streaming service protocol is the root `protocol`, most users won't need to
+The streaming service protocol is the root `protocol`. Most users won't need to
 implement this protocol directly. It treats each of the four RPC types as a
 bidirectional streaming RPC: this allows users to have the most flexibility over
-how their RPCs are implemented at the cost of a harder to use API. The following
+how their RPCs are implemented at the cost of a harder-to-use API. The following
 code shows how the streaming service protocol would look for a service:
 
 ```swift
@@ -236,8 +234,8 @@ An example of where this is useful is when a user wants to implement a unary
 method that first sends the initial metadata and then does some other processing
 before sending a message.
 
-Many users won't need this much fidelity and will use the "regular" service
-protocol which provides APIs which are more appropriate for the type of RPC. The
+Many users won't need this much fidelity and will use the “regular” service
+protocol that provides APIs that are more appropriate for the type of RPC. The
 following code shows how the regular service protocol would look:
 
 ```swift
@@ -264,13 +262,13 @@ protocol ServiceName.ServiceProtocol: ServiceName.StreamingServiceProtocol {
 }
 ```
 
-The conformance to the `StreamingServiceProtocol` is generated an implemented in
+The conformance to the `StreamingServiceProtocol` is generated and implemented in
 terms of the requirements of `ServiceProtocol`. This allows users to use the
 higher-level API where possible but can implement the fully-streamed version
 per-RPC if necessary.
 
 Some users also won't need access to metadata and will only be interested in the
-messages sent and received on an RPC. A higher level "simple" service protocol
+messages sent and received on an RPC. A higher-level “simple” service protocol
 is provided for this use case:
 
 ```swift
@@ -299,10 +297,8 @@ protocol ServiceName.SimpleServiceProtocol: ServiceName.ServiceProtocol {
 }
 ```
 
-> Note: the "simple" version hasn't been implemented yet.
-
-Much like the "regular" protocol, the "simple" version refines another service
-protocol. In this case it refines the "regular" `ServiceProtocol` for which it
+Much like the “regular” protocol, the “simple” version refines another service
+protocol. In this case it refines the “regular” `ServiceProtocol` for which it
 also has a default implementation.
 
 The root of the protocol hierarchy, the `StreamingServiceProtocol`, also
@@ -352,11 +348,11 @@ protocol ServiceName.ClientProtocol {
 ```
 
 Each method takes a request appropriate for its RPC type, a serializer, a
-deserializer, a set of options and a handler for processing the response. The
+deserializer, a set of options, and a handler for processing the response. The
 function doesn't return until the response handler has returned and all
 resources associated with the RPC have been cleaned up.
 
-An extension to the protocol is also generated which provides an appropriate
+An extension to the protocol is also generated, which provides an appropriate
 serializer and deserializer, defaults the options to `.defaults`, and for RPCs
 with a single response message, defaults the closure to returning the response
 message:
@@ -397,11 +393,11 @@ extension ServiceName.ClientProtocol {
 }
 ```
 
-An additional extension is also generated providing even higher level APIs.
-These allow the user to avoid creating the request types by creating them on
-behalf of the user. For unary RPCs this API distils down to message-in,
-message-out, for bidirectional streaming it distils down to two closures, one
-for sending messages, one for handling response messages.
+An additional extension is also generated providing even higher-level APIs.
+These let the user avoid creating the request types themselves, since the
+extension creates them on behalf of the user. For unary RPCs, this API distils
+down to message-in, message-out; for bidirectional streaming, it distils down
+to two closures, one for sending messages, one for handling response messages.
 
 ```swift
 extension ServiceName.ClientProtocol {
@@ -443,6 +439,6 @@ extension ServiceName.ClientProtocol {
 }
 ```
 
-To see this in use refer to the <doc:Hello-World> or <doc:Route-Guide> tutorials
+To see this in use, refer to the <doc:Hello-World> or <doc:Route-Guide> tutorials
 or the examples in the [grpc/grpc-swift-2](https://github.com/grpc/grpc-swift-2)
 repository on GitHub.

--- a/Sources/GRPCCore/Documentation.docc/Development/Design.md
+++ b/Sources/GRPCCore/Documentation.docc/Development/Design.md
@@ -444,5 +444,5 @@ extension ServiceName.ClientProtocol {
 ```
 
 To see this in use refer to the <doc:Hello-World> or <doc:Route-Guide> tutorials
-or the examples in the [grpc/grpc-swift](https://github.com/grpc/grpc-swift)
+or the examples in the [grpc/grpc-swift-2](https://github.com/grpc/grpc-swift-2)
 repository on GitHub.

--- a/Sources/GRPCCore/Documentation.docc/Documentation.md
+++ b/Sources/GRPCCore/Documentation.docc/Documentation.md
@@ -9,9 +9,9 @@ A gRPC library for Swift written natively in Swift.
 gRPC Swift is distributed across multiple Swift packages. These are:
 
 - `grpc-swift` (this package) containing core gRPC abstractions and an in-process transport.
-  - GitHub repository: [`grpc/grpc-swift`](https://github.com/grpc/grpc-swift)
+  - GitHub repository: [`grpc/grpc-swift-2`](https://github.com/grpc/grpc-swift-2)
   - Documentation: hosted on the [Swift Package
-    Index](https://swiftpackageindex.com/grpc/grpc-swift/documentation)
+    Index](https://swiftpackageindex.com/grpc/grpc-swift-2/documentation)
 - `grpc-swift-nio-transport` contains high-performance HTTP/2 transports built on top
     of [SwiftNIO](https://github.com/apple/swift-nio).
   - GitHub repository: [`grpc/grpc-swift-nio-transport`](https://github.com/grpc/grpc-swift-nio-transport)

--- a/Sources/GRPCCore/Documentation.docc/Documentation.md
+++ b/Sources/GRPCCore/Documentation.docc/Documentation.md
@@ -6,7 +6,7 @@ A gRPC library for Swift written natively in Swift.
 
 ### Package structure
 
-gRPC Swift is distributed across multiple Swift packages. These are:
+gRPC Swift spans multiple Swift packages:
 
 - `grpc-swift` (this package) containing core gRPC abstractions and an in-process transport.
   - GitHub repository: [`grpc/grpc-swift-2`](https://github.com/grpc/grpc-swift-2)
@@ -28,12 +28,12 @@ gRPC Swift is distributed across multiple Swift packages. These are:
   - Documentation: hosted on the [Swift Package
     Index](https://swiftpackageindex.com/grpc/grpc-swift-extras/documentation)
 
-This package, and this module (``GRPCCore``) in particular, include higher level documentation such
+This package, and this module (``GRPCCore``) in particular, include higher-level documentation such
 as tutorials.
 
 ### Modules in this package
 
-- ``GRPCCore`` (this module) contains core abstractions, currency types and runtime components
+- ``GRPCCore`` (this module) contains core abstractions, currency types, and runtime components
   for gRPC Swift.
 - `GRPCInProcessTransport` contains an in-process implementation of the ``ClientTransport`` and
   ``ServerTransport`` protocols.
@@ -51,20 +51,20 @@ as tutorials.
 - <doc:Generating-stubs>
 - <doc:Error-handling>
 
-### Project Information
+### Project information
 
 - <doc:Compatibility>
 - <doc:Public-API>
 - <doc:Migration-guide>
 
-### Getting involved
+### Development resources
 
 Resources for developers working on gRPC Swift:
 
 - <doc:Design>
 - <doc:Benchmarks>
 
-### Client and Server
+### Client and server
 
 - ``GRPCClient``
 - ``GRPCServer``

--- a/Sources/GRPCCore/Documentation.docc/Documentation.md
+++ b/Sources/GRPCCore/Documentation.docc/Documentation.md
@@ -37,7 +37,7 @@ as tutorials.
   for gRPC Swift.
 - `GRPCInProcessTransport` contains an in-process implementation of the ``ClientTransport`` and
   ``ServerTransport`` protocols.
-- `GRPCodeGen` contains components for building a code generator.
+- `GRPCCodeGen` contains components for building a code generator.
 
 ## Topics
 

--- a/Sources/GRPCCore/GRPCClient.swift
+++ b/Sources/GRPCCore/GRPCClient.swift
@@ -54,6 +54,9 @@ private import Synchronization
 /// more abruptly you can cancel the task running your client. If your application requires
 /// additional resources that need their lifecycles managed you should consider using [Swift Service
 /// Lifecycle](https://github.com/swift-server/swift-service-lifecycle).
+///
+/// Once the client has stopped it can't be restarted: calling ``runConnections()`` again throws a
+/// ``RuntimeError``. Create a new ``GRPCClient`` (and a new transport) if you need to reconnect.
 @available(gRPCSwift 2.0, *)
 public final class GRPCClient<Transport: ClientTransport>: Sendable {
   /// The transport which provides a bidirectional communication channel with the server.

--- a/Sources/GRPCCore/GRPCClient.swift
+++ b/Sources/GRPCCore/GRPCClient.swift
@@ -31,7 +31,7 @@ private import Synchronization
 /// ## Creating a client
 ///
 /// You can create and run a client using ``withGRPCClient(transport:interceptors:isolation:handleClient:)``
-/// or ``withGRPCClient(transport:interceptorPipeline:isolation:handleClient:)`` which create, configure and
+/// or ``withGRPCClient(transport:interceptorPipeline:isolation:handleClient:)`` which create, configure, and
 /// run the client providing scoped access to it via the `handleClient` closure. The client will
 /// begin gracefully shutting down when the closure returns.
 ///
@@ -44,7 +44,7 @@ private import Synchronization
 ///
 /// ## Creating a client manually
 ///
-/// If the `with`-style methods for creating clients isn't suitable for your application then you
+/// If the `with`-style methods for creating clients aren't suitable for your application then you
 /// can create and run a client manually. This requires you to call the ``runConnections()`` method in a task
 /// which instructs the client to start connecting to the server.
 ///
@@ -173,7 +173,7 @@ public final class GRPCClient<Transport: ClientTransport>: Sendable {
     }
   }
 
-  /// Creates a new client with the given transport, interceptors and configuration.
+  /// Creates a new client with the given transport, interceptors, and configuration.
   ///
   /// - Parameters:
   ///   - transport: The transport used to establish a communication channel with a server.
@@ -192,7 +192,7 @@ public final class GRPCClient<Transport: ClientTransport>: Sendable {
     )
   }
 
-  /// Creates a new client with the given transport, interceptors and configuration.
+  /// Creates a new client with the given transport, interceptors, and configuration.
   ///
   /// - Parameters:
   ///   - transport: The transport used to establish a communication channel with a server.
@@ -209,7 +209,7 @@ public final class GRPCClient<Transport: ClientTransport>: Sendable {
     self.stateMachine = Mutex(StateMachine(interceptorPipeline: interceptorPipeline))
   }
 
-  /// Start the client.
+  /// Starts the client.
   ///
   /// This returns once ``beginGracefulShutdown()`` has been called and all in-flight RPCs have finished executing.
   /// If you need to abruptly stop all work you should cancel the task executing this method.
@@ -235,7 +235,7 @@ public final class GRPCClient<Transport: ClientTransport>: Sendable {
     }
   }
 
-  /// Close the client.
+  /// Closes the client.
   ///
   /// The transport will be closed: this means that it will be given enough time to wait for
   /// in-flight RPCs to finish executing, but no new RPCs will be accepted. You can cancel the task
@@ -281,7 +281,7 @@ public final class GRPCClient<Transport: ClientTransport>: Sendable {
     }
   }
 
-  /// Start a client-streaming RPC.
+  /// Starts a client-streaming RPC.
   ///
   /// - Parameters:
   ///   - request: The request stream.
@@ -315,7 +315,7 @@ public final class GRPCClient<Transport: ClientTransport>: Sendable {
     }
   }
 
-  /// Start a server-streaming RPC.
+  /// Starts a server-streaming RPC.
   ///
   /// - Parameters:
   ///   - request: The unary request.
@@ -347,7 +347,7 @@ public final class GRPCClient<Transport: ClientTransport>: Sendable {
     )
   }
 
-  /// Start a bidirectional streaming RPC.
+  /// Starts a bidirectional streaming RPC.
   ///
   /// - Note: ``runConnections()`` must have been called and still executing, and ``beginGracefulShutdown()`` mustn't
   /// have been called.

--- a/Sources/GRPCCore/GRPCServer.swift
+++ b/Sources/GRPCCore/GRPCServer.swift
@@ -24,8 +24,8 @@ private import Synchronization
 /// can handle the RPC.
 ///
 /// A ``GRPCServer`` listens with a specific transport implementation (for example, HTTP/2 or in-process),
-/// and routes requests from the transport to the service instance. You can also use "interceptors",
-/// to implement cross-cutting logic which apply to all accepted RPCs. Example uses of interceptors
+/// and routes requests from the transport to the service instance. You can also use "interceptors"
+/// to implement cross-cutting logic that applies to all accepted RPCs. Example uses of interceptors
 /// include request filtering, authentication, and logging. Once requests have been intercepted
 /// they are passed to a handler which in turn returns a response to send back to the client.
 ///
@@ -58,7 +58,7 @@ private import Synchronization
 ///
 /// ## Creating a client manually
 ///
-/// If the `with`-style methods for creating a server isn't suitable for your application then you
+/// If the `with`-style methods for creating a server aren't suitable for your application then you
 /// can create and run it manually. This requires you to call the ``serve()`` method in a task
 /// which instructs the server to start its transport and listen for new RPCs. A ``RuntimeError`` is
 /// thrown if the transport can't be started or encounters some other runtime error.
@@ -234,7 +234,7 @@ public final class GRPCServer<Transport: ServerTransport>: Sendable {
     }
   }
 
-  /// Signal to the server that it should stop listening for new requests.
+  /// Signals to the server that it should stop listening for new requests.
   ///
   /// By calling this function you indicate to clients that they mustn't start new requests
   /// against this server. Once the server has processed all requests the ``serve()`` method returns.

--- a/Sources/GRPCCore/Metadata.swift
+++ b/Sources/GRPCCore/Metadata.swift
@@ -16,7 +16,7 @@
 
 /// A collection of metadata key-value pairs, found in RPC streams.
 ///
-/// Metadata is a side channel associated with an RPC, that allows you to send information between clients
+/// Metadata is a side channel associated with an RPC that allows you to send information between clients
 /// and servers. Metadata is stored as a list of key-value pairs where keys aren't required to be unique;
 /// a single key may have multiple values associated with it.
 ///
@@ -82,12 +82,16 @@
 @available(gRPCSwift 2.0, *)
 public struct Metadata: Sendable, Hashable {
 
-  /// A metadata value. It can either be a simple string, or binary data.
+  /// A metadata value.
+  ///
+  /// It can either be a simple string or binary data.
   public enum Value: Sendable, Hashable {
     case string(String)
     case binary([UInt8])
 
-    /// The value as a String. If it was originally stored as a binary, the base64-encoded String version
+    /// The value as a String.
+    ///
+    /// If it was originally stored as a binary, the base64-encoded String version
     /// of the binary data will be returned instead.
     public func encoded() -> String {
       switch self {
@@ -108,7 +112,7 @@ public struct Metadata: Sendable, Hashable {
     ///
     /// - Parameters:
     ///   - key: The key for the key-value pair.
-    ///   - value: The value to be associated to the given key. If it's a binary value, then the associated
+    ///   - value: The value to be associated with the given key. If it's a binary value, then the associated
     ///   key must end in "-bin", otherwise, this method will produce an assertion failure.
     init(key: String, value: Value) {
       if case .binary = value {
@@ -145,7 +149,7 @@ public struct Metadata: Sendable, Hashable {
     self.elements.reserveCapacity(minimumCapacity)
   }
 
-  /// Add a new key-value pair, where the value is a string.
+  /// Adds a new key-value pair, where the value is a string.
   ///
   /// - Parameters:
   ///   - stringValue: The string value to be associated with the given key.
@@ -154,16 +158,16 @@ public struct Metadata: Sendable, Hashable {
     self.addValue(.string(stringValue), forKey: key)
   }
 
-  /// Add a new key-value pair, where the value is binary data, in the form of `[UInt8]`.
+  /// Adds a new key-value pair, where the value is binary data, in the form of `[UInt8]`.
   ///
   /// - Parameters:
-  ///   - binaryValue: The binary data (i.e., `[UInt8]`) to be associated with the given key.
+  ///   - binaryValue: The binary data (that is, `[UInt8]`) to be associated with the given key.
   ///   - key: The key to be associated with the given value. Must end in "-bin".
   public mutating func addBinary(_ binaryValue: [UInt8], forKey key: String) {
     self.addValue(.binary(binaryValue), forKey: key)
   }
 
-  /// Add a new key-value pair.
+  /// Adds a new key-value pair.
   ///
   /// - Parameters:
   ///   - value: The ``Value`` to be associated with the given key.
@@ -172,14 +176,14 @@ public struct Metadata: Sendable, Hashable {
     self.elements.append(.init(key: key, value: value))
   }
 
-  /// Add the contents of a `Sequence` of key-value pairs to this `Metadata` instance.
+  /// Adds the contents of a `Sequence` of key-value pairs to this `Metadata` instance.
   ///
   /// - Parameter other: the `Sequence` whose key-value pairs should be added into this `Metadata` instance.
   public mutating func add(contentsOf other: some Sequence<Element>) {
     self.elements.append(contentsOf: other.map(KeyValuePair.init))
   }
 
-  /// Add the contents of another `Metadata` to this instance.
+  /// Adds the contents of another `Metadata` to this instance.
   ///
   /// - Parameter other: the `Metadata` whose key-value pairs should be added into this one.
   public mutating func add(contentsOf other: Metadata) {
@@ -199,7 +203,7 @@ public struct Metadata: Sendable, Hashable {
 
   /// Adds a key-value pair to the collection, where the value is a string.
   ///
-  /// If there are pairs already associated to the given key, they will all be removed first, and the new pair
+  /// If there are pairs already associated with the given key, they will all be removed first, and the new pair
   /// will be added. If no pairs are present with the given key, a new one will be added.
   ///
   /// - Parameters:
@@ -213,7 +217,7 @@ public struct Metadata: Sendable, Hashable {
 
   /// Adds a key-value pair to the collection, where the value is `[UInt8]`.
   ///
-  /// If there are pairs already associated to the given key, they will all be removed first, and the new pair
+  /// If there are pairs already associated with the given key, they will all be removed first, and the new pair
   /// will be added. If no pairs are present with the given key, a new one will be added.
   ///
   /// - Parameters:
@@ -227,7 +231,7 @@ public struct Metadata: Sendable, Hashable {
 
   /// Adds a key-value pair to the collection.
   ///
-  /// If there are pairs already associated to the given key, they will all be removed first, and the new pair
+  /// If there are pairs already associated with the given key, they will all be removed first, and the new pair
   /// will be added. If no pairs are present with the given key, a new one will be added.
   ///
   /// - Parameters:
@@ -454,9 +458,9 @@ extension Metadata {
   /// also try to decode values stored as strings as if they were base64-encoded strings; only strings that
   /// are successfully decoded will be returned.
   ///
-  /// - Parameter key: The returned sequence will only return binary (i.e. `[UInt8]`) values for this key.
+  /// - Parameter key: The returned sequence will only return binary (that is, `[UInt8]`) values for this key.
   ///
-  /// - Returns: A sequence containing binary (i.e. `[UInt8]`) values for the given key.
+  /// - Returns: A sequence containing binary (that is, `[UInt8]`) values for the given key.
   ///
   /// - SeeAlso: ``BinaryValues/Iterator``.
   public subscript(binaryValues key: String) -> BinaryValues {

--- a/Sources/GRPCCore/MethodDescriptor.swift
+++ b/Sources/GRPCCore/MethodDescriptor.swift
@@ -26,7 +26,7 @@ public struct MethodDescriptor: Sendable, Hashable {
   /// The fully qualified method name in the format "package.service/method".
   ///
   /// For example, the fully qualified name of the "SayHello" method of the "Greeter" service in
-  /// "helloworld" package is "helloworld.Greeter/SayHelllo".
+  /// the "helloworld" package is "helloworld.Greeter/SayHello".
   public var fullyQualifiedMethod: String {
     "\(self.service)/\(self.method)"
   }

--- a/Sources/GRPCCore/RPCError.swift
+++ b/Sources/GRPCCore/RPCError.swift
@@ -36,7 +36,9 @@ public struct RPCError: Sendable, Hashable, Error {
   /// The original error which led to this error being thrown.
   public var cause: (any Error)?
 
-  /// Create a new RPC error. If the given `cause` is also an ``RPCError`` sharing the same `code`,
+  /// Creates a new RPC error.
+  ///
+  /// If the given `cause` is also an ``RPCError`` sharing the same `code`,
   /// then they will be flattened into a single error, by merging the messages and metadata.
   ///
   /// - Parameters:
@@ -65,7 +67,9 @@ public struct RPCError: Sendable, Hashable, Error {
     }
   }
 
-  /// Create a new RPC error. If the given `cause` shares the same `code`, then it will be flattened
+  /// Creates a new RPC error.
+  ///
+  /// If the given `cause` shares the same `code`, then it will be flattened
   /// into a single error, by merging the messages and metadata.
   ///
   /// - Parameters:
@@ -94,7 +98,7 @@ public struct RPCError: Sendable, Hashable, Error {
     }
   }
 
-  /// Create a new RPC error from the provided ``Status``.
+  /// Creates a new RPC error from the provided ``Status``.
   ///
   /// Returns `nil` if the provided ``Status`` has code ``Status/Code-swift.struct/ok``.
   ///
@@ -181,36 +185,43 @@ extension RPCError.Code {
   /// The operation was cancelled (typically by the caller).
   public static let cancelled = Self(code: .cancelled)
 
-  /// Unknown error. An example of where this error may be returned is if a
+  /// Unknown error.
+  ///
+  /// An example of where this error may be returned is if a
   /// Status value received from another address space belongs to an error-space
   /// that is not known in this address space. Also errors raised by APIs that
   /// do not return enough error information may be converted to this error.
   public static let unknown = Self(code: .unknown)
 
-  /// Client specified an invalid argument. Note that this differs from
+  /// Client specified an invalid argument.
+  ///
+  /// Note that this differs from
   /// ``failedPrecondition``. ``invalidArgument`` indicates arguments that are
-  /// problematic regardless of the state of the system (e.g., a malformed file
+  /// problematic regardless of the state of the system (for example, a malformed file
   /// name).
   public static let invalidArgument = Self(code: .invalidArgument)
 
-  /// Deadline expired before operation could complete. For operations that
+  /// Deadline expired before operation could complete.
+  ///
+  /// For operations that
   /// change the state of the system, this error may be returned even if the
   /// operation has completed successfully. For example, a successful response
   /// from a server could have been delayed long enough for the deadline to
   /// expire.
   public static let deadlineExceeded = Self(code: .deadlineExceeded)
 
-  /// Some requested entity (e.g., file or directory) was not found.
+  /// Some requested entity (for example, file or directory) was not found.
   public static let notFound = Self(code: .notFound)
 
-  /// Some entity that we attempted to create (e.g., file or directory) already
+  /// Some entity that we attempted to create (for example, file or directory) already
   /// exists.
   public static let alreadyExists = Self(code: .alreadyExists)
 
   /// The caller does not have permission to execute the specified operation.
+  ///
   /// ``permissionDenied`` must not be used for rejections caused by exhausting
   /// some resource (use ``resourceExhausted`` instead for those errors).
-  /// ``permissionDenied`` must not be used if the caller can not be identified
+  /// ``permissionDenied`` must not be used if the caller cannot be identified
   /// (use ``unauthenticated`` instead for those errors).
   public static let permissionDenied = Self(code: .permissionDenied)
 
@@ -219,22 +230,24 @@ extension RPCError.Code {
   public static let resourceExhausted = Self(code: .resourceExhausted)
 
   /// Operation was rejected because the system is not in a state required for
-  /// the operation's execution. For example, directory to be deleted may be
+  /// the operation's execution.
+  ///
+  /// For example, directory to be deleted may be
   /// non-empty, an rmdir operation is applied to a non-directory, etc.
   ///
   /// A litmus test that may help a service implementor in deciding
   /// between ``failedPrecondition``, ``aborted``, and ``unavailable``:
   /// - Use ``unavailable`` if the client can retry just the failing call.
   /// - Use ``aborted`` if the client should retry at a higher-level
-  ///   (e.g., restarting a read-modify-write sequence).
+  ///   (for example, restarting a read-modify-write sequence).
   /// - Use ``failedPrecondition`` if the client should not retry until
-  ///   the system state has been explicitly fixed. E.g., if an "rmdir"
+  ///   the system state has been explicitly fixed. For example, if an "rmdir"
   ///   fails because the directory is non-empty, ``failedPrecondition``
   ///   should be returned since the client should not retry unless
   ///   they have first fixed up the directory by deleting files from it.
   /// - Use ``failedPrecondition`` if the client performs conditional
   ///   REST Get/Update/Delete on a resource and the resource on the
-  ///   server does not match the condition. E.g., conflicting
+  ///   server does not match the condition. For example, conflicting
   ///   read-modify-write on the same resource.
   public static let failedPrecondition = Self(code: .failedPrecondition)
 
@@ -245,7 +258,9 @@ extension RPCError.Code {
   /// and ``unavailable``.
   public static let aborted = Self(code: .aborted)
 
-  /// Operation was attempted past the valid range. E.g., seeking or reading
+  /// Operation was attempted past the valid range.
+  ///
+  /// For example, seeking or reading
   /// past end of file.
   ///
   /// Unlike ``invalidArgument``, this error indicates a problem that may be fixed
@@ -263,11 +278,15 @@ extension RPCError.Code {
   /// Operation is not implemented or not supported/enabled in this service.
   public static let unimplemented = Self(code: .unimplemented)
 
-  /// Internal errors. Means some invariants expected by underlying System has
-  /// been broken. If you see one of these errors, Something is very broken.
+  /// Internal errors.
+  ///
+  /// This means some invariants expected by the underlying system have
+  /// been broken. If you see one of these errors, something is very broken.
   public static let internalError = Self(code: .internalError)
 
-  /// The service is currently unavailable. This is a most likely a transient
+  /// The service is currently unavailable.
+  ///
+  /// This is most likely a transient
   /// condition and may be corrected by retrying with a backoff.
   ///
   /// See litmus test above for deciding between ``failedPrecondition``, ``aborted``,
@@ -334,7 +353,7 @@ extension RPCErrorConvertible where Self: Error {
 
 @available(gRPCSwift 2.0, *)
 extension RPCError {
-  /// Create a new error by converting the given value.
+  /// Creates a new error by converting the given value.
   public init(_ convertible: some RPCErrorConvertible) {
     self.code = convertible.rpcErrorCode
     self.message = convertible.rpcErrorMessage

--- a/Sources/GRPCCore/RuntimeError.swift
+++ b/Sources/GRPCCore/RuntimeError.swift
@@ -85,22 +85,22 @@ extension RuntimeError {
       Self(.invalidArgument)
     }
 
-    /// At attempt to start the server was made but it is already running.
+    /// An attempt to start the server was made but it is already running.
     public static var serverIsAlreadyRunning: Self {
       Self(.serverIsAlreadyRunning)
     }
 
-    /// At attempt to start the server was made but it has already stopped.
+    /// An attempt to start the server was made but it has already stopped.
     public static var serverIsStopped: Self {
       Self(.serverIsStopped)
     }
 
-    /// At attempt to start the client was made but it is already running.
+    /// An attempt to start the client was made but it is already running.
     public static var clientIsAlreadyRunning: Self {
       Self(.clientIsAlreadyRunning)
     }
 
-    /// At attempt to start the client was made but it has already stopped.
+    /// An attempt to start the client was made but it has already stopped.
     public static var clientIsStopped: Self {
       Self(.clientIsStopped)
     }

--- a/Sources/GRPCCore/ServiceDescriptor.swift
+++ b/Sources/GRPCCore/ServiceDescriptor.swift
@@ -17,7 +17,9 @@
 /// A description of a service.
 @available(gRPCSwift 2.0, *)
 public struct ServiceDescriptor: Sendable, Hashable {
-  /// The name of the package the service belongs to. For example, "helloworld".
+  /// The name of the package the service belongs to.
+  ///
+  /// For example, "helloworld".
   /// An empty string means that the service does not belong to any package.
   public var package: String {
     if let index = self.fullyQualifiedService.utf8.lastIndex(of: UInt8(ascii: ".")) {
@@ -27,7 +29,9 @@ public struct ServiceDescriptor: Sendable, Hashable {
     }
   }
 
-  /// The name of the service. For example, "Greeter".
+  /// The name of the service.
+  ///
+  /// For example, "Greeter".
   public var service: String {
     if var index = self.fullyQualifiedService.utf8.lastIndex(of: UInt8(ascii: ".")) {
       self.fullyQualifiedService.utf8.formIndex(after: &index)
@@ -42,12 +46,14 @@ public struct ServiceDescriptor: Sendable, Hashable {
   /// - "service": if a package name is not specified. For example, "Greeter".
   public var fullyQualifiedService: String
 
-  /// Create a new descriptor from the fully qualified service name.
+  /// Creates a new descriptor from the fully qualified service name.
   /// - Parameter fullyQualifiedService: The fully qualified service name.
   public init(fullyQualifiedService: String) {
     self.fullyQualifiedService = fullyQualifiedService
   }
 
+  /// Creates a new descriptor from a package name and a service name.
+  ///
   /// - Parameters:
   ///   - package: The name of the package the service belongs to. For example, "helloworld".
   ///   An empty string means that the service does not belong to any package.

--- a/Sources/GRPCCore/Status.swift
+++ b/Sources/GRPCCore/Status.swift
@@ -22,7 +22,7 @@
 /// on their own if an error happens.
 ///
 /// ``Status`` represents the raw outcome of an RPC whether it was successful or not; ``RPCError``
-/// is similar to ``Status`` but only represents error cases, in other words represents all status
+/// is similar to ``Status`` but only represents error cases, in other words, represents all status
 /// codes apart from ``Code-swift.struct/ok``.
 @available(gRPCSwift 2.0, *)
 public struct Status: @unchecked Sendable, Hashable {
@@ -53,7 +53,7 @@ public struct Status: @unchecked Sendable, Hashable {
     }
   }
 
-  /// Create a new status.
+  /// Creates a new status.
   ///
   /// - Parameters:
   ///   - code: The status code.
@@ -142,7 +142,7 @@ extension Status {
     /// The numeric value of the error code.
     public var rawValue: Int { Int(self.wrapped.rawValue) }
 
-    /// Creates a status codes from its raw value.
+    /// Creates a status code from its raw value.
     ///
     /// - Parameters:
     ///   - rawValue: The numeric value to create the code from.
@@ -201,36 +201,43 @@ extension Status.Code {
   /// The operation was cancelled (typically by the caller).
   public static let cancelled = Self(code: .cancelled)
 
-  /// Unknown error. An example of where this error may be returned is if a
+  /// Unknown error.
+  ///
+  /// An example of where this error may be returned is if a
   /// Status value received from another address space belongs to an error-space
   /// that is not known in this address space. Also errors raised by APIs that
   /// do not return enough error information may be converted to this error.
   public static let unknown = Self(code: .unknown)
 
-  /// Client specified an invalid argument. Note that this differs from
+  /// Client specified an invalid argument.
+  ///
+  /// Note that this differs from
   /// ``failedPrecondition``. ``invalidArgument`` indicates arguments that are
-  /// problematic regardless of the state of the system (e.g., a malformed file
+  /// problematic regardless of the state of the system (for example, a malformed file
   /// name).
   public static let invalidArgument = Self(code: .invalidArgument)
 
-  /// Deadline expired before operation could complete. For operations that
+  /// Deadline expired before operation could complete.
+  ///
+  /// For operations that
   /// change the state of the system, this error may be returned even if the
   /// operation has completed successfully. For example, a successful response
   /// from a server could have been delayed long enough for the deadline to
   /// expire.
   public static let deadlineExceeded = Self(code: .deadlineExceeded)
 
-  /// Some requested entity (e.g., file or directory) was not found.
+  /// Some requested entity (for example, file or directory) was not found.
   public static let notFound = Self(code: .notFound)
 
-  /// Some entity that we attempted to create (e.g., file or directory) already
+  /// Some entity that we attempted to create (for example, file or directory) already
   /// exists.
   public static let alreadyExists = Self(code: .alreadyExists)
 
   /// The caller does not have permission to execute the specified operation.
+  ///
   /// ``permissionDenied`` must not be used for rejections caused by exhausting
   /// some resource (use ``resourceExhausted`` instead for those errors).
-  /// ``permissionDenied`` must not be used if the caller can not be identified
+  /// ``permissionDenied`` must not be used if the caller cannot be identified
   /// (use ``unauthenticated`` instead for those errors).
   public static let permissionDenied = Self(code: .permissionDenied)
 
@@ -239,22 +246,24 @@ extension Status.Code {
   public static let resourceExhausted = Self(code: .resourceExhausted)
 
   /// Operation was rejected because the system is not in a state required for
-  /// the operation's execution. For example, directory to be deleted may be
+  /// the operation's execution.
+  ///
+  /// For example, directory to be deleted may be
   /// non-empty, an rmdir operation is applied to a non-directory, etc.
   ///
   /// A litmus test that may help a service implementor in deciding
   /// between ``failedPrecondition``, ``aborted``, and ``unavailable``:
   /// - Use ``unavailable`` if the client can retry just the failing call.
   /// - Use ``aborted`` if the client should retry at a higher-level
-  ///   (e.g., restarting a read-modify-write sequence).
+  ///   (for example, restarting a read-modify-write sequence).
   /// - Use ``failedPrecondition`` if the client should not retry until
-  ///   the system state has been explicitly fixed. E.g., if an "rmdir"
+  ///   the system state has been explicitly fixed. For example, if an "rmdir"
   ///   fails because the directory is non-empty, ``failedPrecondition``
   ///   should be returned since the client should not retry unless
   ///   they have first fixed up the directory by deleting files from it.
   /// - Use ``failedPrecondition`` if the client performs conditional
   ///   REST Get/Update/Delete on a resource and the resource on the
-  ///   server does not match the condition. E.g., conflicting
+  ///   server does not match the condition. For example, conflicting
   ///   read-modify-write on the same resource.
   public static let failedPrecondition = Self(code: .failedPrecondition)
 
@@ -265,7 +274,9 @@ extension Status.Code {
   /// and ``unavailable``.
   public static let aborted = Self(code: .aborted)
 
-  /// Operation was attempted past the valid range. E.g., seeking or reading
+  /// Operation was attempted past the valid range.
+  ///
+  /// For example, seeking or reading
   /// past end of file.
   ///
   /// Unlike ``invalidArgument``, this error indicates a problem that may be fixed
@@ -283,11 +294,15 @@ extension Status.Code {
   /// Operation is not implemented or not supported/enabled in this service.
   public static let unimplemented = Self(code: .unimplemented)
 
-  /// Internal errors. Means some invariants expected by underlying System has
-  /// been broken. If you see one of these errors, Something is very broken.
+  /// Internal errors.
+  ///
+  /// This means some invariants expected by the underlying system have
+  /// been broken. If you see one of these errors, something is very broken.
   public static let internalError = Self(code: .internalError)
 
-  /// The service is currently unavailable. This is a most likely a transient
+  /// The service is currently unavailable.
+  ///
+  /// This is most likely a transient
   /// condition and may be corrected by retrying with a backoff.
   ///
   /// See litmus test above for deciding between ``failedPrecondition``, ``aborted``,
@@ -304,7 +319,7 @@ extension Status.Code {
 
 @available(gRPCSwift 2.0, *)
 extension Status {
-  /// Create a status from an HTTP status code for a response which didn't include a gRPC status.
+  /// Creates a status from an HTTP status code for a response that didn't include a gRPC status.
   ///
   /// - Parameter httpStatusCode: The HTTP status code to map to a status.
   public init(httpStatusCode: Int) {

--- a/Sources/GRPCCore/Streaming/RPCWriter+Closable.swift
+++ b/Sources/GRPCCore/Streaming/RPCWriter+Closable.swift
@@ -20,7 +20,7 @@ extension RPCWriter {
     @usableFromInline
     let writer: any ClosableRPCWriterProtocol<Element>
 
-    /// Creates an ``RPCWriter`` by wrapping the `other` writer.
+    /// Creates an ``RPCWriter/Closable`` by wrapping the `other` writer.
     ///
     /// - Parameter other: The writer to wrap.
     @inlinable
@@ -50,7 +50,7 @@ extension RPCWriter {
       try await self.writer.write(contentsOf: elements)
     }
 
-    /// Indicate to the writer that no more writes are to be accepted.
+    /// Indicates to the writer that no more writes are to be accepted.
     ///
     /// All writes after ``finish()`` has been called should result in an error
     /// being thrown.
@@ -59,7 +59,7 @@ extension RPCWriter {
       await self.writer.finish()
     }
 
-    /// Indicate to the writer that no more writes are to be accepted because an error occurred.
+    /// Indicates to the writer that no more writes are to be accepted because an error occurred.
     ///
     /// All writes after ``finish(throwing:)`` has been called should result in an error
     /// being thrown.

--- a/Sources/GRPCCore/Streaming/RPCWriterProtocol.swift
+++ b/Sources/GRPCCore/Streaming/RPCWriterProtocol.swift
@@ -54,13 +54,13 @@ extension RPCWriterProtocol {
 /// A type into which values can be written until it is finished.
 @available(gRPCSwift 2.0, *)
 public protocol ClosableRPCWriterProtocol<Element>: RPCWriterProtocol {
-  /// Indicate to the writer that no more writes are to be accepted.
+  /// Indicates to the writer that no more writes are to be accepted.
   ///
   /// All writes after ``finish()`` has been called should result in an error
   /// being thrown.
   func finish() async
 
-  /// Indicate to the writer that no more writes are to be accepted because an error occurred.
+  /// Indicates to the writer that no more writes are to be accepted because an error occurred.
   ///
   /// All writes after ``finish(throwing:)`` has been called should result in an error
   /// being thrown.

--- a/Sources/GRPCCore/Transport/ClientTransport.swift
+++ b/Sources/GRPCCore/Transport/ClientTransport.swift
@@ -20,9 +20,9 @@
 /// RPC can be executed. A typical transport implementation will establish and maintain connections
 /// to a server (or servers) and manage these over time, potentially closing idle connections and
 /// creating new ones on demand. As such transports can be expensive to create and as such are
-/// intended to be used as long-lived objects which exist for the lifetime of your application.
+/// intended to be used as long-lived objects that exist for the lifetime of your application.
 ///
-/// gRPC provides an in-process transport in the `GRPCInProcessTransport` module and HTTP/2
+/// gRPC provides an in-process transport in the `GRPCInProcessTransport` module and an HTTP/2
 /// transport built on top of SwiftNIO in the https://github.com/grpc/grpc-swift-nio-transport
 /// package.
 @available(gRPCSwift 2.0, *)
@@ -40,29 +40,29 @@ public protocol ClientTransport<Bytes>: Sendable {
   /// performed.
   var retryThrottle: RetryThrottle? { get }
 
-  /// Establish and maintain a connection to the remote destination.
+  /// Establishes and maintains a connection to the remote destination.
   ///
   /// Maintains a long-lived connection, or set of connections, to a remote destination.
   /// Connections may be added or removed over time as required by the implementation and the
   /// demand for streams by the client.
   ///
-  /// Implementations of this function will typically create a long-lived task group which
-  /// maintains connections. The function exits when all open streams have been closed and new connections
-  /// are no longer required by the caller who signals this by calling ``beginGracefulShutdown()``, or by cancelling the
-  /// task this function runs in.
+  /// Implementations of this function will typically create a long-lived task group that
+  /// maintains connections. The function exits either when all open streams have been closed and
+  /// new connections are no longer required by the caller — signaled by calling
+  /// ``beginGracefulShutdown()`` — or when the task this function runs in is cancelled.
   func connect() async throws
 
-  /// Signal to the transport that no new streams may be created.
+  /// Signals to the transport that no new streams may be created.
   ///
-  /// Existing streams may run to completion naturally but calling
+  /// Existing streams may run to completion naturally, but calling
   /// ``ClientTransport/withStream(descriptor:options:_:)`` should result in an ``RPCError`` with
   /// code ``RPCError/Code/failedPrecondition`` being thrown.
   ///
-  /// If you want to forcefully cancel all active streams then cancel the task
+  /// If you want to forcefully cancel all active streams, then cancel the task
   /// running ``connect()``.
   func beginGracefulShutdown()
 
-  /// Opens a stream using the transport, and uses it as input into a user-provided closure alongisde the given context.
+  /// Opens a stream using the transport, and uses it as input to a user-provided closure alongside the given context.
   ///
   /// - Important: The opened stream is closed after the closure is finished.
   ///
@@ -84,7 +84,7 @@ public protocol ClientTransport<Bytes>: Sendable {
 
   /// Returns the configuration for a given method.
   ///
-  /// - Parameter descriptor: The method to lookup configuration for.
+  /// - Parameter descriptor: The method to look up configuration for.
   /// - Returns: Configuration for the method, if it exists.
   func config(forMethod descriptor: MethodDescriptor) -> MethodConfig?
 }

--- a/Sources/GRPCCore/Transport/RPCParts.swift
+++ b/Sources/GRPCCore/Transport/RPCParts.swift
@@ -17,13 +17,15 @@
 /// Part of a request sent from a client to a server in a stream.
 @available(gRPCSwift 2.0, *)
 public enum RPCRequestPart<Bytes: GRPCContiguousBytes> {
-  /// Key-value pairs sent at the start of a request stream. Only one ``metadata(_:)`` value may
-  /// be sent to the server.
+  /// Key-value pairs sent at the start of a request stream.
+  ///
+  /// Only one ``metadata(_:)`` value may be sent to the server.
   case metadata(Metadata)
 
-  /// The bytes of a serialized message to send to the server. A stream may have any number of
-  /// messages sent on it. Restrictions for unary request or response streams are imposed at a
-  /// higher level.
+  /// The bytes of a serialized message to send to the server.
+  ///
+  /// A stream may have any number of messages sent on it. Restrictions for unary request or
+  /// response streams are imposed at a higher level.
   case message(Bytes)
 }
 
@@ -37,18 +39,21 @@ extension RPCRequestPart: Equatable where Bytes: Equatable {}
 /// Part of a response sent from a server to a client in a stream.
 @available(gRPCSwift 2.0, *)
 public enum RPCResponsePart<Bytes: GRPCContiguousBytes> {
-  /// Key-value pairs sent at the start of the response stream. At most one ``metadata(_:)`` value
-  /// may be sent to the client. If the server sends ``metadata(_:)`` it must be the first part in
-  /// the response stream.
+  /// Key-value pairs sent at the start of the response stream.
+  ///
+  /// At most one ``metadata(_:)`` value may be sent to the client. If the server sends
+  /// ``metadata(_:)``, it must be the first part in the response stream.
   case metadata(Metadata)
 
-  /// The bytes of a serialized message to send to the client. A stream may have any number of
-  /// messages sent on it. Restrictions for unary request or response streams are imposed at a
-  /// higher level.
+  /// The bytes of a serialized message to send to the client.
+  ///
+  /// A stream may have any number of messages sent on it. Restrictions for unary request or
+  /// response streams are imposed at a higher level.
   case message(Bytes)
 
-  /// A status and key-value pairs sent to the client at the end of the response stream. Every
-  /// response stream must have exactly one ``status(_:_:)`` as the final part of the request
+  /// A status and key-value pairs sent to the client at the end of the response stream.
+  ///
+  /// Every response stream must have exactly one ``status(_:_:)`` as the final part of the response
   /// stream.
   case status(Status, Metadata)
 }

--- a/Sources/GRPCCore/Transport/RetryThrottle.swift
+++ b/Sources/GRPCCore/Transport/RetryThrottle.swift
@@ -21,11 +21,11 @@ private import Synchronization
 /// gRPC prevents servers from being overloaded by retries and hedging by using a token-based
 /// throttling mechanism at the transport level.
 ///
-/// Each client transport maintains a throttle for the server it is connected to and gRPC records
+/// Each client transport maintains a throttle for the server it is connected to, and gRPC records
 /// successful and failed RPC attempts. Successful attempts increment the number of tokens
 /// by ``tokenRatio`` and failed attempts decrement the available tokens by one. In the context
 /// of throttling, a failed attempt is one where the server terminates the RPC with a status code
-/// which is retryable or non fatal (as defined by ``RetryPolicy/retryableStatusCodes`` and
+/// that is retryable or non-fatal (as defined by ``RetryPolicy/retryableStatusCodes`` and
 /// ``HedgingPolicy/nonFatalStatusCodes``) or when the client receives a pushback response from
 /// the server.
 ///
@@ -49,11 +49,11 @@ public final class RetryThrottle: Sendable {
   /// Returns the throttling token ratio.
   ///
   /// The number of tokens held by the throttle is incremented by this value for each successful
-  /// response. In the context of throttling, a successful response is one which:
+  /// response. In the context of throttling, a successful response is one that:
   /// - receives metadata from the server, or
   /// - is terminated with a non-retryable or fatal status code.
   ///
-  /// If the response is a pushback response then it is not considered to be successful, even if
+  /// If the response is a pushback response, then it is not considered to be successful, even if
   /// either of the preceding conditions are met.
   public var tokenRatio: Double {
     Double(self.scaledTokenRatio) / 1000
@@ -66,7 +66,7 @@ public final class RetryThrottle: Sendable {
 
   /// The number of tokens the throttle currently has.
   ///
-  /// If this value is less than or equal to the retry threshold (defined as `maxTokens / 2`)
+  /// If this value is less than or equal to the retry threshold (defined as `maxTokens / 2`),
   /// then RPCs will not be retried and hedging will be disabled.
   public var tokens: Double {
     self.scaledTokensAvailable.withLock {
@@ -81,7 +81,7 @@ public final class RetryThrottle: Sendable {
     }
   }
 
-  /// Create a new throttle.
+  /// Creates a new throttle.
   ///
   /// - Parameters:
   ///   - maxTokens: The maximum number of tokens available. Must be in the range `1...1000`.
@@ -106,7 +106,7 @@ public final class RetryThrottle: Sendable {
     self.scaledTokensAvailable = Mutex(scaledTokens)
   }
 
-  /// Create a new throttle.
+  /// Creates a new throttle.
   ///
   /// - Parameter policy: The policy to use to configure the throttle.
   public convenience init(policy: ServiceConfig.RetryThrottling) {

--- a/Sources/GRPCCore/Transport/ServerTransport.swift
+++ b/Sources/GRPCCore/Transport/ServerTransport.swift
@@ -17,9 +17,9 @@
 /// A type that provides a bidirectional communication channel with a client.
 ///
 /// The server transport is responsible for handling connections created by a client and
-/// the multiplexing of those connections into streams corresponding to RPCs.
+/// multiplexing those connections into streams corresponding to RPCs.
 ///
-/// gRPC provides an in-process transport in the `GRPCInProcessTransport` module and HTTP/2
+/// gRPC provides an in-process transport in the `GRPCInProcessTransport` module and an HTTP/2
 /// transport built on top of SwiftNIO in the https://github.com/grpc/grpc-swift-nio-transport
 /// package.
 @available(gRPCSwift 2.0, *)

--- a/Sources/GRPCInProcessTransport/Documentation.docc/Documentation.md
+++ b/Sources/GRPCInProcessTransport/Documentation.docc/Documentation.md
@@ -10,8 +10,22 @@ use cases.
 
 ## Topics
 
-### Transports
+### Transport pair
 
 - ``InProcessTransport``
+- ``InProcessTransport/init(serviceConfig:)``
+
+### Client transport
+
 - ``InProcessTransport/Client``
+- ``InProcessTransport/Client/connect()``
+- ``InProcessTransport/Client/withStream(descriptor:options:_:)``
+- ``InProcessTransport/Client/beginGracefulShutdown()``
+- ``InProcessTransport/Client/config(forMethod:)``
+- ``InProcessTransport/Client/retryThrottle``
+
+### Server transport
+
 - ``InProcessTransport/Server``
+- ``InProcessTransport/Server/listen(streamHandler:)``
+- ``InProcessTransport/Server/beginGracefulShutdown()``

--- a/Sources/GRPCInProcessTransport/InProcessTransport+Client.swift
+++ b/Sources/GRPCInProcessTransport/InProcessTransport+Client.swift
@@ -28,7 +28,7 @@ extension InProcessTransport {
   /// as a `ServiceConfig`.
   ///
   /// Once you have a client, you must keep a long-running task executing ``connect()``, which
-  /// will return only once all streams have been finished and ``beginGracefulShutdown()`` has been called on this client; or
+  /// will return only once all streams have been finished and ``beginGracefulShutdown()`` has been called on this client, or
   /// when the containing task is cancelled.
   ///
   /// To execute requests using this client, use ``withStream(descriptor:options:_:)``. If this function is
@@ -129,16 +129,16 @@ extension InProcessTransport {
       self.peer = peer
     }
 
-    /// Establish and maintain a connection to the remote destination.
+    /// Establishes and maintains a connection to the remote destination.
     ///
     /// Maintains a long-lived connection, or set of connections, to a remote destination.
     /// Connections may be added or removed over time as required by the implementation and the
     /// demand for streams by the client.
     ///
-    /// Implementations of this function will typically create a long-lived task group which
-    /// maintains connections. The function exits when all open streams have been closed and new connections
-    /// are no longer required by the caller who signals this by calling ``beginGracefulShutdown()``, or by cancelling the
-    /// task this function runs in.
+    /// Implementations of this function will typically create a long-lived task group that
+    /// maintains connections. The function exits either when all open streams have been closed
+    /// and new connections are no longer required by the caller — signaled by calling
+    /// ``beginGracefulShutdown()`` — or when the task this function runs in is cancelled.
     public func connect() async throws {
       let (stream, continuation) = AsyncStream<Void>.makeStream()
       try self.state.withLock { state in
@@ -195,12 +195,12 @@ extension InProcessTransport {
       }
     }
 
-    /// Signal to the transport that no new streams may be created.
+    /// Signals to the transport that no new streams may be created.
     ///
-    /// Existing streams may run to completion naturally but calling ``withStream(descriptor:options:_:)``
+    /// Existing streams may run to completion naturally, but calling ``withStream(descriptor:options:_:)``
     /// will result in an `RPCError` with code `RPCError/Code/failedPrecondition` being thrown.
     ///
-    /// If you want to forcefully cancel all active streams then cancel the task running ``connect()``.
+    /// If you want to forcefully cancel all active streams, then cancel the task running ``connect()``.
     public func beginGracefulShutdown() {
       let maybeContinuation: AsyncStream<Void>.Continuation? = self.state.withLock { state in
         switch state {
@@ -222,7 +222,7 @@ extension InProcessTransport {
       maybeContinuation?.finish()
     }
 
-    /// Opens a stream using the transport, and uses it as input into a user-provided closure.
+    /// Opens a stream using the transport, and uses it as input to a user-provided closure alongside the given context.
     ///
     /// - Important: The opened stream is closed after the closure is finished.
     ///
@@ -230,7 +230,7 @@ extension InProcessTransport {
     /// is closing or has been closed.
     ///
     ///   This implementation will queue any streams (and thus block this call) if this function is called before
-    ///   ``connect()``, until a connection is established - at which point all streams will be
+    ///   ``connect()``, until a connection is established — at which point all streams will be
     ///   created.
     ///
     /// - Parameters:
@@ -363,7 +363,7 @@ extension InProcessTransport {
 
     /// Returns the execution configuration for a given method.
     ///
-    /// - Parameter descriptor: The method to lookup configuration for.
+    /// - Parameter descriptor: The method to look up configuration for.
     /// - Returns: Execution configuration for the method, if it exists.
     public func config(
       forMethod descriptor: MethodDescriptor

--- a/Sources/GRPCInProcessTransport/InProcessTransport+Client.swift
+++ b/Sources/GRPCInProcessTransport/InProcessTransport+Client.swift
@@ -37,6 +37,7 @@ extension InProcessTransport {
   ///
   /// - SeeAlso: `ClientTransport`
   public final class Client: ClientTransport {
+    /// The type of bytes this client sends and receives, represented as an array of bytes.
     public typealias Bytes = [UInt8]
 
     private enum State: Sendable {
@@ -101,6 +102,10 @@ extension InProcessTransport {
       case closed(ClosedState)
     }
 
+    /// The retry throttle configuration.
+    ///
+    /// This is derived from the `ServiceConfig` passed to the transport's initializer; it's
+    /// `nil` if the service config doesn't specify a retry-throttling policy.
     public let retryThrottle: RetryThrottle?
 
     private let methodConfig: MethodConfigs

--- a/Sources/GRPCInProcessTransport/InProcessTransport+Server.swift
+++ b/Sources/GRPCInProcessTransport/InProcessTransport+Server.swift
@@ -28,7 +28,7 @@ extension InProcessTransport {
   /// RPC requests made from clients (as `RPCStream`s).
   /// To stop listening to new requests, call ``beginGracefulShutdown()``.
   ///
-  /// - SeeAlso: `ClientTransport`
+  /// - SeeAlso: `ServerTransport`
   public final class Server: ServerTransport, Sendable {
     /// The type of bytes this server sends and receives, represented as an array of bytes.
     public typealias Bytes = [UInt8]
@@ -148,7 +148,7 @@ extension InProcessTransport {
       }
     }
 
-    /// Stop listening to any new `RPCStream` publications.
+    /// Stops listening to any new `RPCStream` publications.
     ///
     /// - SeeAlso: `ServerTransport`
     public func beginGracefulShutdown() {

--- a/Sources/GRPCInProcessTransport/InProcessTransport+Server.swift
+++ b/Sources/GRPCInProcessTransport/InProcessTransport+Server.swift
@@ -30,9 +30,12 @@ extension InProcessTransport {
   ///
   /// - SeeAlso: `ClientTransport`
   public final class Server: ServerTransport, Sendable {
+    /// The type of bytes this server sends and receives, represented as an array of bytes.
     public typealias Bytes = [UInt8]
 
+    /// The stream of inbound requests this server receives.
     public typealias Inbound = RPCAsyncSequence<RPCRequestPart<Bytes>, any Error>
+    /// The writer this server uses to send outbound responses.
     public typealias Outbound = RPCWriter<RPCResponsePart<Bytes>>.Closable
 
     private let newStreams: AsyncStream<RPCStream<Inbound, Outbound>>
@@ -102,6 +105,14 @@ extension InProcessTransport {
       }
     }
 
+    /// Starts the server, listening for new streams opened by an in-process client.
+    ///
+    /// This function returns only once ``beginGracefulShutdown()`` has been called and every
+    /// in-flight stream has finished, or when the calling task is cancelled. Call this from a
+    /// long-running task, typically inside a task group alongside the client's `connect()`.
+    ///
+    /// - Parameter streamHandler: A closure invoked with each new `RPCStream` and its
+    ///   `ServerContext`, responsible for handling the RPC.
     public func listen(
       streamHandler:
         @escaping @Sendable (

--- a/Sources/GRPCInProcessTransport/InProcessTransport.swift
+++ b/Sources/GRPCInProcessTransport/InProcessTransport.swift
@@ -18,7 +18,14 @@ public import GRPCCore
 
 @available(gRPCSwift 2.0, *)
 public struct InProcessTransport: Sendable {
+  /// The server side of this transport pairing.
+  ///
+  /// Pass this to a `GRPCServer` to accept RPCs made via ``client``.
   public let server: Self.Server
+
+  /// The client side of this transport pairing.
+  ///
+  /// Pass this to a `GRPCClient` to make RPCs that ``server`` handles.
   public let client: Self.Client
 
   /// Initializes a new ``InProcessTransport`` pairing a ``Client`` and a ``Server``.


### PR DESCRIPTION
- fixes typos, grammar issues, and mis-linking the current repo
- adds DocC curation (organization) for types to cover all the current public API
- Adds missing curation and abstracts in GRPCInProcessTransport
- Adding notes into types to provide clarity missing from the docs (mined from questions about the API that I found in public forums)