### PR TITLE
Fix outdated links in documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -17,7 +17,7 @@ For troubleshooting or new feature requests please use one of the other template
 Describe the bug as clearly and as concisely as you can. Without enough
 information, we will not be able to help you.
 
-Include the version of `grpc-swift` and `protoc-gen-grpc-swift` you are using
+Include the version of `grpc-swift-2` and `protoc-gen-grpc-swift-2` you are using
 (or the Podspec version if you are using CocoaPods), how you are building the
 code (eg. `swift build -c release`) as well as the platform(s) on which you
 experienced the bug.

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ DerivedData/
 .swiftpm
 build
 /protoc-gen-swift
-/protoc-gen-grpc-swift
+/protoc-gen-grpc-swift-2
 third_party/**
 /Echo
 /EchoNIO

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ DerivedData/
 .swiftpm
 build
 /protoc-gen-swift
-/protoc-gen-grpc-swift-2
+/protoc-gen-grpc-swift
 third_party/**
 /Echo
 /EchoNIO

--- a/Examples/route-guide/README.md
+++ b/Examples/route-guide/README.md
@@ -13,7 +13,7 @@ The tool uses the [SwiftNIO](https://github.com/grpc/grpc-swift-nio-transport)
 HTTP/2 transport.
 
 This example has an accompanying tutorial hosted on the [Swift Package
-Index](https://swiftpackageindex.com/grpc/grpc-swift/main/tutorials/grpccore/route-guide).
+Index](https://swiftpackageindex.com/grpc/grpc-swift-2/main/tutorials/grpccore/route-guide).
 
 ## Usage
 

--- a/Package.swift
+++ b/Package.swift
@@ -108,7 +108,7 @@ let targets: [Target] = [
     swiftSettings: defaultSwiftSettings
   ),
 
-  // Code generator library for protoc-gen-grpc-swift
+  // Code generator library for protoc-gen-grpc-swift-2
   .target(
     name: "GRPCCodeGen",
     dependencies: [],

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository contains a gRPC implementation for Swift. You can read more
 about gRPC on the [gRPC project's website][grpcio].
 
-- 📚 **Documentation** and **tutorials** are available on the [Swift Package Index][spi-grpc-swift].
+- 📚 **Documentation** and **tutorials** are available on the [Swift Package Index][spi-grpc-swift-2].
 - 💻 **Examples** are available in the [Examples](Examples) directory.
 - 🚀 **Contributions** are welcome; please see [CONTRIBUTING.md](CONTRIBUTING.md).
 - 🪪 **License** is Apache 2.0; see [LICENSE](LICENSE) for the full text.
@@ -50,7 +50,7 @@ let package = Package(
 
 [gh-grpc]: https://github.com/grpc/grpc
 [grpcio]: https://grpc.io
-[spi-grpc-swift]: https://swiftpackageindex.com/grpc/grpc-swift-2/documentation
+[spi-grpc-swift-2]: https://swiftpackageindex.com/grpc/grpc-swift-2/documentation
 [grpc-swift-nio-transport]: https://github.com/grpc/grpc-swift-nio-transport
 [grpc-swift-protobuf]: https://github.com/grpc/grpc-swift-protobuf
 [grpc-swift-extras]: https://github.com/grpc/grpc-swift-extras

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,7 +39,7 @@ with the [details usually included with bug reports][issue-template].
   and the [SSWG][sswg] will announce the vulnerability on the [Swift
   forums][swift-forums-sec].
 
-[issue-template]: https://github.com/grpc/grpc-swift/blob/main/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+[issue-template]: https://github.com/grpc/grpc-swift-2/blob/main/.github/ISSUE_TEMPLATE/BUG_REPORT.md
 [sswg]: https://github.com/swift-server/sswg
 [sswg-security]: https://github.com/swift-server/sswg/blob/main/process/incubation.md#security-best-practices
 [swift-forums-sec]: https://forums.swift.org/c/server/security-updates/

--- a/Sources/GRPCCore/Documentation.docc/Articles/Compatibility.md
+++ b/Sources/GRPCCore/Documentation.docc/Articles/Compatibility.md
@@ -10,9 +10,9 @@ over time.
 gRPC Swift supports the **three most recent Swift versions** that are **Swift 6
 or newer**. Within a minor Swift release, only the latest patch version is supported.
 
-| grpc-swift | Minimum Supported Swift version |
-|------------|---------------------------------|
-| 2.0        | 6.0                             |
+| grpc-swift-2 | Minimum Supported Swift version |
+|--------------|---------------------------------|
+| 2.0          | 6.0                             |
 
 ### Platforms
 

--- a/Sources/GRPCCore/Documentation.docc/Articles/Migration-guide.md
+++ b/Sources/GRPCCore/Documentation.docc/Articles/Migration-guide.md
@@ -492,7 +492,5 @@ If there were any parts of this guide you felt were unclear or didn't cover enou
 of the migration, then please file an issue on GitHub so that we can work on improving
 it.
 
-[0]: https://github.com/grpc/grpc-swift-2/tree/main
-[1]: https://github.com/grpc/grpc-swift/tree/release/1.x
 [2]: https://swiftpackageindex.com/grpc/grpc-swift-protobuf/documentation
 [3]: https://swiftpackageindex.com/grpc/grpc-swift-protobuf/documentation/grpcprotobuf/generating-stubs

--- a/Sources/GRPCCore/Documentation.docc/Development/Benchmarks.md
+++ b/Sources/GRPCCore/Documentation.docc/Development/Benchmarks.md
@@ -1,6 +1,6 @@
 # Benchmarks
 
-This article discusses benchmarking in `grpc-swift`.
+This article discusses benchmarking in `grpc-swift-2`.
 
 ## Overview
 

--- a/Sources/GRPCCore/Documentation.docc/Documentation.md
+++ b/Sources/GRPCCore/Documentation.docc/Documentation.md
@@ -8,7 +8,7 @@ A gRPC library for Swift written natively in Swift.
 
 gRPC Swift spans multiple Swift packages:
 
-- `grpc-swift` (this package) containing core gRPC abstractions and an in-process transport.
+- `grpc-swift-2` (this package) containing core gRPC abstractions and an in-process transport.
   - GitHub repository: [`grpc/grpc-swift-2`](https://github.com/grpc/grpc-swift-2)
   - Documentation: hosted on the [Swift Package
     Index](https://swiftpackageindex.com/grpc/grpc-swift-2/documentation)

--- a/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Route-Guide.tutorial
+++ b/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Route-Guide.tutorial
@@ -310,7 +310,7 @@
     @Steps {
       @Step {
         First we need to download a database of known features for the service. Copy
-        `route_guide_db.json` from the [gRPC Swift repository](https://github.com/grpc/grpc-swift/tree/main/Examples/route-guide)
+        `route_guide_db.json` from the [gRPC Swift repository](https://github.com/grpc/grpc-swift-2/tree/main/Examples/route-guide)
         and place it in the `Sources` directory.
       }
 

--- a/dev/v1-to-v2/v1_to_v2.sh
+++ b/dev/v1-to-v2/v1_to_v2.sh
@@ -32,7 +32,7 @@ function checkout_v1 {
   log "Cloning grpc-swift to ${grpc_checkout_path}"
   git clone \
     --quiet \
-    https://github.com/grpc/grpc-swift-2.git \
+    https://github.com/grpc/grpc-swift.git \
     "${grpc_checkout_path}"
 
   # Get the latest version of 1.x.y.


### PR DESCRIPTION
There were a few outdated links from when this project was the same repo as `grpc/grpc-swift`. 
Hopefully the search was thorough, used the following regexp: `"grpc-swift(?!-)"`.

I was unsure about the first sentence in https://github.com/grpc/grpc-swift-2/blob/main/CONTRIBUTING.md - I left it as "grpc-swift" since it's written in clear-text, and I take it to refer to the entire "project" rather than this repo, specifically.