### PR TITLE
Doc updates

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -2,8 +2,6 @@ version: 1
 builder:
   configs:
     - documentation_targets: [GRPCCore, GRPCCodeGen]
-      swift_version: 6.0
     - documentation_targets: [GRPCInProcessTransport]
-      swift_version: 6.0
       # Don't include @_exported types from GRPCCore
       custom_documentation_parameters: [--exclude-extended-types]

--- a/Examples/echo-metadata/README.md
+++ b/Examples/echo-metadata/README.md
@@ -2,7 +2,7 @@
 
 This example demonstrates how to interact with `Metadata` on RPCs: how to set and read it on unary 
 and streaming requests, as well as how to set and read both initial and trailing metadata on unary 
-and streaming responses. This is done using a simple `echo` server and client, and the SwiftNIO-based 
+and streaming responses. This example does this using a simple `echo` server and client, and the SwiftNIO-based 
 HTTP/2 transport.
 
 ## Overview
@@ -15,7 +15,7 @@ provided `message` as both the request’s message and as the value for the `ech
 the request’s metadata.
 
 The server will then echo back the message and the metadata’s `echo-message` key-value pair sent
-by the client. The request’s metadata will be echoed in both the initial and the trailing metadata.
+by the client. The server will echo the request’s metadata in both the initial and the trailing metadata.
 
 The tool uses the [SwiftNIO](https://github.com/grpc/grpc-swift-nio-transport) HTTP/2 transport.
 

--- a/Examples/error-details/README.md
+++ b/Examples/error-details/README.md
@@ -4,11 +4,11 @@ This example demonstrates how to create and unpack detailed errors.
 
 ## Overview
 
-A command line tool that demonstrates how a detailed error can be thrown by a
-service and unpacked and inspected by a client. The detailed error model is
-described in more detail in the [gRPC Error
-Guide](https://grpc.io/docs/guides/error/) and is made available via the
-[grpc-swift-protobuf](https://github.com/grpc-swift-protobuf) package.
+A command line tool that demonstrates how a service can throw a detailed error
+and how a client can unpack and inspect it. The [gRPC Error
+Guide](https://grpc.io/docs/guides/error/) describes the detailed error model in more
+detail, and the [grpc-swift-protobuf](https://github.com/grpc-swift-protobuf) package
+makes it available.
 
 ## Usage
 

--- a/Examples/reflection-server/README.md
+++ b/Examples/reflection-server/README.md
@@ -1,7 +1,7 @@
 # Reflection Server
 
-This example demonstrates the gRPC Reflection service, which is described in more
-detail in the [gRPC documentation](https://github.com/grpc/grpc/blob/6fa8043bf9befb070b846993b59a3348248e6566/doc/server-reflection.md).
+This example demonstrates the gRPC Reflection service; the [gRPC documentation](https://github.com/grpc/grpc/blob/6fa8043bf9befb070b846993b59a3348248e6566/doc/server-reflection.md)
+describes it in more detail.
 
 ## Overview
 

--- a/Examples/service-lifecycle/README.md
+++ b/Examples/service-lifecycle/README.md
@@ -1,7 +1,7 @@
 # Service Lifecycle
 
 This example demonstrates gRPC Swift’s integration with Swift Service Lifecycle,
-which is provided by the gRPC Swift Extras package.
+which the gRPC Swift Extras package provides.
 
 ## Overview
 

--- a/Package.swift
+++ b/Package.swift
@@ -45,6 +45,12 @@ let dependencies: [Package.Dependency] = [
     from: "1.31.0",
     traits: []
   ),
+
+  // Documentation preview/generation:
+  .package(
+    url: "https://github.com/swiftlang/swift-docc-plugin.git",
+    from: "1.4.0"
+  ),
 ]
 
 // -------------------------------------------------------------------------------------------------

--- a/Package.swift
+++ b/Package.swift
@@ -45,12 +45,6 @@ let dependencies: [Package.Dependency] = [
     from: "1.31.0",
     traits: []
   ),
-
-  // Documentation preview/generation:
-  .package(
-    url: "https://github.com/swiftlang/swift-docc-plugin.git",
-    from: "1.4.0"
-  ),
 ]
 
 // -------------------------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ about gRPC on the [gRPC project's website][grpcio].
 - 💻 **Examples** are available in the [Examples](Examples) directory.
 - 🚀 **Contributions** are welcome; please see [CONTRIBUTING.md](CONTRIBUTING.md).
 - 🪪 **License** is Apache 2.0; see [LICENSE](LICENSE) for the full text.
-- 🔒 **Security** issues should be reported via the process in [SECURITY.md](SECURITY.md).
+- 🔒 **Security**: report issues using the process in [SECURITY.md](SECURITY.md).
 - 🔀 **Related Repositories**:
   - [`grpc-swift-nio-transport`][grpc-swift-nio-transport] contains
     high-performance HTTP/2 client and server transport implementations for gRPC

--- a/Sources/GRPCCodeGen/CodeGenError.swift
+++ b/Sources/GRPCCodeGen/CodeGenError.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-/// An error thrown by the ``SourceGenerator`` to signal errors in the ``CodeGenerationRequest`` object.
+/// ``SourceGenerator`` throws this error to signal errors in the ``CodeGenerationRequest`` object.
 @available(gRPCSwift 2.0, *)
 public struct CodeGenError: Error, Hashable, Sendable {
   /// The code indicating the domain of the error.
@@ -48,17 +48,17 @@ extension CodeGenError {
       self.value = value
     }
 
-    /// The same name is used for two services that either are in the same namespace or don't have a namespace.
+    /// Two services that are either in the same namespace or don't have a namespace use the same name.
     public static var nonUniqueServiceName: Self {
       Self(.nonUniqueServiceName)
     }
 
-    /// The same name is used for two methods of the same service.
+    /// Two methods of the same service use the same name.
     public static var nonUniqueMethodName: Self {
       Self(.nonUniqueMethodName)
     }
 
-    /// An invalid kind name is used for an import.
+    /// An import uses an invalid kind name.
     public static var invalidKind: Self {
       Self(.invalidKind)
     }

--- a/Sources/GRPCCodeGen/CodeGenerationRequest.swift
+++ b/Sources/GRPCCodeGen/CodeGenerationRequest.swift
@@ -409,8 +409,8 @@ public struct ServiceName: Hashable, Sendable {
 
   /// The name as used on types, including any namespace.
   ///
-  /// Generated code uses this to generate a namespace for each service, which contains a number
-  /// of client and server protocols and concrete types.
+  /// The code generator uses this to generate a namespace for each service, which contains a
+  /// number of client and server protocols and concrete types.
   ///
   /// If you declare the service in package "foo.bar" and call it "Baz", then this
   /// value should be "Foo\_Bar\_Baz".
@@ -418,7 +418,8 @@ public struct ServiceName: Hashable, Sendable {
 
   /// The name as used as a property.
   ///
-  /// Generated code uses this to provide a convenience getter for a descriptor of the service.
+  /// The code generator uses this to provide a convenience getter for a descriptor of the
+  /// service.
   ///
   /// If you declare the service in package "foo.bar" and call it "Baz", then this
   /// value should be "foo\_bar\_Baz".
@@ -443,7 +444,7 @@ public struct MethodName: Hashable, Sendable {
 
   /// The name as used on types, including any namespace.
   ///
-  /// Generated code uses this to generate a namespace for each method, which contains
+  /// The code generator uses this to generate a namespace for each method, which contains
   /// information about the method.
   ///
   /// This value typically starts with an uppercase character, for example "Get".

--- a/Sources/GRPCCodeGen/CodeGenerationRequest.swift
+++ b/Sources/GRPCCodeGen/CodeGenerationRequest.swift
@@ -23,14 +23,14 @@ public struct CodeGenerationRequest {
 
   /// Any comments at the top of the file such as documentation and copyright headers.
   ///
-  /// They will be placed at the top of the generated file. They are already formatted,
-  /// meaning they contain "///" and new lines.
+  /// The code generator places them at the top of the generated file. They are already
+  /// formatted, meaning they contain "///" and new lines.
   public var leadingTrivia: String
 
   /// The Swift imports that the generated file depends on.
   ///
-  /// The gRPC-specific imports aren't required as they will be added by default in the generated
-  /// file.
+  /// The gRPC-specific imports aren't required because the code generator adds them by default
+  /// in the generated file.
   ///
   /// - SeeAlso: ``Dependency``.
   public var dependencies: [Dependency]
@@ -43,8 +43,8 @@ public struct CodeGenerationRequest {
   /// Closure that receives a message type as a `String` and returns a code snippet to
   /// initialize a `MessageSerializer` for that type as a `String`.
   ///
-  /// The result is inserted in the generated code, where clients serialize RPC inputs and
-  /// servers serialize RPC outputs.
+  /// The code generator inserts the result into the generated code, where clients serialize
+  /// RPC inputs and servers serialize RPC outputs.
   ///
   /// For example, to serialize Protobuf messages you could specify a serializer as:
   /// ```swift
@@ -57,8 +57,8 @@ public struct CodeGenerationRequest {
   /// Closure that receives a message type as a `String` and returns a code snippet to
   /// initialize a `MessageDeserializer` for that type as a `String`.
   ///
-  /// The result is inserted in the generated code, where clients deserialize RPC outputs and
-  /// servers deserialize RPC inputs.
+  /// The code generator inserts the result into the generated code, where clients deserialize
+  /// RPC outputs and servers deserialize RPC inputs.
   ///
   /// For example, to deserialize Protobuf messages you could specify a deserializer as:
   /// ```swift
@@ -135,10 +135,10 @@ public struct Dependency: Equatable, Sendable {
   /// If the dependency is a module, this property is nil.
   public var item: Item?
 
-  /// The access level to be included in imports of this dependency.
+  /// The access level to include in imports of this dependency.
   public var accessLevel: CodeGenerator.Config.AccessLevel
 
-  /// The name of the imported module or of the module an item is imported from.
+  /// The name of the imported module, or of the module that an item comes from.
   public var module: String
 
   /// The name of the private interface for an `@_spi` import.
@@ -400,27 +400,27 @@ extension MethodDescriptor {
 public struct ServiceName: Hashable, Sendable {
   /// The identifying name as used in the service/method descriptors, including any namespace.
   ///
-  /// This value is also used to identify the service to the remote peer, usually as part of the
-  /// ":path" pseudoheader if doing gRPC over HTTP/2.
+  /// Generated code also uses this value to identify the service to the remote peer, usually as
+  /// part of the ":path" pseudoheader if doing gRPC over HTTP/2.
   ///
-  /// If the service is declared in package "foo.bar" and the service is called "Baz" then this
+  /// If you declare the service in package "foo.bar" and call it "Baz", then this
   /// value should be "foo.bar.Baz".
   public var identifyingName: String
 
   /// The name as used on types, including any namespace.
   ///
-  /// This is used to generate a namespace for each service which contains a number of client and
-  /// server protocols and concrete types.
+  /// Generated code uses this to generate a namespace for each service, which contains a number
+  /// of client and server protocols and concrete types.
   ///
-  /// If the service is declared in package "foo.bar" and the service is called "Baz", then this
+  /// If you declare the service in package "foo.bar" and call it "Baz", then this
   /// value should be "Foo\_Bar\_Baz".
   public var typeName: String
 
   /// The name as used as a property.
   ///
-  /// This is used to provide a convenience getter for a descriptor of the service.
+  /// Generated code uses this to provide a convenience getter for a descriptor of the service.
   ///
-  /// If the service is declared in package "foo.bar" and the service is called "Baz", then this
+  /// If you declare the service in package "foo.bar" and call it "Baz", then this
   /// value should be "foo\_bar\_Baz".
   public var propertyName: String
 
@@ -435,16 +435,16 @@ public struct ServiceName: Hashable, Sendable {
 public struct MethodName: Hashable, Sendable {
   /// The identifying name as used in the service/method descriptors.
   ///
-  /// This value is also used to identify the method to the remote peer, usually as part of the
-  /// ":path" pseudoheader if doing gRPC over HTTP/2.
+  /// Generated code also uses this value to identify the method to the remote peer, usually as
+  /// part of the ":path" pseudoheader if doing gRPC over HTTP/2.
   ///
   /// This value typically starts with an uppercase character, for example "Get".
   public var identifyingName: String
 
   /// The name as used on types, including any namespace.
   ///
-  /// This is used to generate a namespace for each method which contains information about
-  /// the method.
+  /// Generated code uses this to generate a namespace for each method, which contains
+  /// information about the method.
   ///
   /// This value typically starts with an uppercase character, for example "Get".
   public var typeName: String
@@ -468,20 +468,20 @@ public struct Name: Hashable, Sendable {
   /// The base name is the name used for the namespace/service/method in the IDL file, so it should follow
   /// the specific casing of the IDL.
   ///
-  /// The base name is also used in the descriptors that identify a specific method or service:
+  /// Descriptors that identify a specific method or service also use the base name:
   /// `<service_namespace_baseName>.<service_baseName>.<method_baseName>`.
   public var base: String
 
-  /// The `generatedUpperCase` name is used in the generated code.
+  /// Generated code uses the `generatedUpperCase` name.
   ///
-  /// It is expected to be the UpperCamelCase version of the base name.
+  /// It should be the UpperCamelCase version of the base name.
   ///
   /// For example, if `base` is "fooBar", then `generatedUpperCase` is "FooBar".
   public var generatedUpperCase: String
 
-  /// The `generatedLowerCase` name is used in the generated code.
+  /// Generated code uses the `generatedLowerCase` name.
   ///
-  /// It is expected to be the lowerCamelCase version of the base name.
+  /// It should be the lowerCamelCase version of the base name.
   ///
   /// For example, if `base` is "FooBar", then `generatedLowerCase` is "fooBar".
   public var generatedLowerCase: String

--- a/Sources/GRPCCodeGen/CodeGenerator.swift
+++ b/Sources/GRPCCodeGen/CodeGenerator.swift
@@ -38,9 +38,9 @@ public struct CodeGenerator: Sendable {
     public var accessLevelOnImports: Bool
     /// The indentation of the generated code as the number of spaces.
     public var indentation: Int
-    /// Whether or not client code should be generated.
+    /// Whether to generate client code.
     public var client: Bool
-    /// Whether or not server code should be generated.
+    /// Whether to generate server code.
     public var server: Bool
     /// The name of the core gRPC module.
     public var grpcCoreModuleName: String
@@ -52,8 +52,8 @@ public struct CodeGenerator: Sendable {
     /// - Parameters:
     ///   - accessLevel: The access level the generated code will have.
     ///   - accessLevelOnImports: Whether imports have explicit access levels.
-    ///   - client: Whether or not client code should be generated.
-    ///   - server: Whether or not server code should be generated.
+    ///   - client: Whether to generate client code.
+    ///   - server: Whether to generate server code.
     ///   - indentation: The indentation of the generated code as the number of spaces.
     public init(
       accessLevel: AccessLevel,

--- a/Sources/GRPCCodeGen/Documentation.docc/Documentation.md
+++ b/Sources/GRPCCodeGen/Documentation.docc/Documentation.md
@@ -4,13 +4,13 @@ Transport-agnostic Swift source generation for gRPC services.
 
 ## Overview
 
-``GRPCCodeGen`` generates Swift client and server code for RPC services described by a
-language-neutral intermediate representation. It builds a structured Swift representation of
+``GRPCCodeGen`` generates Swift client and server code for RPC services that a
+language-neutral intermediate representation describes. It builds a structured Swift representation of
 the generated code and renders that representation to text; it doesn't itself parse any
 interface definition language (IDL), such as Protocol Buffers.
 
 Consumers construct a ``CodeGenerationRequest`` describing the services, methods, and
-dependencies parsed from an IDL file, and pass it to ``CodeGenerator/generate(_:)`` to produce
+dependencies that they parse from an IDL file, and pass it to ``CodeGenerator/generate(_:)`` to produce
 a ``SourceFile`` containing the generated Swift source. For example, `protoc-gen-grpc-swift-2`
 in [`grpc-swift-protobuf`](https://github.com/grpc/grpc-swift-protobuf) parses `.proto` files
 and uses this module to generate the corresponding Swift source.

--- a/Sources/GRPCCodeGen/Internal/Renderer/TextBasedRenderer.swift
+++ b/Sources/GRPCCodeGen/Internal/Renderer/TextBasedRenderer.swift
@@ -43,7 +43,7 @@ final class StringCodeWriter {
   internal let indentation: Int
 
   /// Whether the next call to `writeLine` will continue writing to the last
-  /// stored line. Otherwise a new line is appended.
+  /// stored line. Otherwise, `writeLine` appends a new line.
   private var nextWriteAppendsToLastLine: Bool = false
 
   /// Creates a new empty writer.
@@ -59,7 +59,7 @@ final class StringCodeWriter {
 
   /// Writes a line of code.
   ///
-  /// By default, a new line is appended to the file.
+  /// By default, this method appends a new line to the file.
   ///
   /// To continue the last line, make a call to `nextLineAppendsToLastLine`
   /// before calling `writeLine`.
@@ -102,7 +102,7 @@ final class StringCodeWriter {
   /// Sets a flag on the writer so that the next call to `writeLine` continues
   /// the last stored line instead of starting a new line.
   ///
-  /// Safe to call repeatedly, it gets reset by `writeLine`.
+  /// Safe to call repeatedly; `writeLine` resets the flag.
   func nextLineAppendsToLastLine() { nextWriteAppendsToLastLine = true }
 }
 
@@ -1184,8 +1184,7 @@ extension Array {
 }
 
 extension Array where Element == String {
-  /// Returns a string where the elements of the array are joined
-  /// by a space character.
+  /// Returns a string that joins the array's elements with a space character.
   /// - Returns: A string with the elements of the array joined by space characters.
   fileprivate func joinedWords() -> String { joined(separator: " ") }
 }
@@ -1202,7 +1201,7 @@ extension String {
   /// Returns a new string where the provided closure transforms each line.
   /// The closure takes a string representing one line as a parameter.
   /// - Parameter work: The closure that transforms each line.
-  /// - Returns: A new string where each line has been transformed using the given closure.
+  /// - Returns: A new string where the given closure transformed each line.
   fileprivate func transformingLines(_ work: (String, Bool) -> String?) -> [String] {
     asLines().enumeratedWithLastMarker().compactMap(work)
   }

--- a/Sources/GRPCCodeGen/Internal/StructuredSwift+Client.swift
+++ b/Sources/GRPCCodeGen/Internal/StructuredSwift+Client.swift
@@ -782,9 +782,9 @@ private func docs(
 
   let otherParameters = """
     ///   - options: Options to apply to this RPC.
-    ///   - handleResponse: A closure which handles the response, the result of which is
-    ///       returned to the caller. Returning from the closure will cancel the RPC if it
-    ///       hasn't already finished.
+    ///   - handleResponse: A closure which handles the response and returns its result to
+    ///       the caller. Returning from the closure will cancel the RPC if it hasn't
+    ///       already finished.
     /// - Returns: The result of `handleResponse`.
     """
 
@@ -821,16 +821,16 @@ private func explodedDocs(for method: MethodDescriptor) -> String {
   if method.isInputStreaming {
     parameters += "\n"
     parameters += """
-      ///   - producer: A closure producing request messages to send to the server. The request
-      ///       stream is closed when the closure returns.
+      ///   - producer: A closure producing request messages to send to the server. Returning
+      ///       from the closure closes the request stream.
       """
   }
 
   parameters += "\n"
   parameters += """
-    ///   - handleResponse: A closure which handles the response, the result of which is
-    ///       returned to the caller. Returning from the closure will cancel the RPC if it
-    ///       hasn't already finished.
+    ///   - handleResponse: A closure which handles the response and returns its result to
+    ///       the caller. Returning from the closure will cancel the RPC if it hasn't
+    ///       already finished.
     /// - Returns: The result of `handleResponse`.
     """
 

--- a/Sources/GRPCCodeGen/Internal/StructuredSwift+Server.swift
+++ b/Sources/GRPCCodeGen/Internal/StructuredSwift+Server.swift
@@ -70,9 +70,9 @@ extension ProtocolDescription {
         /// - Parameters:
         ///   - request: A streaming request of `\(method.inputType)` messages.
         ///   - context: Context providing information about the RPC.
-        /// - Throws: Any error which occurred during the processing of the request. The server
-        ///     maps thrown errors of type `RPCError` to appropriate statuses and converts all
-        ///     other errors to an internal error.
+        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+        ///     to an internal error.
         /// - Returns: A streaming response of `\(method.outputType)` messages.
         """
 
@@ -175,9 +175,9 @@ extension ProtocolDescription {
         /// - Parameters:
         ///   - request: \(request)
         ///   - context: Context providing information about the RPC.
-        /// - Throws: Any error which occurred during the processing of the request. The server
-        ///     maps thrown errors of type `RPCError` to appropriate statuses and converts all
-        ///     other errors to an internal error.
+        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+        ///     to an internal error.
         /// - Returns: \(returns)
         """
 
@@ -592,9 +592,9 @@ extension ProtocolDescription {
       parameters += "\n"
       parameters += """
         ///   - context: Context providing information about the RPC.
-        /// - Throws: Any error which occurred during the processing of the request. The server
-        ///     maps thrown errors of type `RPCError` to appropriate statuses and converts all
-        ///     other errors to an internal error.
+        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
+        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
+        ///     to an internal error.
         """
 
       if !method.isOutputStreaming {

--- a/Sources/GRPCCodeGen/Internal/StructuredSwift+Server.swift
+++ b/Sources/GRPCCodeGen/Internal/StructuredSwift+Server.swift
@@ -70,9 +70,9 @@ extension ProtocolDescription {
         /// - Parameters:
         ///   - request: A streaming request of `\(method.inputType)` messages.
         ///   - context: Context providing information about the RPC.
-        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
-        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
-        ///     to an internal error.
+        /// - Throws: Any error which occurred during the processing of the request. The server
+        ///     maps thrown errors of type `RPCError` to appropriate statuses and converts all
+        ///     other errors to an internal error.
         /// - Returns: A streaming response of `\(method.outputType)` messages.
         """
 
@@ -175,9 +175,9 @@ extension ProtocolDescription {
         /// - Parameters:
         ///   - request: \(request)
         ///   - context: Context providing information about the RPC.
-        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
-        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
-        ///     to an internal error.
+        /// - Throws: Any error which occurred during the processing of the request. The server
+        ///     maps thrown errors of type `RPCError` to appropriate statuses and converts all
+        ///     other errors to an internal error.
         /// - Returns: \(returns)
         """
 
@@ -592,9 +592,9 @@ extension ProtocolDescription {
       parameters += "\n"
       parameters += """
         ///   - context: Context providing information about the RPC.
-        /// - Throws: Any error which occurred during the processing of the request. Thrown errors
-        ///     of type `RPCError` are mapped to appropriate statuses. All other errors are converted
-        ///     to an internal error.
+        /// - Throws: Any error which occurred during the processing of the request. The server
+        ///     maps thrown errors of type `RPCError` to appropriate statuses and converts all
+        ///     other errors to an internal error.
         """
 
       if !method.isOutputStreaming {

--- a/Sources/GRPCCodeGen/Internal/StructuredSwiftRepresentation.swift
+++ b/Sources/GRPCCodeGen/Internal/StructuredSwiftRepresentation.swift
@@ -45,7 +45,7 @@ package struct ImportDescription: Equatable, Codable, Sendable {
 
   /// An array of module types imported from the module, if applicable.
   ///
-  /// For example, if there are type imports like `import Foo.Bar`, they would be listed here.
+  /// For example, this array lists type imports like `import Foo.Bar`.
   var moduleTypes: [String]?
 
   /// The name of the private interface for an `@_spi` import.
@@ -207,7 +207,7 @@ enum IdentifierDescription: Equatable, Codable, Sendable {
 /// For example `foo.bar`.
 struct MemberAccessDescription: Equatable, Codable, Sendable {
 
-  /// The expression of which a member `right` is accessed.
+  /// The expression that provides the member `right`.
   ///
   /// For example, in `foo.bar`, `left` represents `foo`.
   var left: Expression?
@@ -239,12 +239,12 @@ struct FunctionArgumentDescription: Equatable, Codable, Sendable {
 /// For example `foo(bar: 42)`.
 struct FunctionCallDescription: Equatable, Codable, Sendable {
 
-  /// The expression that returns the function to be called.
+  /// The expression that returns the function to call.
   ///
   /// For example, in `foo(bar: 42)`, `calledExpression` represents `foo`.
   var calledExpression: Expression
 
-  /// The arguments to be passed to the function.
+  /// The arguments to pass to the function.
   var arguments: [FunctionArgumentDescription]
 
   /// A trailing closure.
@@ -252,8 +252,8 @@ struct FunctionCallDescription: Equatable, Codable, Sendable {
 
   /// Creates a new function call description.
   /// - Parameters:
-  ///   - calledExpression: An expression that returns the function to be called.
-  ///   - arguments: Arguments to be passed to the function.
+  ///   - calledExpression: An expression that returns the function to call.
+  ///   - arguments: Arguments to pass to the function.
   ///   - trailingClosure: A trailing closure.
   init(
     calledExpression: Expression,
@@ -267,8 +267,8 @@ struct FunctionCallDescription: Equatable, Codable, Sendable {
 
   /// Creates a new function call description.
   /// - Parameters:
-  ///   - calledExpression: An expression that returns the function to be called.
-  ///   - arguments: Arguments to be passed to the function.
+  ///   - calledExpression: An expression that returns the function to call.
+  ///   - arguments: Arguments to pass to the function.
   ///   - trailingClosure: A trailing closure.
   init(
     calledExpression: Expression,
@@ -317,7 +317,7 @@ struct VariableDescription: Equatable, Codable, Sendable {
   /// For example, in `let foo: Int = 42`, `type` is `Int`.
   var type: ExistingTypeDescription?
 
-  /// The expression to be assigned to the variable.
+  /// The expression to assign to the variable.
   ///
   /// For example, in `let foo = 42`, `right` represents `42`.
   var right: Expression? = nil
@@ -359,7 +359,7 @@ enum WhereClauseRequirement: Equatable, Codable, Sendable {
 /// For example: `extension Array where Element: Foo {`.
 struct WhereClause: Equatable, Codable, Sendable {
 
-  /// One or more requirements to be added after the `where` keyword.
+  /// One or more requirements to add after the `where` keyword.
   var requirements: [WhereClauseRequirement]
 }
 
@@ -841,7 +841,7 @@ struct DeprecationDescription: Equatable, Codable, Sendable {
 ///
 /// For example: `@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)`
 package struct AvailabilityDescription: Equatable, Codable, Sendable {
-  /// The array of OSes and versions which are specified in the availability guard.
+  /// The array of OSes and versions that the availability guard specifies.
   package var osVersions: [OSVersion]
   package init(osVersions: [OSVersion]) {
     self.osVersions = osVersions
@@ -943,7 +943,7 @@ struct SwitchDescription: Equatable, Codable, Sendable {
 struct IfBranch: Equatable, Codable, Sendable {
 
   /// The expressions evaluated by the if statement and their corresponding
-  /// body blocks. If more than one is provided, an `else if` branch is added.
+  /// body blocks. Providing more than one condition adds an `else if` branch.
   ///
   /// For example, in `if foo { bar }`, `condition` is `foo`.
   var condition: Expression
@@ -967,7 +967,7 @@ struct IfStatementDescription: Equatable, Codable, Sendable {
 
   /// The body of an else block.
   ///
-  /// No `else` statement is added when `elseBody` is nil.
+  /// If nil, adds no `else` statement.
   var elseBody: [CodeBlock]?
 }
 
@@ -984,7 +984,7 @@ struct DoStatementDescription: Equatable, Codable, Sendable {
 
   /// The code blocks in the `catch` statement.
   ///
-  /// If nil, no `catch` statement is added.
+  /// If nil, adds no `catch` statement.
   ///
   /// For example, in `do { try foo() } catch { return bar }`,
   /// `catchBody` is `return bar`.
@@ -1273,7 +1273,7 @@ extension Declaration {
   ///   - kind: The variable binding kind.
   ///   - left: The name of the variable.
   ///   - type: The type of the variable.
-  ///   - right: The expression to be assigned to the variable.
+  ///   - right: The expression to assign to the variable.
   ///   - getter: Body code for the getter of the variable.
   ///   - getterEffects: Effects of the getter.
   ///   - setter: Body code for the setter of the variable.
@@ -1316,7 +1316,7 @@ extension Declaration {
   ///   - kind: The variable binding kind.
   ///   - left: The name of the variable.
   ///   - type: The type of the variable.
-  ///   - right: The expression to be assigned to the variable.
+  ///   - right: The expression to assign to the variable.
   ///   - getter: Body code for the getter of the variable.
   ///   - getterEffects: Effects of the getter.
   ///   - setter: Body code for the setter of the variable.
@@ -1604,8 +1604,8 @@ extension Expression {
   ///
   /// For example `foo(bar: 42)`.
   /// - Parameters:
-  ///   - calledExpression: The expression to be called as a function.
-  ///   - arguments: The arguments to be passed to the function call.
+  ///   - calledExpression: The expression to call as a function.
+  ///   - arguments: The arguments to pass to the function call.
   ///   - trailingClosure: A trailing closure.
   /// - Returns: A new expression representing a function call with the specified called expression and arguments.
   static func functionCall(
@@ -1820,16 +1820,16 @@ extension VariableDescription {
 
 extension Expression {
 
-  /// Creates a new assignment description where the called expression is
-  /// assigned the value of the specified expression.
+  /// Creates a new assignment description that assigns the value of the
+  /// specified expression to the called expression.
   /// - Parameter rhs: The right-hand side of the assignment expression.
   /// - Returns: An assignment description representing the assignment.
   func equals(_ rhs: Expression) -> AssignmentDescription { .init(left: self, right: rhs) }
 }
 
 extension FunctionSignatureDescription {
-  /// Returns a new function signature description that has the access
-  /// modifier updated to the specified one.
+  /// Returns a new function signature description with the access
+  /// modifier set to the specified one.
   /// - Parameter accessModifier: The access modifier to use.
   /// - Returns: A function signature description with the specified access modifier.
   func withAccessModifier(_ accessModifier: AccessModifier?) -> Self {

--- a/Sources/GRPCCodeGen/Internal/Translator/ClientCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ClientCodeTranslator.swift
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-/// Creates a representation for the client code that will be generated based on the ``CodeGenerationRequest`` object
-/// specifications, using types from ``StructuredSwiftRepresentation``.
+/// Creates a representation for the client code that ``ClientCodeTranslator`` generates based
+/// on the ``CodeGenerationRequest`` object's specifications, using types from
+/// ``StructuredSwiftRepresentation``.
 ///
 /// For example, in the case of a service called "Bar", in the "foo" namespace which has
 /// one method "baz" with input type "Input" and output type "Output", the ``ClientCodeTranslator`` will create

--- a/Sources/GRPCCodeGen/Internal/Translator/IDLToStructuredSwiftTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/IDLToStructuredSwiftTranslator.swift
@@ -15,7 +15,7 @@
  */
 
 /// Creates a representation for the server and client code, as well as for the enums containing useful type aliases and properties.
-/// The representation is generated based on the ``CodeGenerationRequest`` object and user specifications,
+/// It generates the representation based on the ``CodeGenerationRequest`` object and user specifications,
 /// using types from ``StructuredSwiftRepresentation``.
 @available(gRPCSwift 2.0, *)
 package struct IDLToStructuredSwiftTranslator {

--- a/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
+++ b/Sources/GRPCCodeGen/Internal/Translator/ServerCodeTranslator.swift
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-/// Creates a representation for the server code that will be generated based on the ``CodeGenerationRequest`` object
-/// specifications, using types from ``StructuredSwiftRepresentation``.
+/// Creates a representation for the server code that ``ServerCodeTranslator`` generates based
+/// on the ``CodeGenerationRequest`` object's specifications, using types from
+/// ``StructuredSwiftRepresentation``.
 ///
 /// For example, in the case of a service called "Bar", in the "foo" namespace which has
 /// one method "baz" with input type "Input" and output type "Output", the ``ServerCodeTranslator`` will create
@@ -191,8 +192,9 @@ struct ServerCodeTranslator {
       /// This protocol is the lowest-level of the service protocols generated for this service
       /// giving you the most flexibility over the implementation of your service. This comes at
       /// the cost of more verbose and less strict APIs. Each RPC requires you to implement it in
-      /// terms of a request stream and response stream. Where only a single request or response
-      /// message is expected, you are responsible for enforcing this invariant is maintained.
+      /// terms of a request stream and response stream. Where the RPC expects only a single
+      /// request or response message, you are responsible for ensuring your implementation
+      /// maintains this invariant.
       ///
       /// Where possible, prefer using the stricter, less-verbose ``ServiceProtocol``
       /// or ``SimpleServiceProtocol`` instead.

--- a/Sources/GRPCCodeGen/Internal/TypeUsage.swift
+++ b/Sources/GRPCCodeGen/Internal/TypeUsage.swift
@@ -35,19 +35,19 @@
 ///
 /// To define a type, use `TypeName`, and to refer to a type, use `TypeUsage`.
 ///
-/// This type is not meant to represent all the various ways types can be
-/// wrapped in Swift, only the ways we wrap things in this project. For example,
-/// double optionals (`String??`) are automatically collapsed into a single
+/// This type is not meant to represent every way Swift can wrap types, only
+/// the ways we wrap things in this project. For example, this type
+/// automatically collapses double optionals (`String??`) into a single
 /// optional, and so on.
 struct TypeUsage {
 
   /// Describes either a type name or a type usage.
   fileprivate indirect enum Wrapped {
 
-    /// A type name, used to define a type.
+    /// A type name that you use to define a type.
     case name(TypeName)
 
-    /// A type usage, used to refer to a type.
+    /// A type usage that you use to refer to a type.
     case usage(TypeUsage)
   }
 
@@ -142,7 +142,7 @@ extension TypeUsage {
     }
   }
 
-  /// The type name wrapped by the current type usage.
+  /// The type name that the current type usage wraps.
   var typeName: TypeName {
     switch wrapped {
     case .name(let typeName): return typeName

--- a/Sources/GRPCCodeGen/SourceFile.swift
+++ b/Sources/GRPCCodeGen/SourceFile.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-/// Representation of the file to be created by the code generator that contains the
+/// Representation of the file that the code generator creates, containing the
 /// generated Swift source code.
 @available(gRPCSwift 2.0, *)
 public struct SourceFile: Sendable, Hashable {

--- a/Sources/GRPCCore/Call/Client/CallOptions.swift
+++ b/Sources/GRPCCore/Call/Client/CallOptions.swift
@@ -57,9 +57,9 @@ public struct CallOptions: Sendable {
 
   /// The maximum allowed payload size in bytes for an individual response message.
   ///
-  /// If a server attempts to send an object larger than this value, the server won't send the
-  /// object and instead sends an error to the client. Note that 0 is a valid value,
-  /// meaning that the response message must be empty.
+  /// If the server sends an object larger than this value, the client won't accept it and will
+  /// see an error instead. Note that 0 is a valid value, meaning that the response message must
+  /// be empty.
   ///
   /// Note that if compression is used the uncompressed message size is validated.
   public var maxResponseMessageBytes: Int?

--- a/Sources/GRPCCore/Call/Client/CallOptions.swift
+++ b/Sources/GRPCCore/Call/Client/CallOptions.swift
@@ -16,7 +16,7 @@
 
 /// Options applied to a call.
 ///
-/// If set, these options are used in preference to any options configured on
+/// If set, gRPC uses these options in preference to any options configured on
 /// the client or its transport.
 ///
 /// You can create the default set of options, which defers all possible
@@ -25,31 +25,31 @@
 public struct CallOptions: Sendable {
   /// The default timeout for the RPC.
   ///
-  /// If no reply is received in the specified amount of time, the request is aborted
+  /// If the client doesn't receive a reply in the specified amount of time, it aborts the request
   /// with an ``RPCError`` with code ``RPCError/Code/deadlineExceeded``.
   ///
   /// The actual deadline used will be the minimum of the value specified here
-  /// and the value set by the application by the client API. If either one isn't set,
-  /// then the other value is used. If neither is set, then the request has no deadline.
+  /// and the value set by the application by the client API. If you don't set either one,
+  /// gRPC uses the other value. If you set neither, the request has no deadline.
   ///
-  /// The timeout applies to the overall execution of an RPC. If, for example, a retry
-  /// policy is set, then the timeout begins when the first attempt is started and _isn't_ reset
+  /// The timeout applies to the overall execution of an RPC. If, for example, you set a retry
+  /// policy, then the timeout begins when the first attempt starts, and gRPC doesn't reset it
   /// when subsequent attempts start.
   public var timeout: Duration?
 
   /// Whether RPCs for this method should wait until the connection is ready.
   ///
   /// If `false`, the RPC will abort immediately if there is a transient failure connecting to
-  /// the server. Otherwise gRPC will attempt to connect until the deadline is exceeded.
+  /// the server. Otherwise gRPC will attempt to connect until the deadline passes.
   ///
-  /// If left unset, transports conventionally treat this the same as `false`, so RPCs fail fast
-  /// on a transient connection failure rather than queuing until the connection is ready.
+  /// If you leave this unset, transports conventionally treat it the same as `false`, so RPCs
+  /// fail fast on a transient connection failure rather than queuing until the connection is ready.
   public var waitForReady: Bool?
 
   /// The maximum allowed payload size in bytes for an individual request message.
   ///
-  /// If a client attempts to send an object larger than this value, it will not be sent and the
-  /// client will see an error. Note that 0 is a valid value, meaning that the request message
+  /// If a client attempts to send an object larger than this value, the client won't send it and
+  /// will see an error instead. Note that 0 is a valid value, meaning that the request message
   /// must be empty.
   ///
   /// Note that if compression is used the uncompressed message size is validated.
@@ -57,27 +57,27 @@ public struct CallOptions: Sendable {
 
   /// The maximum allowed payload size in bytes for an individual response message.
   ///
-  /// If a server attempts to send an object larger than this value, it will not
-  /// be sent, and an error will be sent to the client instead. Note that 0 is a valid value,
+  /// If a server attempts to send an object larger than this value, the server won't send the
+  /// object and instead sends an error to the client. Note that 0 is a valid value,
   /// meaning that the response message must be empty.
   ///
   /// Note that if compression is used the uncompressed message size is validated.
   public var maxResponseMessageBytes: Int?
 
-  /// The policy determining how many times, and when, the RPC is executed.
+  /// The policy determining how many times, and when, gRPC executes the RPC.
   ///
   /// There are two policy types:
   /// 1. Retry
   /// 2. Hedging
   ///
-  /// The retry policy allows an RPC to be retried a limited number of times if the RPC
-  /// fails with one of the configured set of status codes. RPCs are only retried if they
+  /// The retry policy lets gRPC retry an RPC a limited number of times if the RPC
+  /// fails with one of the configured set of status codes. gRPC only retries RPCs if they
   /// fail immediately, that is, the first response part received from the server is a
   /// status code.
   ///
-  /// The hedging policy allows an RPC to be executed multiple times concurrently. Typically
-  /// each execution will be staggered by some delay. The first successful response will be
-  /// reported to the client. Hedging is only suitable for idempotent RPCs.
+  /// The hedging policy lets gRPC execute an RPC multiple times concurrently. Typically
+  /// gRPC staggers each execution by some delay. gRPC reports the first successful response
+  /// to the client. Hedging is only suitable for idempotent RPCs.
   public var executionPolicy: RPCExecutionPolicy?
 
   /// The compression used for the call.
@@ -89,9 +89,9 @@ public struct CallOptions: Sendable {
   /// Note that this configuration is advisory: not all transports support compression and may
   /// ignore this configuration. Transports that support compression will use this configuration
   /// in preference to the algorithm configured at a transport level. If the transport hasn't
-  /// enabled the use of the algorithm, then compression won't be used for the call.
+  /// enabled the use of the algorithm, then it won't use compression for the call.
   ///
-  /// If `nil`, the value configured on the transport will be used instead.
+  /// If `nil`, gRPC uses the value configured on the transport instead.
   public var compression: CompressionAlgorithm?
 
   internal init(

--- a/Sources/GRPCCore/Call/Client/ClientContext.swift
+++ b/Sources/GRPCCore/Call/Client/ClientContext.swift
@@ -17,15 +17,16 @@
 /// A context passed to the client containing additional information about the RPC.
 @available(gRPCSwift 2.0, *)
 public struct ClientContext: Sendable {
-  /// A description of the method being called.
+  /// A description of the method the client is calling.
   public var descriptor: MethodDescriptor
 
   /// A description of the remote peer.
   ///
   /// The format of the description should follow the pattern "<transport>:<address>" where
   /// "<transport>" indicates the underlying network transport (such as "ipv4", "unix", or
-  /// "in-process"). This is a guideline for how descriptions should be formatted; different
-  /// implementations may not follow this format, so you shouldn't make assumptions based on it.
+  /// "in-process"). This is a guideline for how implementations should format descriptions;
+  /// different implementations may not follow this format, so don't make assumptions
+  /// based on it.
   ///
   /// Some examples include:
   /// - "ipv4:127.0.0.1:31415",
@@ -37,8 +38,9 @@ public struct ClientContext: Sendable {
   ///
   /// The format of the description should follow the pattern "<transport>:<address>" where
   /// "<transport>" indicates the underlying network transport (such as "ipv4", "unix", or
-  /// "in-process"). This is a guideline for how descriptions should be formatted; different
-  /// implementations may not follow this format, so you shouldn't make assumptions based on it.
+  /// "in-process"). This is a guideline for how implementations should format descriptions;
+  /// different implementations may not follow this format, so don't make assumptions
+  /// based on it.
   ///
   /// Some examples include:
   /// - "ipv4:127.0.0.1:31415",

--- a/Sources/GRPCCore/Call/Client/ClientInterceptor.swift
+++ b/Sources/GRPCCore/Call/Client/ClientInterceptor.swift
@@ -18,16 +18,16 @@
 
 /// A type that intercepts requests and responses for clients.
 ///
-/// Interceptors allow you to inspect and modify requests and responses. Requests are intercepted
-/// before they are handed to a transport, and responses are intercepted after they have been
-/// received from the transport. They are typically used for cross-cutting concerns like injecting
+/// Interceptors allow you to inspect and modify requests and responses. The client intercepts
+/// requests before handing them to a transport, and intercepts responses after receiving them
+/// from the transport. You typically use interceptors for cross-cutting concerns like injecting
 /// metadata, validating messages, logging additional data, and tracing.
 ///
-/// Interceptors are registered with the client via ``ConditionalInterceptor``s.
-/// You may register them for all services registered with a server, for RPCs directed to specific services, or
-/// for RPCs directed to specific methods. If you need to modify the behavior of an interceptor on a
+/// Register interceptors with the client via ``ConditionalInterceptor``s. You may register them
+/// for all services registered with a server, for RPCs directed to specific services, or for
+/// RPCs directed to specific methods. If you need to modify the behavior of an interceptor on a
 /// per-RPC basis in more detail, then you can use the ``ClientContext/descriptor`` to determine
-/// which RPC is being called and conditionalise behavior accordingly.
+/// which RPC the client is calling and conditionalise behavior accordingly.
 ///
 /// Some examples of simple interceptors follow.
 ///
@@ -59,7 +59,7 @@
 /// }
 /// ```
 ///
-/// Interceptors can also be used to print information about RPCs.
+/// Also use interceptors to print information about RPCs.
 ///
 /// ## Logging interceptor
 ///

--- a/Sources/GRPCCore/Call/Client/ClientRequest.swift
+++ b/Sources/GRPCCore/Call/Client/ClientRequest.swift
@@ -16,7 +16,7 @@
 
 /// A request created by the client for a single message.
 ///
-/// This is used for unary and server-streaming RPCs.
+/// Use this for unary and server-streaming RPCs.
 ///
 /// See ``StreamingClientRequest`` for streaming requests and ``ServerRequest`` for the
 /// server's representation of a single-message request.
@@ -32,11 +32,11 @@
 public struct ClientRequest<Message: Sendable>: Sendable {
   /// Caller-specified metadata to send to the server at the start of the RPC.
   ///
-  /// Both gRPC Swift and its transport layer may insert additional metadata. Keys prefixed with
-  /// "grpc-" are prohibited and may result in undefined behaviour. Transports may also insert
-  /// their own metadata; you should avoid using key names that may clash with transport-specific
-  /// metadata. Note that transports may also impose limits on the amount of metadata that may
-  /// be sent.
+  /// Both gRPC Swift and its transport layer may insert additional metadata. gRPC prohibits keys
+  /// prefixed with "grpc-"; using them may result in undefined behaviour. Transports may also
+  /// insert their own metadata; avoid key names that may clash with
+  /// transport-specific metadata. Note that transports may also impose limits on the amount of
+  /// metadata you can send.
   public var metadata: Metadata
 
   /// The message to send to the server.
@@ -58,7 +58,7 @@ public struct ClientRequest<Message: Sendable>: Sendable {
 
 /// A request created by the client for a stream of messages.
 ///
-/// This is used for client-streaming and bidirectional-streaming RPCs.
+/// Use this for client-streaming and bidirectional-streaming RPCs.
 ///
 /// See ``ClientRequest`` for single-message requests and ``StreamingServerRequest`` for the
 /// server's representation of a streaming-message request.
@@ -66,18 +66,18 @@ public struct ClientRequest<Message: Sendable>: Sendable {
 public struct StreamingClientRequest<Message: Sendable>: Sendable {
   /// Caller-specified metadata sent to the server at the start of the RPC.
   ///
-  /// Both gRPC Swift and its transport layer may insert additional metadata. Keys prefixed with
-  /// "grpc-" are prohibited and may result in undefined behaviour. Transports may also insert
-  /// their own metadata; you should avoid using key names that may clash with transport-specific
-  /// metadata. Note that transports may also impose limits on the amount of metadata that may
-  /// be sent.
+  /// Both gRPC Swift and its transport layer may insert additional metadata. gRPC prohibits keys
+  /// prefixed with "grpc-"; using them may result in undefined behaviour. Transports may also
+  /// insert their own metadata; avoid key names that may clash with
+  /// transport-specific metadata. Note that transports may also impose limits on the amount of
+  /// metadata you can send.
   public var metadata: Metadata
 
   /// A closure that, when called, writes messages to the writer.
   ///
-  /// The producer will only be consumed once by gRPC and therefore isn't required to be
-  /// idempotent. If the producer throws an error, then the RPC will be cancelled. Once the
-  /// producer returns, the request stream is closed.
+  /// gRPC will only consume the producer once, so it doesn't need to be idempotent. If the
+  /// producer throws an error, then gRPC will cancel the RPC. Once the producer returns, gRPC
+  /// closes the request stream.
   public var producer: @Sendable (RPCWriter<Message>) async throws -> Void
 
   /// Creates a new streaming client request.

--- a/Sources/GRPCCore/Call/Client/ClientResponse.swift
+++ b/Sources/GRPCCore/Call/Client/ClientResponse.swift
@@ -201,6 +201,7 @@ public struct ClientResponse<Message: Sendable>: Sendable {
 /// ```
 @available(gRPCSwift 2.0, *)
 public struct StreamingClientResponse<Message: Sendable>: Sendable {
+  /// The contents of an accepted response with a stream of messages.
   public struct Contents: Sendable {
     /// Metadata received from the server at the beginning of the response.
     ///

--- a/Sources/GRPCCore/Call/Client/ClientResponse.swift
+++ b/Sources/GRPCCore/Call/Client/ClientResponse.swift
@@ -87,7 +87,7 @@ public struct ClientResponse<Message: Sendable>: Sendable {
     /// metadata provided by the service.
     public var trailingMetadata: Metadata
 
-    /// Creates a `Contents`.
+    /// Creates contents representing a successful response.
     ///
     /// - Parameters:
     ///   - metadata: Metadata received from the server at the beginning of the response.
@@ -103,7 +103,7 @@ public struct ClientResponse<Message: Sendable>: Sendable {
       self.trailingMetadata = trailingMetadata
     }
 
-    /// Creates a `Contents`.
+    /// Creates contents representing a failed response.
     ///
     /// - Parameters:
     ///   - metadata: Metadata received from the server at the beginning of the response.
@@ -227,7 +227,7 @@ public struct StreamingClientResponse<Message: Sendable>: Sendable {
       case trailingMetadata(Metadata)
     }
 
-    /// Creates a ``Contents``.
+    /// Creates contents for an accepted response.
     ///
     /// - Parameters:
     ///   - metadata: Metadata received from the server at the beginning of the response.
@@ -390,7 +390,7 @@ extension StreamingClientResponse {
     }
   }
 
-  /// Returns the body parts (that is, `messages` and `trailingMetadata`) returned from the server.
+  /// Returns the message and trailing-metadata parts returned from the server.
   ///
   /// For rejected RPCs (in other words, where ``accepted`` is `failure`), the `RPCAsyncSequence` throws an ``RPCError``.
   public var bodyParts: RPCAsyncSequence<Contents.BodyPart, any Error> {

--- a/Sources/GRPCCore/Call/Client/ClientResponse.swift
+++ b/Sources/GRPCCore/Call/Client/ClientResponse.swift
@@ -16,7 +16,7 @@
 
 /// A response for a single message received by a client.
 ///
-/// Single responses are used for unary and client-streaming RPCs. For streaming responses,
+/// Use single responses for unary and client-streaming RPCs. For streaming responses,
 /// see ``StreamingClientResponse``.
 ///
 /// A single response captures every part of the response stream and distinguishes successful
@@ -121,8 +121,8 @@ public struct ClientResponse<Message: Sendable>: Sendable {
   /// Whether the RPC was accepted or rejected.
   ///
   /// The `success` case indicates the RPC completed successfully with an
-  /// ``Status/Code-swift.struct/ok`` status code. The `failure` case indicates that the RPC was
-  /// rejected by the server and wasn't processed or couldn't be processed successfully.
+  /// ``Status/Code-swift.struct/ok`` status code. The `failure` case indicates that the server
+  /// rejected the RPC and didn't process it, or couldn't process it successfully.
   public var accepted: Result<Contents, RPCError>
 
   /// Creates a new response.
@@ -135,7 +135,7 @@ public struct ClientResponse<Message: Sendable>: Sendable {
 
 /// A response for a stream of messages received by a client.
 ///
-/// Stream responses are used for server-streaming and bidirectional-streaming RPCs. For single
+/// Use stream responses for server-streaming and bidirectional-streaming RPCs. For single
 /// responses, see ``ClientResponse``.
 ///
 /// A stream response captures every part of the response stream over time and distinguishes
@@ -214,7 +214,7 @@ public struct StreamingClientResponse<Message: Sendable>: Sendable {
     ///
     /// If the RPC fails, then the sequence will throw an ``RPCError``.
     ///
-    /// The sequence may only be iterated once.
+    /// You may only iterate the sequence once.
     public var bodyParts: RPCAsyncSequence<BodyPart, any Error>
 
     /// Parts received from the server.
@@ -243,10 +243,10 @@ public struct StreamingClientResponse<Message: Sendable>: Sendable {
 
   /// Whether the RPC was accepted or rejected.
   ///
-  /// The `success` case indicates the RPC was accepted by the server for
+  /// The `success` case indicates that the server accepted the RPC for
   /// processing; however, the RPC may still fail by throwing an error from its
-  /// `messages` sequence. The `failure` case indicates that the RPC was
-  /// rejected by the server.
+  /// `messages` sequence. The `failure` case indicates that the server
+  /// rejected the RPC.
   public var accepted: Result<Contents, RPCError>
 
   /// Creates a new response.

--- a/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/ClientRPCExecutor.swift
@@ -26,10 +26,10 @@ enum ClientRPCExecutor: Sendable {
   ///   - serializer: A serializer to convert input messages to bytes.
   ///   - deserializer: A deserializer to convert bytes to output messages.
   ///   - transport: The transport to execute the request on.
-  ///   - interceptors: An array of interceptors which the request and response pass through. The
-  ///       interceptors will be called in the order of the array.
-  ///   - handler: A closure for handling the response. Once the closure returns, any resources from
-  ///       the RPC will be torn down.
+  ///   - interceptors: An array of interceptors which the request and response pass through. This
+  ///       function calls the interceptors in the order of the array.
+  ///   - handler: A closure for handling the response. Once the closure returns, this function
+  ///       tears down any resources from the RPC.
   /// - Returns: The result returns from the `handler`.
   @inlinable
   static func execute<Input: Sendable, Output: Sendable, Result: Sendable>(
@@ -110,8 +110,8 @@ extension ClientRPCExecutor {
   ///   - attempt: The attempt number of the request.
   ///   - serializer: A serializer to convert input messages to bytes.
   ///   - deserializer: A deserializer to convert bytes to output messages.
-  ///   - interceptors: An array of interceptors which the request and response pass through. The
-  ///       interceptors will be called in the order of the array.
+  ///   - interceptors: An array of interceptors which the request and response pass through. This
+  ///       function calls the interceptors in the order of the array.
   ///   - stream: The stream to excecute the RPC on.
   /// - Returns: The deserialized response.
   @inlinable  // would be private

--- a/Sources/GRPCCore/Call/Client/Internal/ClientResponse+Convenience.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/ClientResponse+Convenience.swift
@@ -88,8 +88,8 @@ extension ClientResponse {
 extension StreamingClientResponse {
   /// Creates a streaming response from the given status and metadata.
   ///
-  /// If the ``Status`` has code ``Status/Code-swift.struct/ok`` then an accepted stream is created
-  /// containing only the provided metadata. Otherwise a failed response is returned with an error
+  /// If the ``Status`` has code ``Status/Code-swift.struct/ok`` then this creates an accepted stream
+  /// containing only the provided metadata. Otherwise this returns a failed response with an error
   /// created from the status and metadata.
   ///
   /// - Parameters:

--- a/Sources/GRPCCore/Call/Client/Internal/ClientStreamExecutor.swift
+++ b/Sources/GRPCCore/Call/Client/Internal/ClientStreamExecutor.swift
@@ -23,7 +23,7 @@ internal enum ClientStreamExecutor: Sendable {
   ///   - request: A streaming request.
   ///   - method: A description of the method to call.
   ///   - context: The client context.
-  ///   - attempt: The attempt number for the RPC that will be executed.
+  ///   - attempt: The attempt number for the RPC that this executor will execute.
   ///   - serializer: A request serializer.
   ///   - deserializer: A response deserializer.
   ///   - stream: The stream to execute the RPC on.

--- a/Sources/GRPCCore/Call/ConditionalInterceptor.swift
+++ b/Sources/GRPCCore/Call/ConditionalInterceptor.swift
@@ -28,6 +28,7 @@
 ///   server interceptors, respectively.
 @available(gRPCSwift 2.0, *)
 public struct ConditionalInterceptor<Interceptor: Sendable>: Sendable {
+  /// Describes which RPCs an interceptor applies to.
   public struct Subject: Sendable {
 
     private let predicate: @Sendable (_ descriptor: MethodDescriptor) -> Bool

--- a/Sources/GRPCCore/Call/ConditionalInterceptor.swift
+++ b/Sources/GRPCCore/Call/ConditionalInterceptor.swift
@@ -137,9 +137,7 @@ public struct ConditionalInterceptor<Interceptor: Sendable>: Sendable {
 
 @available(gRPCSwift 2.0, *)
 extension ConditionalInterceptor where Interceptor == any ClientInterceptor {
-  /// Creates an operation, specifying which interceptor to apply and to which RPCs.
-  ///
-  /// Accepts any ``ClientInterceptor`` and a ``Subject`` describing which RPCs it applies to.
+  /// Creates an operation that applies a client interceptor to a specific set of RPCs.
   ///
   /// - Parameters:
   ///   - interceptor: The ``ClientInterceptor`` to register with the client.
@@ -154,9 +152,7 @@ extension ConditionalInterceptor where Interceptor == any ClientInterceptor {
 
 @available(gRPCSwift 2.0, *)
 extension ConditionalInterceptor where Interceptor == any ServerInterceptor {
-  /// Creates an operation, specifying which interceptor to apply and to which RPCs.
-  ///
-  /// Accepts any ``ServerInterceptor`` and a ``Subject`` describing which RPCs it applies to.
+  /// Creates an operation that applies a server interceptor to a specific set of RPCs.
   ///
   /// - Parameters:
   ///   - interceptor: The ``ServerInterceptor`` to register with the server.

--- a/Sources/GRPCCore/Call/ConditionalInterceptor.swift
+++ b/Sources/GRPCCore/Call/ConditionalInterceptor.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-/// Describes the conditions under which an interceptor should be applied.
+/// Describes the conditions under which an interceptor applies.
 ///
 /// You can configure interceptors to be applied to:
 /// - all RPCs and services; or
@@ -33,12 +33,12 @@ public struct ConditionalInterceptor<Interceptor: Sendable>: Sendable {
 
     private let predicate: @Sendable (_ descriptor: MethodDescriptor) -> Bool
 
-    /// An operation subject specifying an interceptor that applies to all RPCs across all services will be registered with this client.
+    /// An operation subject specifying an interceptor that applies to all RPCs across all services you register with this client.
     public static var all: Self {
       Self { _ in true }
     }
 
-    /// An operation subject specifying an interceptor that will be applied only to RPCs directed to the specified services.
+    /// An operation subject specifying an interceptor that applies only to RPCs directed to the specified services.
     ///
     /// - Parameters:
     ///   - services: The list of service descriptors for which this interceptor should intercept RPCs.
@@ -48,7 +48,7 @@ public struct ConditionalInterceptor<Interceptor: Sendable>: Sendable {
       }
     }
 
-    /// An operation subject specifying an interceptor that will be applied only to RPCs directed to the specified service methods.
+    /// An operation subject specifying an interceptor that applies only to RPCs directed to the specified service methods.
     ///
     /// - Parameters:
     ///   - methods: The list of method descriptors for which this interceptor should intercept RPCs.
@@ -58,7 +58,7 @@ public struct ConditionalInterceptor<Interceptor: Sendable>: Sendable {
       }
     }
 
-    /// An operation subject specifying an interceptor that will be applied only to RPCs directed to the specified services or service methods.
+    /// An operation subject specifying an interceptor that applies only to RPCs directed to the specified services or service methods.
     ///
     /// - Parameters:
     ///   - services: The list of service descriptors for which this interceptor should intercept RPCs.
@@ -73,7 +73,7 @@ public struct ConditionalInterceptor<Interceptor: Sendable>: Sendable {
       }
     }
 
-    /// An operation subject specifying an interceptor that will be applied to all RPCs across all services for this client excluding the specified services or service methods.
+    /// An operation subject specifying an interceptor that applies to all RPCs across all services for this client, excluding the specified services or service methods.
     ///
     /// - Parameters:
     ///   - services: The list of service descriptors for which this interceptor should **not** intercept RPCs.
@@ -93,9 +93,9 @@ public struct ConditionalInterceptor<Interceptor: Sendable>: Sendable {
     /// The predicate receives the RPC's ``MethodDescriptor`` and returns whether the interceptor
     /// should apply.
     ///
-    /// - Important: The result of `predicate` is **cached per `MethodDescriptor`** by the client.
-    ///   The predicate is evaluated the first time a given method is encountered, and that result
-    ///   is reused for subsequent RPCs of the same method for the lifetime of the client.
+    /// - Important: The client **caches the result of `predicate` per `MethodDescriptor`**.
+    ///   The client evaluates the predicate the first time it encounters a given method, and
+    ///   reuses that result for subsequent RPCs of the same method for the lifetime of the client.
     ///   As a consequence, the `predicate` closure should be **deterministic**.
     ///   Do **not** base it on dynamic state, such as time, session, or feature flags.
     ///   If you need per-call decisions, put that logic inside the interceptor itself.

--- a/Sources/GRPCCore/Call/ConditionalInterceptor.swift
+++ b/Sources/GRPCCore/Call/ConditionalInterceptor.swift
@@ -88,7 +88,10 @@ public struct ConditionalInterceptor<Interceptor: Sendable>: Sendable {
       }
     }
 
-    /// An operation subject specifying an interceptor that will be applied to RPCs whose ``MethodDescriptor`` satisfies a `predicate`.
+    /// An operation subject specifying an interceptor that applies to RPCs matching a custom predicate.
+    ///
+    /// The predicate receives the RPC's ``MethodDescriptor`` and returns whether the interceptor
+    /// should apply.
     ///
     /// - Important: The result of `predicate` is **cached per `MethodDescriptor`** by the client.
     ///   The predicate is evaluated the first time a given method is encountered, and that result
@@ -134,7 +137,10 @@ public struct ConditionalInterceptor<Interceptor: Sendable>: Sendable {
 
 @available(gRPCSwift 2.0, *)
 extension ConditionalInterceptor where Interceptor == any ClientInterceptor {
-  /// Creates an operation, specifying which ``ClientInterceptor`` to apply and to which ``Subject``.
+  /// Creates an operation, specifying which interceptor to apply and to which RPCs.
+  ///
+  /// Accepts any ``ClientInterceptor`` and a ``Subject`` describing which RPCs it applies to.
+  ///
   /// - Parameters:
   ///   - interceptor: The ``ClientInterceptor`` to register with the client.
   ///   - subject: The ``Subject`` to which the `interceptor` applies.
@@ -148,7 +154,10 @@ extension ConditionalInterceptor where Interceptor == any ClientInterceptor {
 
 @available(gRPCSwift 2.0, *)
 extension ConditionalInterceptor where Interceptor == any ServerInterceptor {
-  /// Creates an operation, specifying which ``ServerInterceptor`` to apply and to which ``Subject``.
+  /// Creates an operation, specifying which interceptor to apply and to which RPCs.
+  ///
+  /// Accepts any ``ServerInterceptor`` and a ``Subject`` describing which RPCs it applies to.
+  ///
   /// - Parameters:
   ///   - interceptor: The ``ServerInterceptor`` to register with the server.
   ///   - subject: The ``Subject`` to which the `interceptor` applies.

--- a/Sources/GRPCCore/Call/Server/Internal/ServerCancellationManager.swift
+++ b/Sources/GRPCCore/Call/Server/Internal/ServerCancellationManager.swift
@@ -54,9 +54,9 @@ package final class ServerCancellationManager: Sendable {
     }
   }
 
-  /// Adds a handler which is invoked when the RPC is cancelled.
+  /// Adds a handler that this manager invokes when the RPC is cancelled.
   ///
-  /// - Returns: The ID of the handler, if it was added, or `nil` if the RPC is already cancelled.
+  /// - Returns: The ID of the handler if this method added it, or `nil` if the RPC is already cancelled.
   package func addRPCCancelledHandler(_ handler: @Sendable @escaping () -> Void) -> UInt64? {
     return self.state.withLock { state -> UInt64? in
       state.addRPCCancelledHandler(handler)

--- a/Sources/GRPCCore/Call/Server/Internal/ServerRPCExecutor.swift
+++ b/Sources/GRPCCore/Call/Server/Internal/ServerRPCExecutor.swift
@@ -24,8 +24,8 @@ struct ServerRPCExecutor: Sendable {
   ///   - stream: The accepted stream to execute the RPC on.
   ///   - deserializer: A deserializer for messages received from the client.
   ///   - serializer: A serializer for messages to send to the client.
-  ///   - interceptors: Server interceptors to apply to this RPC.  The
-  ///       interceptors will be called in the order of the array.
+  ///   - interceptors: Server interceptors to apply to this RPC. This method calls the
+  ///       interceptors in the order of the array.
   ///   - handler: A handler which turns the request into a response.
   @inlinable
   static func execute<Input, Output, Bytes: GRPCContiguousBytes>(

--- a/Sources/GRPCCore/Call/Server/RPCRouter.swift
+++ b/Sources/GRPCCore/Call/Server/RPCRouter.swift
@@ -17,7 +17,7 @@
 /// Stores and provides handlers for RPCs.
 ///
 /// The router stores a handler for each RPC it knows about. Each handler encapsulates the business
-/// logic for the RPC that is typically implemented by service owners. To register a handler, you
+/// logic for the RPC, which service owners typically implement. To register a handler, you
 /// can call ``registerHandler(forMethod:deserializer:serializer:handler:)``. You can check whether
 /// the router has a handler for a method with ``hasHandler(forMethod:)`` or get a list of all
 /// methods with handlers registered by calling ``methods``. You can also remove the handler for a
@@ -33,7 +33,7 @@
 ///
 /// 1. Remove individual methods by calling ``removeHandler(forMethod:)``, or
 /// 2. Implement ``RegistrableRPCService/registerMethods(with:)`` to register only the methods you
-///    want to be served.
+///    want the router to serve.
 @available(gRPCSwift 2.0, *)
 public struct RPCRouter<Transport: ServerTransport>: Sendable {
   @usableFromInline
@@ -140,7 +140,7 @@ public struct RPCRouter<Transport: ServerTransport>: Sendable {
 
   /// Registers a handler with the router.
   ///
-  /// - Note: If a handler already exists for a given method, then it will be replaced.
+  /// - Note: If a handler already exists for a given method, the router replaces it.
   ///
   /// - Parameters:
   ///   - descriptor: A descriptor for the method to register a handler for.
@@ -170,7 +170,7 @@ public struct RPCRouter<Transport: ServerTransport>: Sendable {
   /// Removes any handler registered for the specified method.
   ///
   /// - Parameter descriptor: A descriptor of the method to remove a handler for.
-  /// - Returns: Whether a handler was removed.
+  /// - Returns: Whether this call removed a handler.
   @discardableResult
   public mutating func removeHandler(forMethod descriptor: MethodDescriptor) -> Bool {
     return self.handlers.removeValue(forKey: HandlerKey(descriptor)) != nil
@@ -178,10 +178,10 @@ public struct RPCRouter<Transport: ServerTransport>: Sendable {
 
   /// Registers applicable interceptors to all currently-registered handlers.
   ///
-  /// - Important: Calling this method will apply the interceptors only to existing handlers. Any handlers registered via
-  ///  ``registerHandler(forMethod:deserializer:serializer:handler:)`` _after_ calling this method will not have
-  ///    any interceptors applied to them. If you want to make sure all registered methods have any applicable interceptors applied,
-  ///    only call this method _after_ you have registered all handlers.
+  /// - Important: Calling this method will apply the interceptors only to existing handlers. If you register handlers via
+  ///  ``registerHandler(forMethod:deserializer:serializer:handler:)`` _after_ calling this method, the router won't apply
+  ///    any interceptors to them. If you want every registered method to receive any applicable interceptors,
+  ///    call this method only after you have registered all handlers.
   /// - Parameter pipeline: The interceptor pipeline operations to register to all currently-registered handlers. The order of the
   ///  interceptors matters.
   @inlinable

--- a/Sources/GRPCCore/Call/Server/RegistrableRPCService.swift
+++ b/Sources/GRPCCore/Call/Server/RegistrableRPCService.swift
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-/// An RPC service which can register its methods with an ``RPCRouter``.
+/// An RPC service that can register its own methods.
+///
+/// Registers with an ``RPCRouter``.
 ///
 /// You typically won't have to implement this protocol yourself as the generated service code
 /// provides conformance for your generated service type. However, if you need to customise which
@@ -24,7 +26,9 @@
 /// you want to register with the router.
 @available(gRPCSwift 2.0, *)
 public protocol RegistrableRPCService: Sendable {
-  /// Registers the service's methods with the provided ``RPCRouter``.
+  /// Registers the service's methods for handling RPCs.
+  ///
+  /// Methods are registered with the provided ``RPCRouter``.
   ///
   /// - Parameter router: The router to register methods with.
   func registerMethods<Transport: ServerTransport>(with router: inout RPCRouter<Transport>)

--- a/Sources/GRPCCore/Call/Server/RegistrableRPCService.swift
+++ b/Sources/GRPCCore/Call/Server/RegistrableRPCService.swift
@@ -20,7 +20,7 @@
 ///
 /// You typically won't have to implement this protocol yourself as the generated service code
 /// provides conformance for your generated service type. However, if you need to customise which
-/// methods your service offers or how the methods are registered, then you can override the
+/// methods your service offers or how it registers the methods, then override the
 /// generated conformance by implementing ``registerMethods(with:)`` manually by calling
 /// ``RPCRouter/registerHandler(forMethod:deserializer:serializer:handler:)`` for each method
 /// you want to register with the router.
@@ -28,7 +28,7 @@
 public protocol RegistrableRPCService: Sendable {
   /// Registers the service's methods for handling RPCs.
   ///
-  /// Methods are registered with the provided ``RPCRouter``.
+  /// This method registers methods with the provided ``RPCRouter``.
   ///
   /// - Parameter router: The router to register methods with.
   func registerMethods<Transport: ServerTransport>(with router: inout RPCRouter<Transport>)

--- a/Sources/GRPCCore/Call/Server/ServerContext+RPCCancellationHandle.swift
+++ b/Sources/GRPCCore/Call/Server/ServerContext+RPCCancellationHandle.swift
@@ -25,7 +25,7 @@ extension ServerContext {
   ///
   /// gRPC signals cancellation through this handle, not by cancelling your handler's `Task`. If
   /// you don't check ``isCancelled`` or use ``withRPCCancellationHandler(operation:onCancelRPC:)``,
-  /// your handler keeps running after the RPC is cancelled. For a streaming response, this means
+  /// your handler keeps running after gRPC cancels the RPC. For a streaming response, this means
   /// it keeps writing messages the client will never see.
   public struct RPCCancellationHandle: Sendable {
     internal let manager: ServerCancellationManager
@@ -47,7 +47,7 @@ extension ServerContext {
     ///
     /// Throws a `CancellationError` if the `Task` is cancelled.
     ///
-    /// You can also be notified when an RPC is cancelled by using
+    /// Also learn when an RPC is cancelled by using
     /// ``withRPCCancellationHandler(operation:onCancelRPC:)``.
     public var cancelled: Void {
       get async throws {
@@ -55,7 +55,7 @@ extension ServerContext {
       }
     }
 
-    /// Signals that the RPC should be cancelled.
+    /// Cancels the RPC.
     ///
     /// This is idempotent: calling it more than once has no effect.
     public func cancel() {
@@ -64,7 +64,7 @@ extension ServerContext {
   }
 }
 
-/// Executes an operation with an RPC cancellation handler that's immediately invoked
+/// Executes an operation with an RPC cancellation handler that gRPC invokes immediately
 /// if the RPC is cancelled.
 ///
 /// RPCs can be cancelled for a number of reasons including:
@@ -76,7 +76,7 @@ extension ServerContext {
 /// - Important: This only applies to RPCs on the server.
 /// - Parameters:
 ///   - operation: The operation to execute.
-///   - handler: The handler which is invoked when the RPC is cancelled.
+///   - handler: The handler that gRPC invokes when the RPC is cancelled.
 /// - Throws: Any error thrown by the `operation` closure.
 /// - Returns: The result of the `operation` closure.
 @available(gRPCSwift 2.0, *)
@@ -99,13 +99,13 @@ public func withRPCCancellationHandler<Result, Failure: Error>(
 
 /// Provides scoped access to a server RPC cancellation handle.
 ///
-/// The cancellation handle should be passed to a ``ServerContext`` and last
+/// Pass the cancellation handle to a ``ServerContext``; the handle should last
 /// the duration of the RPC.
 ///
-/// - Important: This function is intended for use when implementing
+/// - Important: Use this function when implementing
 ///   a ``ServerTransport``.
 ///
-/// If you want to be notified about RPCs being cancelled,
+/// If you want to know about RPCs being cancelled,
 /// use ``withRPCCancellationHandler(operation:onCancelRPC:)``.
 ///
 /// - Parameter operation: The operation to execute with the handle.

--- a/Sources/GRPCCore/Call/Server/ServerContext.swift
+++ b/Sources/GRPCCore/Call/Server/ServerContext.swift
@@ -28,8 +28,8 @@ public struct ServerContext: Sendable {
   ///
   /// The format of the description should follow the pattern `<transport>:<address>` where
   /// `<transport>` indicates the underlying network transport (such as `ipv4`, `unix`, or
-  /// `in-process`). This is a guideline for how descriptions should be formatted; different
-  /// implementations may not follow this format so you shouldn't make assumptions based on it.
+  /// `in-process`). This is a guideline for how transports should format descriptions; different
+  /// implementations may not follow this format, so don't make assumptions based on it.
   ///
   /// Some examples include:
   /// - `ipv4:127.0.0.1:31415`,
@@ -41,8 +41,8 @@ public struct ServerContext: Sendable {
   ///
   /// The format of the description should follow the pattern `<transport>:<address>` where
   /// `<transport>` indicates the underlying network transport (such as `ipv4`, `unix`, or
-  /// `in-process`). This is a guideline for how descriptions should be formatted; different
-  /// implementations may not follow this format so you shouldn't make assumptions based on it.
+  /// `in-process`). This is a guideline for how transports should format descriptions; different
+  /// implementations may not follow this format, so don't make assumptions based on it.
   ///
   /// Some examples include:
   /// - `ipv4:127.0.0.1:31415`,
@@ -55,8 +55,8 @@ public struct ServerContext: Sendable {
   /// Refer to the transport documentation to understand what type of
   /// value this field will contain, if any.
   ///
-  /// An example of what this field can be used for would be to store
-  /// things like a peer certificate from an mTLS connection.
+  /// For example, a transport might use this field to store something like a peer certificate
+  /// from an mTLS connection.
   public var transportSpecific: (any TransportSpecific)?
 
   /// A handle for checking the cancellation status of an RPC.

--- a/Sources/GRPCCore/Call/Server/ServerInterceptor.swift
+++ b/Sources/GRPCCore/Call/Server/ServerInterceptor.swift
@@ -16,21 +16,21 @@
 
 /// A type that intercepts requests and responses for a server.
 ///
-/// Interceptors allow you to inspect and modify requests and responses. Requests are intercepted
-/// after they have been received by the transport and responses are intercepted after they have
-/// been returned from a service. They are typically used for cross-cutting concerns like filtering
-/// requests, validating messages, logging additional data, and tracing.
+/// Interceptors allow you to inspect and modify requests and responses. The server intercepts
+/// requests after the transport receives them, and intercepts responses after a service returns
+/// them. You typically use interceptors for cross-cutting concerns like filtering requests,
+/// validating messages, logging additional data, and tracing.
 ///
-/// Interceptors can be registered with the server either directly or via ``ConditionalInterceptor``s.
+/// Register interceptors with the server either directly or via ``ConditionalInterceptor``s.
 /// You may register them for all services registered with a server, for RPCs directed to specific services, or
 /// for RPCs directed to specific methods. If you need to modify the behavior of an interceptor on a
 /// per-RPC basis in more detail, then you can use the ``ServerContext/descriptor`` to determine
-/// which RPC is being called and conditionalise behavior accordingly.
+/// which RPC the client is calling and conditionalise behavior accordingly.
 ///
 /// ## RPC filtering
 ///
 /// A common use of server-side interceptors is to filter requests from clients. Interceptors can
-/// reject requests that are invalid without service code being called. The following example
+/// reject invalid requests without calling service code. The following example
 /// demonstrates this.
 ///
 /// ```swift

--- a/Sources/GRPCCore/Call/Server/ServerRequest.swift
+++ b/Sources/GRPCCore/Call/Server/ServerRequest.swift
@@ -48,7 +48,7 @@ public struct StreamingServerRequest<Message: Sendable>: Sendable {
 
   /// A sequence of messages received from the client.
   ///
-  /// The sequence may be iterated at most once.
+  /// You may iterate the sequence at most once.
   public var messages: RPCAsyncSequence<Message, any Error>
 
   /// Creates a new streaming request.

--- a/Sources/GRPCCore/Call/Server/ServerResponse.swift
+++ b/Sources/GRPCCore/Call/Server/ServerResponse.swift
@@ -16,7 +16,7 @@
 
 /// A response for a single message sent by a server.
 ///
-/// Single responses are used for unary and client-streaming RPCs. For streaming responses,
+/// Use single responses for unary and client-streaming RPCs. For streaming responses,
 /// see ``StreamingServerResponse``.
 ///
 /// A single response captures every part of the response stream and distinguishes successful
@@ -72,11 +72,11 @@ public struct ServerResponse<Message: Sendable>: Sendable {
   public struct Contents: Sendable {
     /// Caller-specified metadata to send to the client at the start of the response.
     ///
-    /// Both gRPC Swift and its transport layer may insert additional metadata. Keys prefixed with
-    /// "grpc-" are prohibited and may result in undefined behaviour. Transports may also insert
-    /// their own metadata; you should avoid using key names that may clash with transport-specific
-    /// metadata. Note that transports may also impose limits on the amount of metadata
-    /// that may be sent.
+    /// Both gRPC Swift and its transport layer may insert additional metadata. gRPC prohibits keys
+    /// prefixed with "grpc-"; using them may result in undefined behaviour. Transports may also
+    /// insert their own metadata; avoid key names that may clash with
+    /// transport-specific metadata. Note that transports may also impose limits on the amount of
+    /// metadata you can send.
     public var metadata: Metadata
 
     /// The message to send to the client.
@@ -84,11 +84,11 @@ public struct ServerResponse<Message: Sendable>: Sendable {
 
     /// Caller-specified metadata to send to the client at the end of the response.
     ///
-    /// Both gRPC Swift and its transport layer may insert additional metadata. Keys prefixed with
-    /// "grpc-" are prohibited and may result in undefined behaviour. Transports may also insert
-    /// their own metadata; you should avoid using key names that may clash with transport-specific
-    /// metadata. Note that transports may also impose limits on the amount of metadata
-    /// that may be sent.
+    /// Both gRPC Swift and its transport layer may insert additional metadata. gRPC prohibits keys
+    /// prefixed with "grpc-"; using them may result in undefined behaviour. Transports may also
+    /// insert their own metadata; avoid key names that may clash with
+    /// transport-specific metadata. Note that transports may also impose limits on the amount of
+    /// metadata you can send.
     public var trailingMetadata: Metadata
 
     /// Creates a new single response.
@@ -128,17 +128,17 @@ public struct ServerResponse<Message: Sendable>: Sendable {
 
 /// A response for a stream of messages sent by a server.
 ///
-/// Stream responses are used for server-streaming and bidirectional-streaming RPCs. For single
+/// Use stream responses for server-streaming and bidirectional-streaming RPCs. For single
 /// responses, see ``ServerResponse``.
 ///
 /// A stream response captures every part of the response stream and distinguishes whether the
-/// request was processed by the server via the ``accepted`` property. The value for the `success`
-/// case contains the initial metadata and a closure which is provided with a message writer and
+/// server processed the request via the ``accepted`` property. The value for the `success`
+/// case contains the initial metadata and a closure that takes a message writer and
 /// returns trailing metadata. If the closure returns without error, then the response implicitly
 /// has an ``Status/Code-swift.struct/ok`` status code. You can throw an error from the producer
-/// to indicate that the request couldn't be handled successfully. If an ``RPCError`` is thrown,
+/// to indicate that it couldn't handle the request successfully. If you throw an ``RPCError``,
 /// then the client will receive an equivalent error populated with the same code and message. If
-/// an error of any other type is thrown, then the client will receive an error with the
+/// you throw an error of any other type, then the client will receive an error with the
 /// ``Status/Code-swift.struct/unknown`` status code.
 ///
 /// The `failure` case indicates that the server chose not to process the RPC. The failure case
@@ -171,7 +171,7 @@ public struct ServerResponse<Message: Sendable>: Sendable {
 /// ```
 @available(gRPCSwift 2.0, *)
 public struct StreamingServerResponse<Message: Sendable>: Sendable {
-  /// The contents of a response to a request that has been accepted for processing.
+  /// The contents of a response to a request that the server has accepted for processing.
   public struct Contents: Sendable {
     /// Metadata to send to the client at the beginning of the response stream.
     public var metadata: Metadata
@@ -183,10 +183,10 @@ public struct StreamingServerResponse<Message: Sendable>: Sendable {
     /// an ``Status/Code-swift.struct/ok`` status code. Throwing an error will terminate the RPC
     /// with an appropriate status code. You can control the status code, message, and metadata
     /// returned to the client by throwing an ``RPCError``. If the error thrown is a type other
-    /// than ``RPCError``, then a status with code ``Status/Code-swift.struct/unknown`` will
-    /// be returned to the client.
+    /// than ``RPCError``, then gRPC will return a status with code
+    /// ``Status/Code-swift.struct/unknown`` to the client.
     ///
-    /// gRPC will invoke this function at most once; therefore, it isn't required to be idempotent.
+    /// gRPC will invoke this function at most once; therefore, it doesn't need to be idempotent.
     ///
     /// Cancelling the client's call doesn't cancel this closure's `Task`. Task-local values bound
     /// with `withValue(_:operation:)` while building this response aren't visible here either:
@@ -220,8 +220,8 @@ public struct StreamingServerResponse<Message: Sendable>: Sendable {
   /// send initial metadata back to the client before producing response messages. The RPC may
   /// still result in failure by later throwing an error.
   ///
-  /// The `failure` case indicates that the server rejected the RPC and will not process it. Only
-  /// the status and trailing metadata will be sent to the client.
+  /// The `failure` case indicates that the server rejected the RPC and will not process it. The
+  /// server will only send the status and trailing metadata to the client.
   public var accepted: Result<Contents, RPCError>
 
   /// Creates a response.

--- a/Sources/GRPCCore/Call/Server/ServerResponse.swift
+++ b/Sources/GRPCCore/Call/Server/ServerResponse.swift
@@ -200,7 +200,7 @@ public struct StreamingServerResponse<Message: Sendable>: Sendable {
     /// > ``withRPCCancellationHandler(operation:onCancelRPC:)``.
     public var producer: @Sendable (RPCWriter<Message>) async throws -> Metadata
 
-    /// Creates a ``Contents``.
+    /// Creates contents for an accepted response.
     ///
     /// - Parameters:
     ///   - metadata: Metadata to send to the client at the start of the response.

--- a/Sources/GRPCCore/Coding/Coding.swift
+++ b/Sources/GRPCCore/Coding/Coding.swift
@@ -27,7 +27,7 @@ public protocol MessageSerializer<Message>: Sendable {
   /// The type of message this serializer can serialize.
   associatedtype Message
 
-  /// Serializes a ``Message`` into a sequence of bytes.
+  /// Serializes a message into a sequence of bytes.
   ///
   /// - Parameter message: The message to serialize.
   /// - Returns: The serialized bytes of a message.
@@ -47,7 +47,7 @@ public protocol MessageDeserializer<Message>: Sendable {
   /// The type of message this deserializer can deserialize.
   associatedtype Message
 
-  /// Deserializes a sequence of bytes into a ``Message``.
+  /// Deserializes a sequence of bytes into a message.
   ///
   /// - Parameter serializedMessageBytes: The bytes to deserialize.
   /// - Returns: The deserialized message.

--- a/Sources/GRPCCore/Coding/Coding.swift
+++ b/Sources/GRPCCore/Coding/Coding.swift
@@ -16,11 +16,11 @@
 
 /// Serializes a message into a sequence of bytes.
 ///
-/// Message serializers convert an input message to a sequence of bytes. Serializers are used to
-/// convert messages into a form that is suitable for sending over a network. The reverse
-/// operation, deserialization, is performed by a ``MessageDeserializer``.
+/// Message serializers convert an input message to a sequence of bytes. The transport uses
+/// serializers to convert messages into a form suitable for sending over a network. A
+/// ``MessageDeserializer`` performs the reverse operation, deserialization.
 ///
-/// Serializers are used frequently and implementations should take care to ensure that
+/// Callers use serializers frequently, so implementations should take care to ensure that
 /// serialization is as cheap as possible.
 @available(gRPCSwift 2.0, *)
 public protocol MessageSerializer<Message>: Sendable {
@@ -36,11 +36,11 @@ public protocol MessageSerializer<Message>: Sendable {
 
 /// Deserializes a sequence of bytes into a message.
 ///
-/// Message deserializers convert a sequence of bytes into a message. Deserializers are used to
-/// convert bytes received from the network into an application-specific message. The reverse
-/// operation, serialization, is performed by a ``MessageSerializer``.
+/// Message deserializers convert a sequence of bytes into a message. The transport uses
+/// deserializers to convert bytes received from the network into an application-specific
+/// message. A ``MessageSerializer`` performs the reverse operation, serialization.
 ///
-/// Deserializers are used frequently and implementations should take care to ensure that
+/// Callers use deserializers frequently, so implementations should take care to ensure that
 /// deserialization is as cheap as possible.
 @available(gRPCSwift 2.0, *)
 public protocol MessageDeserializer<Message>: Sendable {

--- a/Sources/GRPCCore/Coding/Coding.swift
+++ b/Sources/GRPCCore/Coding/Coding.swift
@@ -16,7 +16,7 @@
 
 /// Serializes a message into a sequence of bytes.
 ///
-/// Message serializers convert an input message to a sequence of bytes. The transport uses
+/// Message serializers convert an input message to a sequence of bytes. gRPC uses
 /// serializers to convert messages into a form suitable for sending over a network. A
 /// ``MessageDeserializer`` performs the reverse operation, deserialization.
 ///
@@ -36,7 +36,7 @@ public protocol MessageSerializer<Message>: Sendable {
 
 /// Deserializes a sequence of bytes into a message.
 ///
-/// Message deserializers convert a sequence of bytes into a message. The transport uses
+/// Message deserializers convert a sequence of bytes into a message. gRPC uses
 /// deserializers to convert bytes received from the network into an application-specific
 /// message. A ``MessageSerializer`` performs the reverse operation, serialization.
 ///

--- a/Sources/GRPCCore/Coding/CompressionAlgorithm.swift
+++ b/Sources/GRPCCore/Coding/CompressionAlgorithm.swift
@@ -107,6 +107,7 @@ extension CompressionAlgorithmSet {
       return Iterator(algorithmSet: self.algorithmSet)
     }
 
+    /// The iterator used by ``CompressionAlgorithmSet/Elements-swift.struct``.
     public struct Iterator: IteratorProtocol, Sendable {
       private let algorithmSet: CompressionAlgorithmSet
       private var iterator: IndexingIterator<[CompressionAlgorithm.Value]>

--- a/Sources/GRPCCore/Coding/CompressionAlgorithm.swift
+++ b/Sources/GRPCCore/Coding/CompressionAlgorithm.swift
@@ -88,12 +88,16 @@ public struct CompressionAlgorithmSet: OptionSet, Hashable, Sendable {
 
 @available(gRPCSwift 2.0, *)
 extension CompressionAlgorithmSet {
-  /// A sequence of ``CompressionAlgorithm`` values present in the set.
+  /// The compression algorithms present in this set.
+  ///
+  /// Iterating the sequence produces ``CompressionAlgorithm`` values.
   public var elements: Elements {
     Elements(algorithmSet: self)
   }
 
-  /// A sequence of ``CompressionAlgorithm`` values present in a ``CompressionAlgorithmSet``.
+  /// A sequence of the compression algorithms present in a set.
+  ///
+  /// Iterating this sequence produces ``CompressionAlgorithm`` values.
   public struct Elements: Sequence, Sendable {
     public typealias Element = CompressionAlgorithm
 
@@ -107,7 +111,7 @@ extension CompressionAlgorithmSet {
       return Iterator(algorithmSet: self.algorithmSet)
     }
 
-    /// The iterator used by ``CompressionAlgorithmSet/Elements-swift.struct``.
+    /// An iterator over the compression algorithms in a set.
     public struct Iterator: IteratorProtocol, Sendable {
       private let algorithmSet: CompressionAlgorithmSet
       private var iterator: IndexingIterator<[CompressionAlgorithm.Value]>

--- a/Sources/GRPCCore/Coding/GRPCContiguousBytes.swift
+++ b/Sources/GRPCCore/Coding/GRPCContiguousBytes.swift
@@ -16,22 +16,22 @@
 
 /// A bag-of-bytes type.
 ///
-/// This protocol is used by the transport protocols (``ClientTransport`` and ``ServerTransport``)
-/// with the serialization protocols (``MessageSerializer`` and ``MessageDeserializer``) so that
-/// messages don't have to be copied to a fixed intermediate bag-of-bytes type.
+/// The transport protocols (``ClientTransport`` and ``ServerTransport``) use this protocol
+/// together with the serialization protocols (``MessageSerializer`` and ``MessageDeserializer``)
+/// so that messages don't have to be copied to a fixed intermediate bag-of-bytes type.
 @available(gRPCSwift 2.0, *)
 public protocol GRPCContiguousBytes {
   /// Initialize the bytes to a repeated value.
   ///
   /// - Parameters:
-  ///   - byte: The value to be repeated.
+  ///   - byte: The value to repeat.
   ///   - count: The number of times to repeat the byte value.
   init(repeating byte: UInt8, count: Int)
 
   /// Initialize the bag of bytes from a sequence of bytes.
   ///
   /// - Parameters:
-  ///   - sequence: A sequence of `UInt8` from which the bag of bytes should be constructed.
+  ///   - sequence: A sequence of `UInt8` from which to construct the bag of bytes.
   init<Bytes: Sequence>(_ sequence: Bytes) where Bytes.Element == UInt8
 
   /// The number of bytes in the bag of bytes.
@@ -39,18 +39,18 @@ public protocol GRPCContiguousBytes {
 
   /// Calls the given closure with read-only access to the underlying storage.
   ///
-  /// - Note: Calling `withUnsafeBytes` multiple times does not guarantee that
-  ///         the same buffer pointer will be passed in every time.
-  /// - Warning: The buffer argument to the body should not be stored or used
-  ///            outside of the lifetime of the call to the closure.
+  /// - Note: Calling `withUnsafeBytes` multiple times does not guarantee that the implementation
+  ///         will pass in the same buffer pointer every time.
+  /// - Warning: The body should not store or use the buffer argument outside of the lifetime of
+  ///            the call to the closure.
   func withUnsafeBytes<R>(_ body: (_ buffer: UnsafeRawBufferPointer) throws -> R) rethrows -> R
 
   /// Calls the given closure with mutable access to the underlying storage.
   ///
-  /// - Note: Calling `withUnsafeBytes` multiple times does not guarantee that
-  ///         the same buffer pointer will be passed in every time.
-  /// - Warning: The buffer argument to the body should not be stored or used
-  ///            outside of the lifetime of the call to the closure.
+  /// - Note: Calling `withUnsafeBytes` multiple times does not guarantee that the implementation
+  ///         will pass in the same buffer pointer every time.
+  /// - Warning: The body should not store or use the buffer argument outside of the lifetime of
+  ///            the call to the closure.
   mutating func withUnsafeMutableBytes<R>(
     _ body: (_ buffer: UnsafeMutableRawBufferPointer) throws -> R
   ) rethrows -> R

--- a/Sources/GRPCCore/Coding/GRPCContiguousBytes.swift
+++ b/Sources/GRPCCore/Coding/GRPCContiguousBytes.swift
@@ -37,7 +37,7 @@ public protocol GRPCContiguousBytes {
   /// The number of bytes in the bag of bytes.
   var count: Int { get }
 
-  /// Calls the given closure with the contents of the underlying storage.
+  /// Calls the given closure with read-only access to the underlying storage.
   ///
   /// - Note: Calling `withUnsafeBytes` multiple times does not guarantee that
   ///         the same buffer pointer will be passed in every time.
@@ -45,7 +45,7 @@ public protocol GRPCContiguousBytes {
   ///            outside of the lifetime of the call to the closure.
   func withUnsafeBytes<R>(_ body: (_ buffer: UnsafeRawBufferPointer) throws -> R) rethrows -> R
 
-  /// Calls the given closure with the contents of the underlying storage.
+  /// Calls the given closure with mutable access to the underlying storage.
   ///
   /// - Note: Calling `withUnsafeBytes` multiple times does not guarantee that
   ///         the same buffer pointer will be passed in every time.

--- a/Sources/GRPCCore/Configuration/MethodConfig.swift
+++ b/Sources/GRPCCore/Configuration/MethodConfig.swift
@@ -76,50 +76,50 @@ public struct MethodConfig: Hashable, Sendable {
 
   /// The default timeout for the RPC.
   ///
-  /// If no reply is received in the specified amount of time, the request is aborted
+  /// If gRPC doesn't receive a reply in the specified amount of time, it aborts the request
   /// with an ``RPCError`` with code ``RPCError/Code/deadlineExceeded``.
   ///
   /// The actual deadline used will be the minimum of the value specified here
   /// and the value set by the application by the client API. If either one isn't set,
-  /// then the other value is used. If neither is set, then the request has no deadline.
+  /// gRPC uses the other value. If neither is set, then the request has no deadline.
   ///
-  /// The timeout applies to the overall execution of an RPC. If, for example, a retry
-  /// policy is set, then the timeout begins when the first attempt is started and _isn't_ reset
-  /// when subsequent attempts start.
+  /// The timeout applies to the overall execution of an RPC. For example, if you set a retry
+  /// policy, the timeout begins when the first attempt starts, and subsequent attempts don't
+  /// reset it.
   public var timeout: Duration?
 
   /// The maximum allowed payload size in bytes for an individual message.
   ///
-  /// If a client attempts to send an object larger than this value, it will not be sent, and the
-  /// client will see an error. Note that 0 is a valid value, meaning that the request message
-  /// must be empty.
+  /// If a client attempts to send an object larger than this value, the client won't send it,
+  /// and the client will see an error. Note that 0 is a valid value, meaning that the request
+  /// message must be empty.
   ///
-  /// Note that if compression is used, the uncompressed message size is validated.
+  /// Note that if you use compression, gRPC validates the uncompressed message size.
   public var maxRequestMessageBytes: Int?
 
   /// The maximum allowed payload size in bytes for an individual response message.
   ///
-  /// If a server attempts to send an object larger than this value, it will not
-  /// be sent, and an error will be sent to the client instead. Note that 0 is a valid value,
-  /// meaning that the response message must be empty.
+  /// If a server attempts to send an object larger than this value, the server won't send it,
+  /// and it will send an error to the client instead. Note that 0 is a valid value, meaning
+  /// that the response message must be empty.
   ///
-  /// Note that if compression is used, the uncompressed message size is validated.
+  /// Note that if you use compression, gRPC validates the uncompressed message size.
   public var maxResponseMessageBytes: Int?
 
-  /// The policy determining how many times, and when, the RPC is executed.
+  /// The policy that determines how many times, and when, gRPC executes the RPC.
   ///
   /// There are two policy types:
   /// 1. Retry
   /// 2. Hedging
   ///
-  /// The retry policy allows an RPC to be retried a limited number of times if the RPC
-  /// fails with one of the configured set of status codes. RPCs are only retried if they
+  /// The retry policy allows gRPC to retry an RPC a limited number of times if the RPC
+  /// fails with one of the configured set of status codes. gRPC only retries RPCs if they
   /// fail immediately, that is, the first response part received from the server is a
   /// status code.
   ///
-  /// The hedging policy allows an RPC to be executed multiple times concurrently. Typically
-  /// each execution will be staggered by some delay. The first successful response will be
-  /// reported to the client. Hedging is only suitable for idempotent RPCs.
+  /// The hedging policy allows gRPC to execute an RPC multiple times concurrently. Typically,
+  /// gRPC staggers each execution by some delay. gRPC reports the first successful response
+  /// to the client. Hedging is only suitable for idempotent RPCs.
   public var executionPolicy: RPCExecutionPolicy?
 
   /// Creates an execution configuration.
@@ -148,7 +148,7 @@ public struct MethodConfig: Hashable, Sendable {
   }
 }
 
-/// Whether an RPC should be retried or hedged.
+/// Whether to retry or hedge an RPC.
 @available(gRPCSwift 2.0, *)
 public struct RPCExecutionPolicy: Hashable, Sendable {
   @usableFromInline
@@ -206,14 +206,14 @@ public struct RPCExecutionPolicy: Hashable, Sendable {
 ///
 /// gRPC retries RPCs when the first response from the server is a status code that matches
 /// one of the configured retryable status codes. If the server begins processing the RPC and
-/// first responds with metadata and later responds with a retryable status code, then the RPC
-/// won't be retried.
+/// first responds with metadata and later responds with a retryable status code, then gRPC
+/// won't retry the RPC.
 ///
-/// Execution attempts are limited by ``maxAttempts``, which includes the original attempt. The
-/// maximum number of attempts is limited to five.
+/// ``maxAttempts`` limits execution attempts, including the original attempt. gRPC caps the
+/// maximum number of attempts at five.
 ///
-/// Subsequent attempts are executed after some delay. The first _retry_, or second attempt, will
-/// be started after a randomly chosen delay between zero and ``initialBackoff``. More generally,
+/// gRPC executes subsequent attempts after some delay. It starts the first _retry_, or second
+/// attempt, after a randomly chosen delay between zero and ``initialBackoff``. More generally,
 /// the nth retry will happen after a randomly chosen delay between zero
 /// and `min(initialBackoff * backoffMultiplier^(n-1), maxBackoff)`.
 ///
@@ -223,7 +223,7 @@ public struct RPCExecutionPolicy: Hashable, Sendable {
 public struct RetryPolicy: Hashable, Sendable {
   /// The maximum number of RPC attempts, including the original attempt.
   ///
-  /// Must be greater than one. Values greater than five are treated as five.
+  /// Must be greater than one. gRPC treats values greater than five as five.
   public var maxAttempts: Int {
     didSet { self.maxAttempts = try! validateMaxAttempts(self.maxAttempts) }
   }
@@ -251,7 +251,7 @@ public struct RetryPolicy: Hashable, Sendable {
     willSet { try! Self.validateBackoffMultiplier(newValue) }
   }
 
-  /// The set of status codes that may be retried.
+  /// The set of status codes that gRPC may retry.
   ///
   /// - Precondition: Must not be empty.
   public var retryableStatusCodes: Set<Status.Code> {
@@ -267,7 +267,7 @@ public struct RetryPolicy: Hashable, Sendable {
   ///   - maxBackoff: The maximum period of time to wait between attempts. Must be greater than
   ///       zero.
   ///   - backoffMultiplier: The exponential backoff multiplier. Must be greater than zero.
-  ///   - retryableStatusCodes: The set of status codes that may be retried. Must not be empty.
+  ///   - retryableStatusCodes: The set of status codes that gRPC may retry. Must not be empty.
   /// - Precondition: `maxAttempts` must be greater than one.
   /// - Precondition: `initialBackoff`, `maxBackoff`, and `backoffMultiplier` must be greater
   ///     than zero.
@@ -330,8 +330,8 @@ public struct RetryPolicy: Hashable, Sendable {
 
 /// Policy for hedging an RPC.
 ///
-/// Hedged RPCs may execute more than once on a server, so only idempotent methods should
-/// be hedged.
+/// Hedged RPCs may execute more than once on a server, so only hedge idempotent
+/// methods.
 ///
 /// gRPC executes the RPC at most ``maxAttempts`` times, staggering each attempt
 /// by ``hedgingDelay``.
@@ -342,14 +342,14 @@ public struct RetryPolicy: Hashable, Sendable {
 public struct HedgingPolicy: Hashable, Sendable {
   /// The maximum number of RPC attempts, including the original attempt.
   ///
-  /// Values greater than five are treated as five.
+  /// gRPC treats values greater than five as five.
   ///
   /// - Precondition: Must be greater than one.
   public var maxAttempts: Int {
     didSet { self.maxAttempts = try! validateMaxAttempts(self.maxAttempts) }
   }
 
-  /// The first RPC is sent immediately, and each subsequent RPC is sent after this delay.
+  /// gRPC sends the first RPC immediately and sends each subsequent RPC after this delay.
   ///
   /// Set this to zero to immediately send all RPCs.
   public var hedgingDelay: Duration {
@@ -358,9 +358,8 @@ public struct HedgingPolicy: Hashable, Sendable {
 
   /// The set of status codes that indicate other hedged RPCs may still succeed.
   ///
-  /// If a non-fatal status code is returned by the server, hedged RPCs will continue.
-  /// Otherwise, outstanding requests will be cancelled and the error returned to the
-  /// application layer.
+  /// If the server returns a non-fatal status code, hedged RPCs will continue. Otherwise,
+  /// gRPC cancels outstanding requests and returns the error to the application layer.
   public var nonFatalStatusCodes: Set<Status.Code>
 
   /// Creates a new hedging policy.

--- a/Sources/GRPCCore/Configuration/MethodConfig.swift
+++ b/Sources/GRPCCore/Configuration/MethodConfig.swift
@@ -349,8 +349,7 @@ public struct HedgingPolicy: Hashable, Sendable {
     didSet { self.maxAttempts = try! validateMaxAttempts(self.maxAttempts) }
   }
 
-  /// The first RPC will be sent immediately, but each subsequent RPC will be sent at intervals
-  /// of `hedgingDelay`.
+  /// The first RPC is sent immediately, and each subsequent RPC is sent after this delay.
   ///
   /// Set this to zero to immediately send all RPCs.
   public var hedgingDelay: Duration {

--- a/Sources/GRPCCore/Configuration/ServiceConfig.swift
+++ b/Sources/GRPCCore/Configuration/ServiceConfig.swift
@@ -50,7 +50,7 @@ public struct ServiceConfig: Hashable, Sendable {
   /// and hedged RPCs will not be sent.
   public var retryThrottling: RetryThrottling?
 
-  /// Creates a new ``ServiceConfig``.
+  /// Creates a new service configuration.
   ///
   /// - Parameters:
   ///   - methodConfig: Per-method configuration.

--- a/Sources/GRPCCore/Configuration/ServiceConfig.swift
+++ b/Sources/GRPCCore/Configuration/ServiceConfig.swift
@@ -232,6 +232,7 @@ extension ServiceConfig.LoadBalancingConfig: Codable {
 
 @available(gRPCSwift 2.0, *)
 extension ServiceConfig {
+  /// Configuration for throttling retries and hedging attempts.
   public struct RetryThrottling: Hashable, Sendable, Codable {
     /// The initial and maximum number of tokens.
     ///

--- a/Sources/GRPCCore/Configuration/ServiceConfig.swift
+++ b/Sources/GRPCCore/Configuration/ServiceConfig.swift
@@ -19,9 +19,9 @@
 /// A service config mostly contains parameters describing how clients connecting to a service
 /// should behave (for example, the load balancing policy to use).
 ///
-/// The schema is described by [`grpc/service_config/service_config.proto`](https://github.com/grpc/grpc-proto/blob/0b30c8c05277ab78ec72e77c9cbf66a26684673d/grpc/service_config/service_config.proto)
-/// in the `grpc/grpc-proto` GitHub repository, although gRPC uses it in its JSON form rather than
-/// the Protobuf form.
+/// [`grpc/service_config/service_config.proto`](https://github.com/grpc/grpc-proto/blob/0b30c8c05277ab78ec72e77c9cbf66a26684673d/grpc/service_config/service_config.proto)
+/// in the `grpc/grpc-proto` GitHub repository describes the schema, although gRPC uses it in
+/// its JSON form rather than the Protobuf form.
 @available(gRPCSwift 2.0, *)
 public struct ServiceConfig: Hashable, Sendable {
   /// Per-method configuration.
@@ -30,15 +30,15 @@ public struct ServiceConfig: Hashable, Sendable {
   /// Load balancing policies.
   ///
   /// The client iterates through the list in order and picks the first configuration it supports.
-  /// If no policies are supported, then the configuration is considered to be invalid.
+  /// If the client doesn't support any policies, gRPC considers the configuration invalid.
   public var loadBalancingConfig: [LoadBalancingConfig]
 
   /// The policy for throttling retries.
   ///
-  /// If ``RetryThrottling`` is provided, gRPC will automatically throttle retry attempts
+  /// If you provide ``RetryThrottling``, gRPC will automatically throttle retry attempts
   /// and hedged RPCs when the client's ratio of failures to successes exceeds a threshold.
   ///
-  /// For each server name, the gRPC client will maintain a `token_count` that is initially set
+  /// For each server name, the gRPC client will maintain a `token_count`, initially set
   /// to ``RetryThrottling-swift.struct/maxTokens``. Every outgoing RPC (regardless of service or
   /// method invoked) will change `token_count` as follows:
   ///
@@ -46,8 +46,8 @@ public struct ServiceConfig: Hashable, Sendable {
   ///   - Every successful RPC will increment the `token_count` by
   ///   ``RetryThrottling-swift.struct/tokenRatio``.
   ///
-  /// If `token_count` is less than or equal to `max_tokens / 2`, then RPCs will not be retried
-  /// and hedged RPCs will not be sent.
+  /// If `token_count` is less than or equal to `max_tokens / 2`, gRPC will not retry RPCs
+  /// and will not send hedged RPCs.
   public var retryThrottling: RetryThrottling?
 
   /// Creates a new service configuration.
@@ -121,8 +121,8 @@ extension ServiceConfig {
 
     /// Creates a pick-first load balancing policy with the given address-shuffling behavior.
     ///
-    /// - Parameter shuffleAddressList: Whether resolved addresses should be shuffled before
-    ///     attempting to connect to them.
+    /// - Parameter shuffleAddressList: Whether to shuffle resolved addresses before attempting
+    ///     to connect to them.
     public static func pickFirst(shuffleAddressList: Bool) -> Self {
       Self(.pickFirst(PickFirst(shuffleAddressList: shuffleAddressList)))
     }
@@ -175,11 +175,11 @@ extension ServiceConfig {
 extension ServiceConfig.LoadBalancingConfig {
   /// Configuration for the pick-first load balancing policy.
   public struct PickFirst: Hashable, Sendable, Codable {
-    /// Whether the resolved addresses should be shuffled before attempting to connect to them.
+    /// Whether to shuffle the resolved addresses before attempting to connect to them.
     public var shuffleAddressList: Bool
 
     /// Creates a new pick-first load balancing policy.
-    /// - Parameter shuffleAddressList: Whether the resolved addresses should be shuffled before
+    /// - Parameter shuffleAddressList: Whether to shuffle the resolved addresses before
     ///     attempting to connect to them.
     public init(shuffleAddressList: Bool = false) {
       self.shuffleAddressList = shuffleAddressList
@@ -241,8 +241,8 @@ extension ServiceConfig {
 
     /// The amount of tokens to add on each successful RPC.
     ///
-    /// Typically this will be some number between 0 and 1, for example, 0.1. Up to three decimal
-    /// places are supported.
+    /// Typically, this is some number between 0 and 1, for example, 0.1. gRPC supports up to
+    /// three decimal places.
     ///
     /// - Precondition: Must be greater than zero.
     public var tokenRatio: Double

--- a/Sources/GRPCCore/Documentation.docc/Articles/Compatibility.md
+++ b/Sources/GRPCCore/Documentation.docc/Articles/Compatibility.md
@@ -1,6 +1,6 @@
 # Compatibility
 
-Learn which versions of Swift are supported by gRPC Swift and how this changes
+Learn which versions of Swift gRPC Swift supports and how this changes
 over time.
 
 ## Overview
@@ -8,7 +8,7 @@ over time.
 ### Supported Swift Versions
 
 gRPC Swift supports the **three most recent Swift versions** that are **Swift 6
-or newer**. Within a minor Swift release, only the latest patch version is supported.
+or newer**. Within a minor Swift release, gRPC Swift supports only the latest patch version.
 
 | grpc-swift-2 | Minimum Supported Swift version |
 |--------------|---------------------------------|
@@ -16,8 +16,8 @@ or newer**. Within a minor Swift release, only the latest patch version is suppo
 
 ### Platforms
 
-gRPC Swift aims to support the same platforms as the Swift project. These are listed
-on [swift.org](https://www.swift.org/platform-support/).
+gRPC Swift aims to support the same platforms as the Swift project.
+[swift.org](https://www.swift.org/platform-support/) lists these.
 
 The only known unsupported platform from that list is currently Windows.
 

--- a/Sources/GRPCCore/Documentation.docc/Articles/Error-handling.md
+++ b/Sources/GRPCCore/Documentation.docc/Articles/Error-handling.md
@@ -95,5 +95,4 @@ the HTTP status is synthesized into a ``Status`` for you to catch as an
 For clients using the rich error model, the ``RPCError`` can be caught and a
 detailed error can be extracted from it using `unpackGoogleRPCStatus()`.
 
-See [`error-details`](https://github.com/grpc/grpc-swift-2/tree/main/Examples/error-details) for
-an example.
+See [`error-details`](https://github.com/grpc/grpc-swift-2/tree/main/Examples/error-details) for an example.

--- a/Sources/GRPCCore/Documentation.docc/Articles/Error-handling.md
+++ b/Sources/GRPCCore/Documentation.docc/Articles/Error-handling.md
@@ -19,16 +19,16 @@ gRPC has two widely used error models:
 
 #### Standard error model
 
-In gRPC the outcome of every RPC is represented by a status made up of a code
-and a message. The status is propagated from the server to the client in the
+In gRPC, a status made up of a code and a message represents the outcome of
+every RPC. gRPC propagates the status from the server to the client in the
 metadata as the final part of an RPC indicating the outcome of the RPC.
 
 You can find more information about the error codes in ``RPCError/Code`` and in
 the status codes guide on the
 [gRPC website](https://grpc.io/docs/guides/status-codes/).
 
-This mechanism is part of the gRPC protocol and is supported by all client/server
-gRPC libraries regardless of the data format (for example, Protocol Buffers) being used
+This mechanism is part of the gRPC protocol, and all client/server gRPC libraries
+support it regardless of the data format (for example, Protocol Buffers) you use
 for messages.
 
 #### Rich error model
@@ -37,15 +37,15 @@ The standard error model is quite limited and doesn't include the ability to
 communicate details about the error. If you're using the Protocol Buffers data
 format for messages, then you may wish to use the “rich” error model.
 
-The model was developed and used by Google and is described in more detail
-in the [gRPC error guide](https://grpc.io/docs/guides/error/) and
-[Google AIP-193](https://google.aip.dev/193).
+Google developed and used the model, which the
+[gRPC error guide](https://grpc.io/docs/guides/error/) and
+[Google AIP-193](https://google.aip.dev/193) describe in more detail.
 
 While not officially part of gRPC, it's a widely used convention with support in
 various client/server gRPC libraries, including gRPC Swift.
 
 It specifies a standard set of error message types covering the most common
-situations. The error details are encoded as protobuf messages in the trailing
+situations. The rich error model encodes the error details as protobuf messages in the trailing
 metadata of an RPC. Clients are able to deserialize and access the details as
 type-safe structured messages should they need to.
 
@@ -55,8 +55,8 @@ Learn how to use both models in gRPC Swift.
 
 #### Service authors
 
-Errors thrown from an RPC handler are caught by the gRPC runtime and turned into
-a status. You have two options to ensure that an appropriate status is sent to
+The gRPC runtime catches errors your RPC handler throws and turns them into
+a status. You have two options to ensure that the gRPC runtime sends an appropriate status to
 the client if your RPC handler throws an error:
 
 1. Throw an ``RPCError`` that explicitly sets the desired status code and
@@ -64,17 +64,17 @@ the client if your RPC handler throws an error:
 2. Throw an error conforming to ``RPCErrorConvertible`` that the gRPC runtime
    will use to create an ``RPCError``.
 
-Any errors thrown that don't fall into these categories will result in a status
-code of `unknown` being sent to the client.
+Any errors thrown that don't fall into these categories cause the gRPC runtime to send a status
+code of `unknown` to the client.
 
-Generally speaking, expected failure scenarios should be considered as part of
-the API contract and each RPC should be documented accordingly.
+Generally speaking, you should consider expected failure scenarios as part of
+the API contract and document each RPC accordingly.
 
 #### Clients
 
 Clients should catch ``RPCError`` if they are interested in the failures from an
-RPC. This is a manifestation of the error sent by the server, but in some cases
-it may be synthesized locally. For example, if a client-side timeout fires
+RPC. This is a manifestation of the error the server sends, but in some cases
+the client may synthesize it locally. For example, if a client-side timeout fires
 before the RPC completes, the client throws an ``RPCError`` with code
 ``RPCError/Code-swift.struct/deadlineExceeded``. If the calling `Task` is
 cancelled, the client may instead throw an ``RPCError`` with code `unknown`
@@ -84,15 +84,15 @@ you need to distinguish cancellation from other failures reported as `unknown`.
 Failures to serialize a request or deserialize a response also surface as an
 ``RPCError``; the exact code and message depend on the serializer/deserializer
 in use. For example, the Protobuf codec provided by `grpc-swift-protobuf` uses
-``RPCError/Code-swift.struct/invalidArgument`` when a message can't be
-serialized or deserialized.
+``RPCError/Code-swift.struct/invalidArgument`` when it can't
+serialize or deserialize a message.
 
 If the transport receives a non-200 HTTP status without an accompanying gRPC
 status (for example because the RPC failed before reaching a gRPC-aware peer),
-the HTTP status is synthesized into a ``Status`` for you to catch as an
+gRPC Swift synthesizes the HTTP status into a ``Status`` for you to catch as an
 ``RPCError``.
 
-For clients using the rich error model, the ``RPCError`` can be caught and a
-detailed error can be extracted from it using `unpackGoogleRPCStatus()`.
+For clients using the rich error model, you can catch the ``RPCError`` and
+extract a detailed error from it using `unpackGoogleRPCStatus()`.
 
 See [`error-details`](https://github.com/grpc/grpc-swift-2/tree/main/Examples/error-details) for an example.

--- a/Sources/GRPCCore/Documentation.docc/Articles/Migration-guide.md
+++ b/Sources/GRPCCore/Documentation.docc/Articles/Migration-guide.md
@@ -232,13 +232,13 @@ compiles and commit any changes.
 
 > If you only need to migrate clients, then skip this section.
 
-By now, your package should be set up to depend on a patched version of 1.x and 2.x
-and have both sets of generated code and still compile. It's time to make some
+By now, your package should depend on a patched version of 1.x and 2.x, have both sets of
+generated code, and still compile. It's time to make some
 code changes, so let's start by migrating a service.
 
 
-A number of these steps can be automated, and the `v1_to_v2` script can do just
-this. However, it might not be sufficient, and you should read through the
+The `v1_to_v2` script can automate a number of these steps. However, it might not be
+sufficient, and you should read through the
 steps below to understand what transformations are done.
 
 Find the service you wish to migrate. The first step is to update any imports
@@ -256,7 +256,7 @@ skip to the section called `ServiceProtocol`.
 
 The requirements for each method are also slightly different; in 2.x the context
 type is called `ServerContext` as opposed to `GRPCAsyncServerCallContext` in 1.x.
-It also has different functionality, but that will be covered later. The types
+It also has different functionality, but this guide covers that later. The types
 for streaming requests and responses are also different:
 - `GRPCAsyncRequestStream<T>` became `RPCAsyncSequence<T, any Error>`, and
 - `GRPCAsyncResponseStreamWriter<T>` became `RPCWriter<T>`.
@@ -290,16 +290,16 @@ service to the 1.x protocol and the 2.x protocol. Add conformance to the
 service (if your service is called `Baz` and declared in the `foo.bar` Protocol
 Buffers package, then this would be `Foo_Bar_Baz.ServiceProtocol`).
 
-Let Xcode generate stubs for the methods that haven't been implemented yet and
+Let Xcode generate stubs for the methods you haven't implemented yet and
 fill each one with a `fatalError` so that your app builds. Each method
 should take a `ServerRequest` or `StreamingServerRequest` and context as input
 and return a `ServerResponse` or `StreamingServerResponse`. Request metadata is
 available on the request object. For single responses, you can set initial and
 trailing metadata when you create the response. For streaming responses, you can
 set initial metadata in the initializer and return trailing metadata from the
-closure you provide to the initializer. This is demonstrated in the
+closure you provide to the initializer. The
 [`echo-metadata`](https://github.com/grpc/grpc-swift-2/tree/main/Examples/echo-metadata)
-example.
+example demonstrates this.
 
 One important difference between this approach and the `SimpleServiceProtocol`
 (and 1.x) is that responses aren't completed until the body of the response has
@@ -359,11 +359,11 @@ it, it's time to commit any changes you've made.
 
 Migrating client code is more difficult as you typically use client code
 throughout a wider part of your app. Our approach is to migrate from client
-calls first and then work upwards through your app to where the client is
-created.
+calls first and then work upwards through your app to where you create the
+client.
 
-Start by finding a place within the target being migrated where a generated
-client is being used.
+Start by finding a place within the target you're migrating where you use a
+generated client.
 
 Note that the generated client in 2.x is generic over a transport type; any
 types or functions using it will either need to choose a concrete type or
@@ -373,11 +373,11 @@ also become generic. The most similar replacements to 1.x are:
 - `HTTP2ClientTransport.TransportServices`.
 
 Changing the type of the client will cause numerous build errors. To keep the
-number of errors manageable, you'll migrate one function at a time. How this
-is done depends on whether the generated client is passed in to the function
-or stored on a property.
+number of errors manageable, you'll migrate one function at a time. How you do this
+depends on whether the function receives the generated client as a parameter
+or a property stores it.
 
-If the function is passed a generated client, then duplicate it, changing the
+If you pass the function a generated client, then duplicate it, changing the
 signature to use a 2.x generated client. The new client is
 named `{Service}.Client` where `{Service}` is the namespaced name of your
 service (if your service is named `Baz` and declared in the `foo.bar`
@@ -452,7 +452,7 @@ any of the unused functions.
 
 ## Client migration
 
-Once all client call sites have been updated, you'll need to update how you
+Once you've updated all client call sites, you'll need to update how you
 create the client. Find where you create the client in your app. In this file,
 you'll need to add imports for `GRPCCore` (which provides the client type) and
 `GRPCNIOTransportHTTP2` (which provides HTTP/2 transports built on top of

--- a/Sources/GRPCCore/Documentation.docc/Articles/Public-API.md
+++ b/Sources/GRPCCore/Documentation.docc/Articles/Public-API.md
@@ -21,7 +21,7 @@ For clarity, the project comprises the following Swift packages:
 
 ### Library targets
 
-All library targets made available as package products are considered to be
+The project considers all library targets made available as package products to be
 public API. Examples of these include `GRPCCore` and `GRPCProtobuf`.
 
 > Exceptions:
@@ -42,9 +42,8 @@ targets are part of the public API. Examples include `Metadata`,
 
 ### Configuration and inputs
 
-Any configuration, input, and interfaces to executable products that have
-inputs (such as command line arguments, or configuration files) are considered
-to be public API. Examples of these include the configuration file passed to the
+The project considers any configuration, input, and interfaces to executable products that have
+inputs (such as command line arguments, or configuration files) to be public API. Examples of these include the configuration file passed to the
 Swift Package Manager build plugin for generating stubs provided by
 [grpc-swift-protobuf][3].
 
@@ -62,16 +61,16 @@ To illustrate this, the maintainers may:
 2. Add a new top-level function to an existing module called `grpcRun()` but
    will not add a new top-level function called `run()`.
 3. Add a new module called `GRPCFoo`. Any symbols added to the new module at the
-   point the module becomes API aren't required to have a “GRPC” prefix; symbols
-   added after that point will be prefixed as required by (1) and (2).
+   point the module becomes API aren't required to have a “GRPC” prefix; the maintainers
+   will prefix symbols added after that point, as required by (1) and (2).
 
 This allows the project to follow Semantic Versioning without breaking adopter
 code in minor and patch releases.
 
 ## Guidelines for users
 
-In order to not have your code broken by a gRPC Swift update, you should only use
-the public API as described above. There are a number of other guidelines you
+So a gRPC Swift update doesn't break your code, you should only use
+the public API described above. There are a number of other guidelines you
 should follow as well:
 
 1. You _may_ conform your own types to protocols provided by gRPC Swift.

--- a/Sources/GRPCCore/Documentation.docc/Development/Benchmarks.md
+++ b/Sources/GRPCCore/Documentation.docc/Development/Benchmarks.md
@@ -1,6 +1,6 @@
 # Benchmarks
 
-This article discusses benchmarking in `grpc-swift-2`.
+This article discusses benchmarking in the grpc-swift-2 repository.
 
 ## Overview
 

--- a/Sources/GRPCCore/Documentation.docc/Development/Benchmarks.md
+++ b/Sources/GRPCCore/Documentation.docc/Development/Benchmarks.md
@@ -8,10 +8,10 @@ Benchmarks for this package are in a separate Swift Package in the `IntegrationT
 subdirectory of the repository.
 
 They use the [`package-benchmark`](https://github.com/ordo-one/package-benchmark) plugin.
-Benchmarks depend on the [`jemalloc`](https://jemalloc.net) memory allocation library, which is
-used by `package-benchmark` to capture memory allocation statistics.
+Benchmarks depend on the [`jemalloc`](https://jemalloc.net) memory allocation library, which
+`package-benchmark` uses to capture memory allocation statistics.
 
-An installation guide can be found in the [Getting Started article](https://swiftpackageindex.com/ordo-one/package-benchmark/documentation/benchmark/gettingstarted)
+You can find an installation guide in the [Getting Started article](https://swiftpackageindex.com/ordo-one/package-benchmark/documentation/benchmark/gettingstarted)
 for `package-benchmark`.
 
 ### Running the benchmarks
@@ -23,8 +23,8 @@ You can run the benchmarks CLI by going to the `IntegrationTests/Benchmarks` sub
 swift package benchmark
 ```
 
-Profiling benchmarks, or building them in release mode in Xcode, isn't currently
-supported with `jemalloc` enabled. Disable `jemalloc` to do either.
+You can't currently profile benchmarks, or build them in release mode in Xcode, with
+`jemalloc` enabled. Disable `jemalloc` to do either.
 
 Quit Xcode, then open it from the command line with the `BENCHMARK_DISABLE_JEMALLOC=true`
 environment variable set:

--- a/Sources/GRPCCore/Documentation.docc/Development/Design.md
+++ b/Sources/GRPCCore/Documentation.docc/Development/Design.md
@@ -2,7 +2,7 @@
 
 This article provides a high-level overview of the design of gRPC Swift.
 
-The library is split into three broad layers:
+The library has three broad layers:
 1. Transport,
 2. Call, and
 3. Stub.
@@ -46,31 +46,31 @@ protocols to create a server or client, respectively.
 #### Server transport
 
 The ``ServerTransport`` is responsible for the server half of a transport. It
-listens for new gRPC streams and then processes them. This is achieved via the
-``ServerTransport/listen(streamHandler:)`` requirement.
+listens for new gRPC streams and then processes them. The
+``ServerTransport/listen(streamHandler:)`` requirement achieves this.
 
-A handler is passed into the `listen` method, which is provided by the gRPC
-server. It's responsible for routing and handling the stream. The stream is
-executed in the context of the server transport — that is, the `listen` method
-is an ancestor task of all RPCs handled by the server.
+The gRPC server passes a handler, which it provides, into the `listen` method.
+It's responsible for routing and handling the stream. The server transport executes the
+stream in its own context — that is, the `listen` method
+is an ancestor task of all RPCs the server handles.
 
 Note that the server transport doesn't include the idea of a “connection”. While
 an HTTP/2 server transport will in all likelihood have multiple connections open
-at any given time, that detail isn't surfaced at this level of abstraction.
+at any given time, this abstraction doesn't surface that detail.
 
 #### Client transport
 
 While the server is responsible for handling streams, the ``ClientTransport`` is
 responsible for creating them. Client transports will typically maintain a
-number of connections that may change over a period of time. Maintaining these
-connections and other background work is done in the ``ClientTransport/connect()``
+number of connections that may change over a period of time. The client transport maintains these
+connections and does other background work in the ``ClientTransport/connect()``
 method. Cancelling the task running this method will result in the transport
-abruptly closing. The transport can be shut down gracefully by calling
+abruptly closing. You can shut down the transport gracefully by calling
 ``ClientTransport/beginGracefulShutdown()``.
 
-Streams are created using ``ClientTransport/withStream(descriptor:options:_:)``
-and the lifetime of the stream is limited to the closure. The handler passed to
-the method will be provided by a gRPC client and will ultimately include the
+You create streams using ``ClientTransport/withStream(descriptor:options:_:)``,
+and the closure limits the stream's lifetime. A gRPC client will provide the handler passed to
+the method, which will ultimately include the
 caller's code to send request messages and process response messages. Cancelling
 the task abruptly closes the stream, although the transport should ensure that
 doing this doesn't leave the other side waiting indefinitely.
@@ -78,16 +78,16 @@ doing this doesn't leave the other side waiting indefinitely.
 gRPC has mechanisms to deliver method-specific configuration at the transport
 layer which can also change dynamically (see [gRFC A2: ServiceConfig in
 DNS](https://github.com/grpc/proposal/blob/0e1807a6e30a1a915c0dcadc873bca92b9fa9720/A2-service-configs-in-dns.md)).
-This configuration is used to determine how clients should interact with servers
-and how methods should be executed, such as the conditions under which they
-may be retried. Some of this is exposed via the ``ClientTransport`` as
-the ``ClientTransport/retryThrottle`` and
+gRPC uses this configuration to determine how clients should interact with servers
+and how the call layer should execute methods, such as the conditions under which it
+may retry them. The ``ClientTransport`` protocol exposes some of this as
+``ClientTransport/retryThrottle`` and
 ``ClientTransport/config(forMethod:)``.
 
 #### Streams
 
 Both client and server transport protocols use ``RPCStream`` to represent
-streams of information. Each RPC can be thought of as having two logical
+streams of information. You can think of each RPC as having two logical
 streams: a request stream where information flows from client to server,
 and a response stream where information flows from server to client.
 Each ``RPCStream`` has inbound and outbound types corresponding to one end of
@@ -96,7 +96,7 @@ each stream.
 Inbound types are `AsyncSequence`s (specifically ``RPCAsyncSequence``) of stream
 parts, and the outbound types are writer objects (``RPCWriter``) of stream parts.
 
-The stream parts are defined as:
+GRPCCore defines the stream parts as:
 - ``RPCRequestPart``, and
 - ``RPCResponsePart``.
 
@@ -143,15 +143,15 @@ compiler, `protoc`.
 #### Interceptors
 
 This layer also provides client and server interceptors allowing you to modify requests
-and responses between the caller and the network. These are implemented as
+and responses between the caller and the network. The call layer implements these as
 ``ClientInterceptor`` and ``ServerInterceptor``, respectively.
 
 As all RPC types are special cases of bidirectional streaming RPCs, the interceptor
 APIs follow the shape of the respective client and server bidirectional streaming APIs.
 Naturally, the interceptor APIs are `async`.
 
-Interceptors are registered directly with the ``GRPCClient`` and ``GRPCServer`` and
-can either be applied to all RPCs or to specific services.
+You register interceptors directly with the ``GRPCClient`` and ``GRPCServer``, and
+you can apply them to all RPCs or to specific services.
 
 #### Client
 
@@ -164,7 +164,7 @@ four types of RPC against a ``ClientTransport``. These methods are:
 - ``GRPCClient/bidirectionalStreaming(request:descriptor:serializer:deserializer:options:onResponse:)``.
 
 As lower-level methods, they require you to pass in a serializer and
-deserializer, as well as the descriptor of the method being called. Each method
+deserializer, as well as the descriptor of the method you're calling. Each method
 has a response-handling closure to process the response from the server, and the
 method won't return until the handler has returned. This enforces structured
 concurrency.
@@ -172,21 +172,21 @@ concurrency.
 Most users won't use ``GRPCClient`` to execute RPCs directly; instead, they will
 use the generated client stubs that wrap the ``GRPCClient``. Users are
 responsible for creating the client and running it (which starts and runs the
-underlying transport). This is done by calling ``GRPCClient/runConnections()``. The client
-can be shut down gracefully by calling ``GRPCClient/beginGracefulShutdown()``,
-which will stop new RPCs from starting (by failing them with
-``RPCError/Code-swift.struct/unavailable``) but allow existing ones to continue.
-Existing work can be stopped more abruptly by cancelling the task where
+underlying transport). You do this by calling ``GRPCClient/runConnections()``. You
+can shut down the client gracefully by calling ``GRPCClient/beginGracefulShutdown()``,
+which stops new RPCs from starting (by failing them with
+``RPCError/Code-swift.struct/unavailable``) but lets existing ones continue.
+You can stop existing work more abruptly by cancelling the task where
 ``GRPCClient/runConnections()`` is executing.
 
 #### Server
 
-``GRPCServer`` is provided by the call layer to host services for a given
+The call layer provides ``GRPCServer`` to host services for a given
 transport. Beyond creating the server, it has a very limited API surface: it has
 a ``GRPCServer/serve()`` method, which runs the underlying transport and is the
 task under which all accepted streams run. Much like the client, you
 can initiate graceful shutdown by calling ``GRPCServer/beginGracefulShutdown()``,
-which will stop new RPCs from being handled but will let existing RPCs run to
+which will stop the server from handling new RPCs but will let existing RPCs run to
 completion. Cancelling the task will close the server more abruptly.
 
 ### Stub
@@ -215,7 +215,7 @@ Each service has three protocols generated for it:
 The streaming service protocol is the root `protocol`. Most users won't need to
 implement this protocol directly. It treats each of the four RPC types as a
 bidirectional streaming RPC: this allows users to have the most flexibility over
-how their RPCs are implemented at the cost of a harder-to-use API. The following
+how they implement their RPCs at the cost of a harder-to-use API. The following
 code shows how the streaming service protocol would look for a service:
 
 ```swift
@@ -262,14 +262,14 @@ protocol ServiceName.ServiceProtocol: ServiceName.StreamingServiceProtocol {
 }
 ```
 
-The conformance to the `StreamingServiceProtocol` is generated and implemented in
+gRPC Swift generates and implements the conformance to `StreamingServiceProtocol` in
 terms of the requirements of `ServiceProtocol`. This allows users to use the
 higher-level API where possible but can implement the fully-streamed version
 per-RPC if necessary.
 
 Some users also won't need access to metadata and will only be interested in the
-messages sent and received on an RPC. A higher-level “simple” service protocol
-is provided for this use case:
+messages sent and received on an RPC. gRPC Swift provides a higher-level “simple” service protocol
+for this use case:
 
 ```swift
 protocol ServiceName.SimpleServiceProtocol: ServiceName.ServiceProtocol {
@@ -303,12 +303,12 @@ also has a default implementation.
 
 The root of the protocol hierarchy, the `StreamingServiceProtocol`, also
 refines the ``RegistrableRPCService`` protocol. This `protocol` has a single
-requirement for registering methods with an ``RPCRouter``. A default
-implementation of this method is also provided.
+requirement for registering methods with an ``RPCRouter``. gRPC Swift also
+provides a default implementation of this method.
 
 #### Client stubs
 
-Generated client code is split into a `protocol` and a concrete `struct`
+gRPC Swift splits generated client code into a `protocol` and a concrete `struct`
 implementing the `protocol`. An example of the client protocol is:
 
 ```swift
@@ -349,11 +349,11 @@ protocol ServiceName.ClientProtocol {
 
 Each method takes a request appropriate for its RPC type, a serializer, a
 deserializer, a set of options, and a handler for processing the response. The
-function doesn't return until the response handler has returned and all
-resources associated with the RPC have been cleaned up.
+function doesn't return until the response handler has returned and gRPC Swift has cleaned up all
+resources associated with the RPC.
 
-An extension to the protocol is also generated, which provides an appropriate
-serializer and deserializer, defaults the options to `.defaults`, and for RPCs
+gRPC Swift also generates an extension to the protocol, which provides an appropriate
+serializer and deserializer, defaults the options to `.defaults`, and, for RPCs
 with a single response message, defaults the closure to returning the response
 message:
 
@@ -393,7 +393,7 @@ extension ServiceName.ClientProtocol {
 }
 ```
 
-An additional extension is also generated providing even higher-level APIs.
+gRPC Swift also generates an additional extension providing even higher-level APIs.
 These let the user avoid creating the request types themselves, since the
 extension creates them on behalf of the user. For unary RPCs, this API distils
 down to message-in, message-out; for bidirectional streaming, it distils down

--- a/Sources/GRPCCore/Documentation.docc/Documentation.md
+++ b/Sources/GRPCCore/Documentation.docc/Documentation.md
@@ -7,7 +7,8 @@ A gRPC library for Swift written natively in Swift.
 ### Package structure
 
 gRPC Swift spans multiple Swift packages, each exposing one or more modules.
-The following list provides a map to the libraries and their documentation:
+This module provides the higher-level documentation to provide gRPC clients and services using these collected packages.
+The following is a map of the libraries and their documentation:
 
 - **[grpc-swift-2](https://github.com/grpc/grpc-swift-2)** — the core gRPC runtime.
   - `GRPCCore` provides the transport-agnostic gRPC engine with ``GRPCClient``, ``GRPCServer``, call execution, streaming primitives, and the ``ClientTransport``/``ServerTransport`` protocols. It layers with your choice of a transport, with common options available in `grpc-swift-nio-transport` below.
@@ -30,9 +31,6 @@ The following list provides a map to the libraries and their documentation:
   - [`GRPCOTelTracingInterceptors`](https://swiftpackageindex.com/grpc/grpc-swift-extras/documentation/grpcoteltracinginterceptors) — client *and* server interceptors that emit OpenTelemetry spans per RPC. Add it to instrument distributed tracing across gRPC calls with OTel-convention span attributes, without hand-writing the interceptor plumbing.
   - [`GRPCServiceLifecycle`](https://swiftpackageindex.com/grpc/grpc-swift-extras/documentation/grpcservicelifecycle) — adapts both ``GRPCClient`` and ``GRPCServer`` to the `Service` protocol of [swift-service-lifecycle](https://swiftpackageindex.com/swift-server/swift-service-lifecycle/documentation/servicelifecycle). Add it if your process already runs a `ServiceGroup` and you want gRPC startup/shutdown to participate in the same graceful-shutdown sequence.
   - [`GRPCInteropTests`](https://swiftpackageindex.com/grpc/grpc-swift-extras/documentation/grpcinteroptests) — a shared cross-implementation gRPC interop test suite. Primarily for contributors, skip this unless you're validating a new transport or language implementation against the gRPC interop spec.
-
-This package, and this module (``GRPCCore``) in particular, include higher-level documentation such
-as tutorials.
 
 ## Topics
 
@@ -67,6 +65,7 @@ Resources for developers working on gRPC Swift:
 - ``withGRPCClient(transport:interceptorPipeline:isolation:handleClient:)``
 - ``withGRPCServer(transport:services:interceptors:isolation:handleServer:)``
 - ``withGRPCServer(transport:services:interceptorPipeline:isolation:handleServer:)``
+- ``GRPCServerContext``
 
 ### Request and response types
 
@@ -78,6 +77,8 @@ Resources for developers working on gRPC Swift:
 - ``StreamingServerRequest``
 - ``ServerResponse``
 - ``StreamingServerResponse``
+- ``Status``
+- ``Metadata``
 
 ### Service definition and routing
 
@@ -111,17 +112,20 @@ Resources for developers working on gRPC Swift:
 - ``MessageDeserializer``
 - ``CompressionAlgorithm``
 - ``CompressionAlgorithmSet``
+- ``GRPCContiguousBytes``
 
-### Transport protocols and supporting types
+### Transport protocols
 
 - ``ClientTransport``
 - ``ServerTransport``
+- ``RPCStream``
+- ``CallOptions``
+- ``RetryThrottle``
 - ``RPCRequestPart``
 - ``RPCResponsePart``
-- ``Status``
-- ``Metadata``
-- ``RetryThrottle``
-- ``RPCStream``
+
+### Streaming primitives
+
 - ``RPCWriterProtocol``
 - ``ClosableRPCWriterProtocol``
 - ``RPCWriter``

--- a/Sources/GRPCCore/Documentation.docc/Documentation.md
+++ b/Sources/GRPCCore/Documentation.docc/Documentation.md
@@ -6,38 +6,33 @@ A gRPC library for Swift written natively in Swift.
 
 ### Package structure
 
-gRPC Swift spans multiple Swift packages:
+gRPC Swift spans multiple Swift packages, each exposing one or more modules.
+The following list provides a map to the libraries and their documentation:
 
-- `grpc-swift-2` (this package) containing core gRPC abstractions and an in-process transport.
-  - GitHub repository: [`grpc/grpc-swift-2`](https://github.com/grpc/grpc-swift-2)
-  - Documentation: hosted on the [Swift Package
-    Index](https://swiftpackageindex.com/grpc/grpc-swift-2/documentation)
-- `grpc-swift-nio-transport` contains high-performance HTTP/2 transports built on top
-    of [SwiftNIO](https://github.com/apple/swift-nio).
-  - GitHub repository: [`grpc/grpc-swift-nio-transport`](https://github.com/grpc/grpc-swift-nio-transport)
-  - Documentation: hosted on the [Swift Package
-    Index](https://swiftpackageindex.com/grpc/grpc-swift-nio-transport/documentation)
-- `grpc-swift-protobuf` contains runtime serialization components to interoperate with
-    [SwiftProtobuf](https://github.com/apple/swift-protobuf) as well as a plugin for the Protocol
-    Buffers compiler, `protoc`.
-  - GitHub repository: [`grpc/grpc-swift-protobuf`](https://github.com/grpc/grpc-swift-protobuf)
-  - Documentation: hosted on the [Swift Package
-    Index](https://swiftpackageindex.com/grpc/grpc-swift-protobuf/documentation)
-- `grpc-swift-extras` contains optional runtime components and integrations with other packages.
-  - GitHub repository: [`grpc/grpc-swift-extras`](https://github.com/grpc/grpc-swift-extras)
-  - Documentation: hosted on the [Swift Package
-    Index](https://swiftpackageindex.com/grpc/grpc-swift-extras/documentation)
+- **[grpc-swift-2](https://github.com/grpc/grpc-swift-2)** — the core gRPC runtime.
+  - `GRPCCore` provides the transport-agnostic gRPC engine with ``GRPCClient``, ``GRPCServer``, call execution, streaming primitives, and the ``ClientTransport``/``ServerTransport`` protocols. It layers with your choice of a transport, with common options available in `grpc-swift-nio-transport` below.
+  - [`GRPCInProcessTransport`](https://swiftpackageindex.com/grpc/grpc-swift-2/documentation/GRPCInProcessTransport) — an in-process ``ClientTransport``/``ServerTransport`` implementation with no real networking.
+    Use this module for testing service logic or to wire a client and server together in one process without sockets or TLS.
+  - [`GRPCCodeGen`](https://swiftpackageindex.com/grpc/grpc-swift-2/documentation/grpccodegen) — a transport and IDL agnostic library for turning a structured service description into Swift source. You only depend on this directly when you create your a code generator for a non-protobuf IDL; most leverage this common module through `grpc-swift-protobuf`.
+
+- **[grpc-swift-nio-transport](https://github.com/grpc/grpc-swift-nio-transport)** — provides two transport libraries for gRPC:
+  - [`GRPCNIOTransportHTTP2Posix`](https://swiftpackageindex.com/grpc/grpc-swift-nio-transport/documentation/grpcniotransporthttp2posix) — a transport built on SwiftNIO's `NIOPosix`, that uses [NIOSSL](https://swiftpackageindex.com/apple/swift-nio-ssl/documentation/niossl) and [swift-certificates](https://swiftpackageindex.com/apple/swift-certificates/documentation/x509) to provide TLS support. Use when your service code runs on Linux, or on a platform that doesn't require the use of Apple's `Network` framework.
+  - [`GRPCNIOTransportHTTP2TransportServices`](https://swiftpackageindex.com/grpc/grpc-swift-nio-transport/documentation/grpcniotransporthttp2transportservices) — the backend built on `NIOTransportServices` (Apple's [Network](https://developer.apple.com/documentation/network) framework), a recommended transport for Apple platforms.
+  - [`GRPCNIOTransportHTTP2`](https://swiftpackageindex.com/grpc/grpc-swift-nio-transport/documentation/grpcniotransporthttp2) — umbrella module that re-exports both backends. Depend on this module to get `.http2NIOPosix` and `.http2NIOTS` from one package dependency and pick per-platform in code, rather than deciding at the manifest level.
+
+- **[grpc-swift-protobuf](https://github.com/grpc/grpc-swift-protobuf)** — bridges ``GRPCCore`` to Protocol Buffers using [SwiftProtobuf](https://swiftpackageindex.com/apple/swift-protobuf/documentation/swiftprotobuf).
+  - [`GRPCProtobuf`](https://swiftpackageindex.com/grpc/grpc-swift-protobuf/documentation/grpcprotobuf) - provides the runtime serialization libraries to work with `GRPCCore`.
+  - Also ships the `protoc-gen-grpc-swift-2` plugin for the Protocol Buffers compiler, `protoc`, and two SwiftPM plugins (`GRPCProtobufGenerator`, `generate-grpc-code-from-protos`) that generate code stubs from your Swift package build process. Read [Generating Stubs](https://swiftpackageindex.com/grpc/grpc-swift-protobuf/documentation/grpcprotobuf/generating-stubs) for documentation on creating client and service stubs.
+
+- **[grpc-swift-extras](https://github.com/grpc/grpc-swift-extras)** — independent, opt-in add-ons for convenience when creating and providing gRPC services. Add the depdendencies fpr each feature you want, not as a bundle.
+  - [`GRPCHealthService`](https://swiftpackageindex.com/grpc/grpc-swift-extras/documentation/grpchealthservice) — an implementation of the gRPC health-checking protocol that you register on your server. Use it to provide readiness and liveness checks that so load balancers or orchestrators (such as Kubernetes, Envoy, and so on) can probe directly over gRPC instead of side-channel alternatives.
+  - [`GRPCReflectionService`](https://swiftpackageindex.com/grpc/grpc-swift-extras/documentation/grpcreflectionservice) — an implementation of gRPC server reflection. Add it for generic tools (such as `grpcurl` or Postman) to discover your services and methods at runtime without you shipping `.proto` files to every caller.
+  - [`GRPCOTelTracingInterceptors`](https://swiftpackageindex.com/grpc/grpc-swift-extras/documentation/grpcoteltracinginterceptors) — client *and* server interceptors that emit OpenTelemetry spans per RPC. Add it to instrument distributed tracing across gRPC calls with OTel-convention span attributes, without hand-writing the interceptor plumbing.
+  - [`GRPCServiceLifecycle`](https://swiftpackageindex.com/grpc/grpc-swift-extras/documentation/grpcservicelifecycle) — adapts both ``GRPCClient`` and ``GRPCServer`` to the `Service` protocol of [swift-service-lifecycle](https://swiftpackageindex.com/swift-server/swift-service-lifecycle/documentation/servicelifecycle). Add it if your process already runs a `ServiceGroup` and you want gRPC startup/shutdown to participate in the same graceful-shutdown sequence.
+  - [`GRPCInteropTests`](https://swiftpackageindex.com/grpc/grpc-swift-extras/documentation/grpcinteroptests) — a shared cross-implementation gRPC interop test suite. Primarily for contributors, skip this unless you're validating a new transport or language implementation against the gRPC interop spec.
 
 This package, and this module (``GRPCCore``) in particular, include higher-level documentation such
 as tutorials.
-
-### Modules in this package
-
-- ``GRPCCore`` (this module) contains core abstractions, currency types, and runtime components
-  for gRPC Swift.
-- `GRPCInProcessTransport` contains an in-process implementation of the ``ClientTransport`` and
-  ``ServerTransport`` protocols.
-- `GRPCCodeGen` contains components for building a code generator.
 
 ## Topics
 

--- a/Sources/GRPCCore/Documentation.docc/Documentation.md
+++ b/Sources/GRPCCore/Documentation.docc/Documentation.md
@@ -14,9 +14,9 @@ The following is a map of the libraries and their documentation:
 - term **[grpc-swift-nio-transport](https://github.com/grpc/grpc-swift-nio-transport)**: A package that provides two transport libraries for gRPC clients and servers, and an umbrella module ([`GRPCNIOTransportHTTP2`](https://swiftpackageindex.com/grpc/grpc-swift-nio-transport/documentation/grpcniotransporthttp2)) that re-exports both backends. Use the umbrella module to get `.http2NIOPosix` and `.http2NIOTS` from one package dependency and pick per-platform in code, rather than deciding at the manifest level.
 
   - term [`GRPCNIOTransportHTTP2Posix`](https://swiftpackageindex.com/grpc/grpc-swift-nio-transport/documentation/grpcniotransporthttp2posix): A gRPC transport built on SwiftNIO's `NIOPosix`, that uses [NIOSSL](https://swiftpackageindex.com/apple/swift-nio-ssl/documentation/niossl) and [swift-certificates](https://swiftpackageindex.com/apple/swift-certificates/documentation/x509) to provide TLS support. Use when your service code runs on Linux, or on a platform that doesn't require the use of Apple's `Network` framework.
-  - term [`GRPCNIOTransportHTTP2TransportServices`](https://swiftpackageindex.com/grpc/grpc-swift-nio-transport/documentation/grpcniotransporthttp2transportservices): a gRPC transport built on (Apple's [Network](https://developer.apple.com/documentation/network) framework), a recommended transport for Apple platforms.
+  - term [`GRPCNIOTransportHTTP2TransportServices`](https://swiftpackageindex.com/grpc/grpc-swift-nio-transport/documentation/grpcniotransporthttp2transportservices): A gRPC transport built on Apple's [Network](https://developer.apple.com/documentation/network) framework, a recommended transport for Apple platforms.
 
-- term **[grpc-swift-protobuf](https://github.com/grpc/grpc-swift-protobuf)**: Bridges the GRPC core to [SwiftProtobuf](https://swiftpackageindex.com/apple/swift-protobuf/documentation/swiftprotobuf) using [`GRPCProtobuf`](https://swiftpackageindex.com/grpc/grpc-swift-protobuf/documentation/grpcprotobuf) for runtime serialization libraries.
+- term **[grpc-swift-protobuf](https://github.com/grpc/grpc-swift-protobuf)**: Bridges the gRPC core to [SwiftProtobuf](https://swiftpackageindex.com/apple/swift-protobuf/documentation/swiftprotobuf) using [`GRPCProtobuf`](https://swiftpackageindex.com/grpc/grpc-swift-protobuf/documentation/grpcprotobuf) for runtime serialization libraries.
   The package also provides the `protoc-gen-grpc-swift-2` plugin for the Protocol Buffers compiler, `protoc`, and two SwiftPM plugins (`GRPCProtobufGenerator`, `generate-grpc-code-from-protos`) that generate code stubs from your Swift package build process. Read [Generating Stubs](https://swiftpackageindex.com/grpc/grpc-swift-protobuf/documentation/grpcprotobuf/generating-stubs) for details on creating client and service stubs.
 
 - term **[grpc-swift-extras](https://github.com/grpc/grpc-swift-extras)**: Opt-in add-ons for convenience when creating and providing gRPC services. Add the depdendencies fpr each feature you want, not as a bundle:
@@ -40,12 +40,12 @@ include 3 of the packages above as dependencies:
 
 Set the dependencies for your internal based on your choice of transport, or use the umbrella library from the `grpc-swift-nio-transport` to choose in code.
 
-In your code, you often import multiple GRPC modules. For example, when creating a gRPC client, you may include the following imports:
+In your code, you often import multiple gRPC modules. For example, when creating a gRPC client, you may include the following imports:
 
 ```swift
 import GRPCCore 
 import GRPCNIOTransportHTTP2 // transport and its configuration
-import GRPCProtobuf // for status and error handling
+import GRPCProtobuf // for message (de)serialization and error details
 ```
 
 ## Topics

--- a/Sources/GRPCCore/Documentation.docc/Documentation.md
+++ b/Sources/GRPCCore/Documentation.docc/Documentation.md
@@ -10,101 +10,64 @@ gRPC Swift spans multiple Swift packages, each exposing one or more modules.
 This module provides the higher-level documentation to provide gRPC clients and services using these collected packages.
 The following is a map of the libraries and their documentation:
 
-- **[grpc-swift-2](https://github.com/grpc/grpc-swift-2)** — the core gRPC runtime.
-  - `GRPCCore` provides the transport-agnostic gRPC engine with ``GRPCClient``, ``GRPCServer``, call execution, streaming primitives, and the ``ClientTransport``/``ServerTransport`` protocols. It layers with your choice of a transport, with common options available in `grpc-swift-nio-transport` below.
-  - [`GRPCInProcessTransport`](https://swiftpackageindex.com/grpc/grpc-swift-2/documentation/GRPCInProcessTransport) — an in-process ``ClientTransport``/``ServerTransport`` implementation with no real networking.
-    Use this module for testing service logic or to wire a client and server together in one process without sockets or TLS.
-  - [`GRPCCodeGen`](https://swiftpackageindex.com/grpc/grpc-swift-2/documentation/grpccodegen) — a transport and IDL agnostic library for turning a structured service description into Swift source. You only depend on this directly when you create your a code generator for a non-protobuf IDL; most leverage this common module through `grpc-swift-protobuf`.
+- term **[grpc-swift-2](https://github.com/grpc/grpc-swift-2)**: The core gRPC runtime that provides ``GRPCClient``, ``GRPCServer``, and the protocols for the transport (``ClientTransport`` and ``ServerTransport``). When creating a client or server instance, choose a transport over which the communication flows, such as `GRPCNIOTransportHTTP2Posix` or `GRPCNIOTransportHTTP2TransportServices` from the package `grpc-swift-nio-transport`. The module [`GRPCInProcessTransport`](https://swiftpackageindex.com/grpc/grpc-swift-2/documentation/GRPCInProcessTransport) provides an in-process transport implementation with no real networking for testing service logic or to wire a client and server together in one process without sockets or TLS.
+- term **[grpc-swift-nio-transport](https://github.com/grpc/grpc-swift-nio-transport)**: A package that provides two transport libraries for gRPC clients and servers, and an umbrella module ([`GRPCNIOTransportHTTP2`](https://swiftpackageindex.com/grpc/grpc-swift-nio-transport/documentation/grpcniotransporthttp2)) that re-exports both backends. Use the umbrella module to get `.http2NIOPosix` and `.http2NIOTS` from one package dependency and pick per-platform in code, rather than deciding at the manifest level.
 
-- **[grpc-swift-nio-transport](https://github.com/grpc/grpc-swift-nio-transport)** — provides two transport libraries for gRPC:
-  - [`GRPCNIOTransportHTTP2Posix`](https://swiftpackageindex.com/grpc/grpc-swift-nio-transport/documentation/grpcniotransporthttp2posix) — a transport built on SwiftNIO's `NIOPosix`, that uses [NIOSSL](https://swiftpackageindex.com/apple/swift-nio-ssl/documentation/niossl) and [swift-certificates](https://swiftpackageindex.com/apple/swift-certificates/documentation/x509) to provide TLS support. Use when your service code runs on Linux, or on a platform that doesn't require the use of Apple's `Network` framework.
-  - [`GRPCNIOTransportHTTP2TransportServices`](https://swiftpackageindex.com/grpc/grpc-swift-nio-transport/documentation/grpcniotransporthttp2transportservices) — the backend built on `NIOTransportServices` (Apple's [Network](https://developer.apple.com/documentation/network) framework), a recommended transport for Apple platforms.
-  - [`GRPCNIOTransportHTTP2`](https://swiftpackageindex.com/grpc/grpc-swift-nio-transport/documentation/grpcniotransporthttp2) — umbrella module that re-exports both backends. Depend on this module to get `.http2NIOPosix` and `.http2NIOTS` from one package dependency and pick per-platform in code, rather than deciding at the manifest level.
+  - term [`GRPCNIOTransportHTTP2Posix`](https://swiftpackageindex.com/grpc/grpc-swift-nio-transport/documentation/grpcniotransporthttp2posix): A gRPC transport built on SwiftNIO's `NIOPosix`, that uses [NIOSSL](https://swiftpackageindex.com/apple/swift-nio-ssl/documentation/niossl) and [swift-certificates](https://swiftpackageindex.com/apple/swift-certificates/documentation/x509) to provide TLS support. Use when your service code runs on Linux, or on a platform that doesn't require the use of Apple's `Network` framework.
+  - term [`GRPCNIOTransportHTTP2TransportServices`](https://swiftpackageindex.com/grpc/grpc-swift-nio-transport/documentation/grpcniotransporthttp2transportservices): a gRPC transport built on (Apple's [Network](https://developer.apple.com/documentation/network) framework), a recommended transport for Apple platforms.
 
-- **[grpc-swift-protobuf](https://github.com/grpc/grpc-swift-protobuf)** — bridges ``GRPCCore`` to Protocol Buffers using [SwiftProtobuf](https://swiftpackageindex.com/apple/swift-protobuf/documentation/swiftprotobuf).
-  - [`GRPCProtobuf`](https://swiftpackageindex.com/grpc/grpc-swift-protobuf/documentation/grpcprotobuf) - provides the runtime serialization libraries to work with `GRPCCore`.
-  - Also ships the `protoc-gen-grpc-swift-2` plugin for the Protocol Buffers compiler, `protoc`, and two SwiftPM plugins (`GRPCProtobufGenerator`, `generate-grpc-code-from-protos`) that generate code stubs from your Swift package build process. Read [Generating Stubs](https://swiftpackageindex.com/grpc/grpc-swift-protobuf/documentation/grpcprotobuf/generating-stubs) for documentation on creating client and service stubs.
+- term **[grpc-swift-protobuf](https://github.com/grpc/grpc-swift-protobuf)**: Bridges the GRPC core to [SwiftProtobuf](https://swiftpackageindex.com/apple/swift-protobuf/documentation/swiftprotobuf) using [`GRPCProtobuf`](https://swiftpackageindex.com/grpc/grpc-swift-protobuf/documentation/grpcprotobuf) for runtime serialization libraries.
+  The package also provides the `protoc-gen-grpc-swift-2` plugin for the Protocol Buffers compiler, `protoc`, and two SwiftPM plugins (`GRPCProtobufGenerator`, `generate-grpc-code-from-protos`) that generate code stubs from your Swift package build process. Read [Generating Stubs](https://swiftpackageindex.com/grpc/grpc-swift-protobuf/documentation/grpcprotobuf/generating-stubs) for details on creating client and service stubs.
 
-- **[grpc-swift-extras](https://github.com/grpc/grpc-swift-extras)** — independent, opt-in add-ons for convenience when creating and providing gRPC services. Add the depdendencies fpr each feature you want, not as a bundle.
+- term **[grpc-swift-extras](https://github.com/grpc/grpc-swift-extras)**: Opt-in add-ons for convenience when creating and providing gRPC services. Add the depdendencies fpr each feature you want, not as a bundle:
   - [`GRPCHealthService`](https://swiftpackageindex.com/grpc/grpc-swift-extras/documentation/grpchealthservice) — an implementation of the gRPC health-checking protocol that you register on your server. Use it to provide readiness and liveness checks that so load balancers or orchestrators (such as Kubernetes, Envoy, and so on) can probe directly over gRPC instead of side-channel alternatives.
   - [`GRPCReflectionService`](https://swiftpackageindex.com/grpc/grpc-swift-extras/documentation/grpcreflectionservice) — an implementation of gRPC server reflection. Add it for generic tools (such as `grpcurl` or Postman) to discover your services and methods at runtime without you shipping `.proto` files to every caller.
   - [`GRPCOTelTracingInterceptors`](https://swiftpackageindex.com/grpc/grpc-swift-extras/documentation/grpcoteltracinginterceptors) — client *and* server interceptors that emit OpenTelemetry spans per RPC. Add it to instrument distributed tracing across gRPC calls with OTel-convention span attributes, without hand-writing the interceptor plumbing.
   - [`GRPCServiceLifecycle`](https://swiftpackageindex.com/grpc/grpc-swift-extras/documentation/grpcservicelifecycle) — adapts both ``GRPCClient`` and ``GRPCServer`` to the `Service` protocol of [swift-service-lifecycle](https://swiftpackageindex.com/swift-server/swift-service-lifecycle/documentation/servicelifecycle). Add it if your process already runs a `ServiceGroup` and you want gRPC startup/shutdown to participate in the same graceful-shutdown sequence.
   - [`GRPCInteropTests`](https://swiftpackageindex.com/grpc/grpc-swift-extras/documentation/grpcinteroptests) — a shared cross-implementation gRPC interop test suite. Primarily for contributors, skip this unless you're validating a new transport or language implementation against the gRPC interop spec.
 
+When you create a gRPC client or server that build from .proto files in your project,
+include 3 of the packages above as dependencies:
+
+```swift
+  dependencies: [
+    // ...
+    .package(url: "https://github.com/grpc/grpc-swift-2.git", from: "2.0.0"),
+    .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "2.4.0"),
+    .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "2.0.0"),
+  ],
+```
+
+Set the dependencies for your internal based on your choice of transport, or use the umbrella library from the `grpc-swift-nio-transport` to choose in code.
+
+In your code, you often import multiple GRPC modules. For example, when creating a gRPC client, you may include the following imports:
+
+```swift
+import GRPCCore 
+import GRPCNIOTransportHTTP2 // transport and its configuration
+import GRPCProtobuf // for status and error handling
+```
+
 ## Topics
-
-### Tutorials
-
-- <doc:Hello-World>
-- <doc:Route-Guide>
 
 ### Essentials
 
+- <doc:Hello-World>
+- <doc:Route-Guide>
 - <doc:Generating-stubs>
-- <doc:Error-handling>
+- <doc:client>
+- <doc:server>
 
-### Project information
 
-- <doc:Compatibility>
-- <doc:Public-API>
-- <doc:Migration-guide>
+### Streaming primitives
 
-### Development resources
-
-Resources for developers working on gRPC Swift:
-
-- <doc:Design>
-- <doc:Benchmarks>
-
-### Client and server
-
-- ``GRPCClient``
-- ``GRPCServer``
-- ``withGRPCClient(transport:interceptors:isolation:handleClient:)``
-- ``withGRPCClient(transport:interceptorPipeline:isolation:handleClient:)``
-- ``withGRPCServer(transport:services:interceptors:isolation:handleServer:)``
-- ``withGRPCServer(transport:services:interceptorPipeline:isolation:handleServer:)``
-- ``GRPCServerContext``
-
-### Request and response types
-
-- ``ClientRequest``
-- ``StreamingClientRequest``
-- ``ClientResponse``
-- ``StreamingClientResponse``
-- ``ServerRequest``
-- ``StreamingServerRequest``
-- ``ServerResponse``
-- ``StreamingServerResponse``
-- ``Status``
-- ``Metadata``
-
-### Service definition and routing
-
-- ``RegistrableRPCService``
-- ``RPCRouter``
-
-### Interceptors
-
-- ``ClientInterceptor``
-- ``ServerInterceptor``
-- ``ClientContext``
-- ``ServerContext``
-- ``ConditionalInterceptor``
-
-### RPC descriptors
-
-- ``MethodDescriptor``
-- ``ServiceDescriptor``
-
-### Service config
-
-- ``ServiceConfig``
-- ``MethodConfig``
-- ``HedgingPolicy``
-- ``RetryPolicy``
-- ``RPCExecutionPolicy``
+- ``RPCStream``
+- ``RPCRequestPart``
+- ``RPCResponsePart``
+- ``RPCWriterProtocol``
+- ``ClosableRPCWriterProtocol``
+- ``RPCWriter``
+- ``RPCAsyncSequence``
 
 ### Serialization
 
@@ -114,30 +77,22 @@ Resources for developers working on gRPC Swift:
 - ``CompressionAlgorithmSet``
 - ``GRPCContiguousBytes``
 
-### Transport protocols
-
-- ``ClientTransport``
-- ``ServerTransport``
-- ``RPCStream``
-- ``CallOptions``
-- ``RetryThrottle``
-- ``RPCRequestPart``
-- ``RPCResponsePart``
-
-### Streaming primitives
-
-- ``RPCWriterProtocol``
-- ``ClosableRPCWriterProtocol``
-- ``RPCWriter``
-- ``RPCAsyncSequence``
-
-### Cancellation
-
-- ``withServerContextRPCCancellationHandle(_:)``
-- ``withRPCCancellationHandler(operation:onCancelRPC:)``
-
 ### Errors
 
+- <doc:Error-handling>
 - ``RPCError``
 - ``RPCErrorConvertible``
 - ``RuntimeError``
+
+### Project information
+
+- <doc:Compatibility>
+- <doc:Migration-guide>
+
+### Development resources
+
+Resources for developers working on gRPC Swift:
+
+- <doc:Design>
+- <doc:Benchmarks>
+- <doc:Public-API>

--- a/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec04-step04-unary.swift
+++ b/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec04-step04-unary.swift
@@ -10,7 +10,7 @@ struct RouteGuideService: Routeguide_RouteGuide.SimpleServiceProtocol {
     self.features = features
   }
 
-  /// Returns the first feature found at the given location, if one exists.
+  /// Returns the first feature at the given location, if one exists.
   private func findFeature(latitude: Int32, longitude: Int32) -> Routeguide_Feature? {
     self.features.first {
       $0.location.latitude == latitude && $0.location.longitude == longitude

--- a/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec04-step05-unary.swift
+++ b/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec04-step05-unary.swift
@@ -10,7 +10,7 @@ struct RouteGuideService: Routeguide_RouteGuide.SimpleServiceProtocol {
     self.features = features
   }
 
-  /// Returns the first feature found at the given location, if one exists.
+  /// Returns the first feature at the given location, if one exists.
   private func findFeature(latitude: Int32, longitude: Int32) -> Routeguide_Feature? {
     self.features.first {
       $0.location.latitude == latitude && $0.location.longitude == longitude

--- a/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec04-step06-server-streaming.swift
+++ b/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec04-step06-server-streaming.swift
@@ -10,7 +10,7 @@ struct RouteGuideService: Routeguide_RouteGuide.SimpleServiceProtocol {
     self.features = features
   }
 
-  /// Returns the first feature found at the given location, if one exists.
+  /// Returns the first feature at the given location, if one exists.
   private func findFeature(latitude: Int32, longitude: Int32) -> Routeguide_Feature? {
     self.features.first {
       $0.location.latitude == latitude && $0.location.longitude == longitude

--- a/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec04-step07-client-streaming.swift
+++ b/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec04-step07-client-streaming.swift
@@ -11,7 +11,7 @@ struct RouteGuideService: Routeguide_RouteGuide.SimpleServiceProtocol {
     self.features = features
   }
 
-  /// Returns the first feature found at the given location, if one exists.
+  /// Returns the first feature at the given location, if one exists.
   private func findFeature(latitude: Int32, longitude: Int32) -> Routeguide_Feature? {
     self.features.first {
       $0.location.latitude == latitude && $0.location.longitude == longitude

--- a/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec04-step08-bidi-streaming.swift
+++ b/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec04-step08-bidi-streaming.swift
@@ -12,7 +12,7 @@ struct RouteGuideService: Routeguide_RouteGuide.SimpleServiceProtocol {
     self.features = features
   }
 
-  /// Returns the first feature found at the given location, if one exists.
+  /// Returns the first feature at the given location, if one exists.
   private func findFeature(latitude: Int32, longitude: Int32) -> Routeguide_Feature? {
     self.features.first {
       $0.location.latitude == latitude && $0.location.longitude == longitude

--- a/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec04-step09-bidi-streaming.swift
+++ b/Sources/GRPCCore/Documentation.docc/Tutorials/Route-Guide/Resources/route-guide-sec04-step09-bidi-streaming.swift
@@ -6,10 +6,10 @@ struct RouteGuideService: Routeguide_RouteGuide.SimpleServiceProtocol {
   /// Known features.
   private let features: [Routeguide_Feature]
 
-  /// Notes recorded by clients.
+  /// Notes that clients record.
   private let receivedNotes: Notes
 
-  /// A thread-safe store for notes sent by clients.
+  /// A thread-safe store for notes that clients send.
   private final class Notes: Sendable {
     private let notes: Mutex<[Routeguide_RouteNote]>
 
@@ -17,10 +17,10 @@ struct RouteGuideService: Routeguide_RouteGuide.SimpleServiceProtocol {
       self.notes = Mutex([])
     }
 
-    /// Records a note and returns all other notes recorded at the same location.
+    /// Records a note and returns the other notes it has already recorded at the same location.
     ///
     /// - Parameter receivedNote: A note to record.
-    /// - Returns: Other notes recorded at the same location.
+    /// - Returns: The other notes it has already recorded at the same location.
     func recordNote(_ receivedNote: Routeguide_RouteNote) -> [Routeguide_RouteNote] {
       return self.notes.withLock { notes in
         var notesFromSameLocation: [Routeguide_RouteNote] = []
@@ -42,7 +42,7 @@ struct RouteGuideService: Routeguide_RouteGuide.SimpleServiceProtocol {
     self.receivedNotes = Notes()
   }
 
-  /// Returns the first feature found at the given location, if one exists.
+  /// Returns the first feature at the given location, if one exists.
   private func findFeature(latitude: Int32, longitude: Int32) -> Routeguide_Feature? {
     self.features.first {
       $0.location.latitude == latitude && $0.location.longitude == longitude

--- a/Sources/GRPCCore/Documentation.docc/reference/ClientResponse.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/ClientResponse.md
@@ -1,0 +1,18 @@
+# ``ClientResponse``
+
+## Topics
+
+### Creating a response
+
+- ``init(message:metadata:trailingMetadata:)``
+- ``init(of:error:)``
+- ``init(of:metadata:error:)``
+- ``init(accepted:)``
+
+### Reading the outcome
+
+- ``accepted``
+- ``Contents``
+- ``message``
+- ``metadata``
+- ``trailingMetadata``

--- a/Sources/GRPCCore/Documentation.docc/reference/ClientTransport.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/ClientTransport.md
@@ -1,0 +1,20 @@
+# ``ClientTransport``
+
+## Topics
+
+### Connecting to a server
+
+- ``connect()``
+- ``beginGracefulShutdown()``
+
+### Making RPCs
+
+- ``withStream(descriptor:options:_:)``
+- ``config(forMethod:)``
+
+### Inspecting the transport
+
+- ``retryThrottle``
+- ``Bytes``
+- ``Inbound``
+- ``Outbound``

--- a/Sources/GRPCCore/Documentation.docc/reference/CompressionAlgorithmSet.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/CompressionAlgorithmSet.md
@@ -1,0 +1,21 @@
+# ``CompressionAlgorithmSet``
+
+## Topics
+
+### Creating a set
+
+- ``init(rawValue:)``
+
+### Getting the standard sets
+
+- ``none``
+- ``deflate``
+- ``gzip``
+- ``all``
+
+### Inspecting a set
+
+- ``contains(_:)``
+- ``elements``
+- ``Elements-swift.struct``
+- ``rawValue``

--- a/Sources/GRPCCore/Documentation.docc/reference/CompressionAlgorithmSet.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/CompressionAlgorithmSet.md
@@ -4,10 +4,6 @@
 
 ### Creating a set
 
-- ``init(rawValue:)``
-
-### Getting the standard sets
-
 - ``none``
 - ``deflate``
 - ``gzip``
@@ -18,4 +14,8 @@
 - ``contains(_:)``
 - ``elements``
 - ``Elements-swift.struct``
+
+### Working with raw values
+
 - ``rawValue``
+- ``init(rawValue:)``

--- a/Sources/GRPCCore/Documentation.docc/reference/ConditionalInterceptor.Subject.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/ConditionalInterceptor.Subject.md
@@ -1,0 +1,12 @@
+# ``ConditionalInterceptor/Subject``
+
+## Topics
+
+### Creating a subject
+
+- ``all``
+- ``services(_:)``
+- ``methods(_:)``
+- ``only(services:methods:)``
+- ``allExcluding(services:methods:)``
+- ``allMatching(_:)``

--- a/Sources/GRPCCore/Documentation.docc/reference/ConditionalInterceptor.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/ConditionalInterceptor.md
@@ -1,0 +1,13 @@
+# ``ConditionalInterceptor``
+
+## Topics
+
+### Creating an operation
+
+- ``apply(_:to:)-2zkw5``
+- ``apply(_:to:)-6enfi``
+
+### Reading an operation
+
+- ``interceptor``
+- ``Subject``

--- a/Sources/GRPCCore/Documentation.docc/reference/ConditionalInterceptor.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/ConditionalInterceptor.md
@@ -6,8 +6,8 @@
 
 - ``apply(_:to:)-2zkw5``
 - ``apply(_:to:)-6enfi``
+- ``Subject``
 
 ### Reading an operation
 
 - ``interceptor``
-- ``Subject``

--- a/Sources/GRPCCore/Documentation.docc/reference/GRPCClient.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/GRPCClient.md
@@ -1,0 +1,20 @@
+# ``GRPCClient``
+
+## Topics
+
+### Creating a client
+
+- ``init(transport:interceptors:)``
+- ``init(transport:interceptorPipeline:)``
+
+### Running the client
+
+- ``runConnections()``
+- ``beginGracefulShutdown()``
+
+### Making RPCs
+
+- ``unary(request:descriptor:serializer:deserializer:options:onResponse:)``
+- ``clientStreaming(request:descriptor:serializer:deserializer:options:onResponse:)``
+- ``serverStreaming(request:descriptor:serializer:deserializer:options:onResponse:)``
+- ``bidirectionalStreaming(request:descriptor:serializer:deserializer:options:onResponse:)``

--- a/Sources/GRPCCore/Documentation.docc/reference/GRPCContiguousBytes.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/GRPCContiguousBytes.md
@@ -1,0 +1,17 @@
+# ``GRPCContiguousBytes``
+
+## Topics
+
+### Creating a bag of bytes
+
+- ``init(repeating:count:)``
+- ``init(_:)``
+
+### Reading bytes
+
+- ``count``
+- ``withUnsafeBytes(_:)``
+
+### Mutating bytes
+
+- ``withUnsafeMutableBytes(_:)``

--- a/Sources/GRPCCore/Documentation.docc/reference/GRPCServer.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/GRPCServer.md
@@ -1,0 +1,18 @@
+# ``GRPCServer``
+
+## Topics
+
+### Creating a server
+
+- ``init(transport:services:interceptors:)``
+- ``init(transport:services:interceptorPipeline:)``
+- ``init(transport:router:)``
+
+### Serving
+
+- ``serve()``
+- ``beginGracefulShutdown()``
+
+### Inspecting the server
+
+- ``transport``

--- a/Sources/GRPCCore/Documentation.docc/reference/Metadata.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/Metadata.md
@@ -1,0 +1,38 @@
+# ``Metadata``
+
+## Topics
+
+### Creating metadata
+
+- ``init()``
+- ``init(_:)``
+
+### Adding and updating entries
+
+- ``addString(_:forKey:)``
+- ``addBinary(_:forKey:)``
+- ``add(contentsOf:)-4u1ib``
+- ``add(contentsOf:)-uuc3``
+- ``replaceOrAddString(_:forKey:)``
+- ``replaceOrAddBinary(_:forKey:)``
+
+### Removing entries
+
+- ``removeAll(keepingCapacity:)``
+- ``removeAll(where:)``
+- ``removeAllValues(forKey:)``
+
+### Accessing values
+
+- ``subscript(_:)-66kgr``
+- ``subscript(stringValues:)``
+- ``subscript(binaryValues:)``
+- ``StringValues``
+- ``BinaryValues``
+- ``Values``
+- ``Value``
+
+### Managing capacity
+
+- ``capacity``
+- ``reserveCapacity(_:)``

--- a/Sources/GRPCCore/Documentation.docc/reference/MethodConfig.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/MethodConfig.md
@@ -1,0 +1,17 @@
+# ``MethodConfig``
+
+## Topics
+
+### Creating a configuration
+
+- ``init(names:waitForReady:timeout:maxRequestMessageBytes:maxResponseMessageBytes:executionPolicy:)``
+- ``Name``
+
+### Reading configuration
+
+- ``names``
+- ``waitForReady``
+- ``timeout``
+- ``maxRequestMessageBytes``
+- ``maxResponseMessageBytes``
+- ``executionPolicy``

--- a/Sources/GRPCCore/Documentation.docc/reference/MethodConfig.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/MethodConfig.md
@@ -5,11 +5,11 @@
 ### Creating a configuration
 
 - ``init(names:waitForReady:timeout:maxRequestMessageBytes:maxResponseMessageBytes:executionPolicy:)``
-- ``Name``
 
 ### Reading configuration
 
 - ``names``
+- ``Name``
 - ``waitForReady``
 - ``timeout``
 - ``maxRequestMessageBytes``

--- a/Sources/GRPCCore/Documentation.docc/reference/MethodDescriptor.RPCType.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/MethodDescriptor.RPCType.md
@@ -1,0 +1,15 @@
+# ``MethodDescriptor/RPCType``
+
+## Topics
+
+### Getting the streaming pattern
+
+- ``unary``
+- ``clientStreaming``
+- ``serverStreaming``
+- ``bidirectionalStreaming``
+
+### Inspecting a pattern
+
+- ``isRequestStreaming``
+- ``isResponseStreaming``

--- a/Sources/GRPCCore/Documentation.docc/reference/MethodDescriptor.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/MethodDescriptor.md
@@ -1,0 +1,18 @@
+# ``MethodDescriptor``
+
+## Topics
+
+### Creating a descriptor
+
+- ``init(service:method:)``
+- ``init(service:method:type:)``
+- ``init(fullyQualifiedService:method:)``
+- ``init(fullyQualifiedService:method:type:)``
+
+### Reading a descriptor
+
+- ``service``
+- ``method``
+- ``fullyQualifiedMethod``
+- ``type``
+- ``RPCType``

--- a/Sources/GRPCCore/Documentation.docc/reference/RPCAsyncSequence.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/RPCAsyncSequence.md
@@ -1,0 +1,12 @@
+# ``RPCAsyncSequence``
+
+## Topics
+
+### Creating a sequence
+
+- ``init(wrapping:)``
+
+### Iterating a sequence
+
+- ``makeAsyncIterator()``
+- ``AsyncIterator``

--- a/Sources/GRPCCore/Documentation.docc/reference/RPCError.Code.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/RPCError.Code.md
@@ -1,0 +1,31 @@
+# ``RPCError/Code-swift.struct``
+
+## Topics
+
+### Getting the standard codes
+
+- ``cancelled``
+- ``unknown``
+- ``invalidArgument``
+- ``deadlineExceeded``
+- ``notFound``
+- ``alreadyExists``
+- ``permissionDenied``
+- ``resourceExhausted``
+- ``failedPrecondition``
+- ``aborted``
+- ``outOfRange``
+- ``unimplemented``
+- ``internalError``
+- ``unavailable``
+- ``dataLoss``
+- ``unauthenticated``
+
+### Creating a code
+
+- ``init(_:)``
+
+### Reading a code
+
+- ``rawValue``
+- ``description``

--- a/Sources/GRPCCore/Documentation.docc/reference/RPCError.Code.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/RPCError.Code.md
@@ -2,24 +2,36 @@
 
 ## Topics
 
-### Getting the standard codes
+### Handling invalid or conflicting requests
 
-- ``cancelled``
-- ``unknown``
 - ``invalidArgument``
-- ``deadlineExceeded``
+- ``outOfRange``
 - ``notFound``
 - ``alreadyExists``
-- ``permissionDenied``
-- ``resourceExhausted``
 - ``failedPrecondition``
+
+### Handling authorization failures
+
+- ``unauthenticated``
+- ``permissionDenied``
+
+### Handling timing and cancellation
+
+- ``deadlineExceeded``
+- ``cancelled``
+
+### Handling concurrency and capacity limits
+
 - ``aborted``
-- ``outOfRange``
+- ``resourceExhausted``
+- ``unavailable``
+
+### Handling server and protocol errors
+
+- ``unknown``
 - ``unimplemented``
 - ``internalError``
-- ``unavailable``
 - ``dataLoss``
-- ``unauthenticated``
 
 ### Creating a code
 

--- a/Sources/GRPCCore/Documentation.docc/reference/RPCError.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/RPCError.md
@@ -1,0 +1,18 @@
+# ``RPCError``
+
+## Topics
+
+### Creating an error
+
+- ``init(code:message:metadata:cause:)-916o1``
+- ``init(code:message:metadata:cause:)-9hwle``
+- ``init(status:metadata:)``
+- ``init(_:)``
+
+### Reading an error
+
+- ``code-swift.property``
+- ``message``
+- ``metadata``
+- ``cause``
+- ``Code-swift.struct``

--- a/Sources/GRPCCore/Documentation.docc/reference/RPCError.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/RPCError.md
@@ -8,6 +8,7 @@
 - ``init(code:message:metadata:cause:)-9hwle``
 - ``init(status:metadata:)``
 - ``init(_:)``
+- ``RPCError/Code``
 
 ### Reading an error
 
@@ -15,4 +16,3 @@
 - ``message``
 - ``metadata``
 - ``cause``
-- ``Code-swift.struct``

--- a/Sources/GRPCCore/Documentation.docc/reference/RPCExecutionPolicy.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/RPCExecutionPolicy.md
@@ -1,0 +1,13 @@
+# ``RPCExecutionPolicy``
+
+## Topics
+
+### Creating a retry policy
+
+- ``retry(_:)``
+- ``retry``
+
+### Creating a hedging policy
+
+- ``hedge(_:)``
+- ``hedge``

--- a/Sources/GRPCCore/Documentation.docc/reference/RPCRouter.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/RPCRouter.md
@@ -1,0 +1,19 @@
+# ``RPCRouter``
+
+## Topics
+
+### Creating a router
+
+- ``init()``
+
+### Registering and removing handlers
+
+- ``registerHandler(forMethod:deserializer:serializer:handler:)``
+- ``removeHandler(forMethod:)``
+- ``registerInterceptors(pipeline:)``
+
+### Inspecting registered methods
+
+- ``methods``
+- ``count``
+- ``hasHandler(forMethod:)``

--- a/Sources/GRPCCore/Documentation.docc/reference/RPCWriter.Closable.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/RPCWriter.Closable.md
@@ -1,0 +1,17 @@
+# ``RPCWriter/Closable``
+
+## Topics
+
+### Creating a writer
+
+- ``init(wrapping:)``
+
+### Writing values
+
+- ``write(_:)``
+- ``write(contentsOf:)``
+
+### Finishing a writer
+
+- ``finish()``
+- ``finish(throwing:)``

--- a/Sources/GRPCCore/Documentation.docc/reference/RPCWriter.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/RPCWriter.md
@@ -1,0 +1,16 @@
+# ``RPCWriter``
+
+## Topics
+
+### Creating a writer
+
+- ``init(wrapping:)``
+
+### Writing values
+
+- ``write(_:)``
+- ``write(contentsOf:)``
+
+### Closing a writer
+
+- ``Closable``

--- a/Sources/GRPCCore/Documentation.docc/reference/RetryThrottle.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/RetryThrottle.md
@@ -1,0 +1,15 @@
+# ``RetryThrottle``
+
+## Topics
+
+### Creating a throttle
+
+- ``init(maxTokens:tokenRatio:)``
+- ``init(policy:)``
+
+### Reading throttle state
+
+- ``tokens``
+- ``maxTokens``
+- ``tokenRatio``
+- ``isRetryPermitted``

--- a/Sources/GRPCCore/Documentation.docc/reference/RuntimeError.Code.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/RuntimeError.Code.md
@@ -2,17 +2,17 @@
 
 ## Topics
 
-### Server codes
+### Getting server codes
 
 - ``serverIsAlreadyRunning``
 - ``serverIsStopped``
 
-### Client codes
+### Getting client codes
 
 - ``clientIsAlreadyRunning``
 - ``clientIsStopped``
 
-### General codes
+### Getting general codes
 
 - ``invalidArgument``
 - ``transportError``

--- a/Sources/GRPCCore/Documentation.docc/reference/RuntimeError.Code.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/RuntimeError.Code.md
@@ -1,0 +1,18 @@
+# ``RuntimeError/Code-swift.struct``
+
+## Topics
+
+### Server codes
+
+- ``serverIsAlreadyRunning``
+- ``serverIsStopped``
+
+### Client codes
+
+- ``clientIsAlreadyRunning``
+- ``clientIsStopped``
+
+### General codes
+
+- ``invalidArgument``
+- ``transportError``

--- a/Sources/GRPCCore/Documentation.docc/reference/RuntimeError.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/RuntimeError.md
@@ -1,0 +1,14 @@
+# ``RuntimeError``
+
+## Topics
+
+### Creating an error
+
+- ``init(code:message:cause:)``
+
+### Reading an error
+
+- ``code-swift.property``
+- ``message``
+- ``cause``
+- ``Code-swift.struct``

--- a/Sources/GRPCCore/Documentation.docc/reference/RuntimeError.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/RuntimeError.md
@@ -5,10 +5,10 @@
 ### Creating an error
 
 - ``init(code:message:cause:)``
+- ``Code-swift.struct``
 
 ### Reading an error
 
 - ``code-swift.property``
 - ``message``
 - ``cause``
-- ``Code-swift.struct``

--- a/Sources/GRPCCore/Documentation.docc/reference/ServerContext.RPCCancellationHandle.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/ServerContext.RPCCancellationHandle.md
@@ -1,0 +1,16 @@
+# ``ServerContext/RPCCancellationHandle``
+
+## Topics
+
+### Creating a handle
+
+- ``init()``
+
+### Checking cancellation
+
+- ``isCancelled``
+- ``cancelled``
+
+### Cancelling the RPC
+
+- ``cancel()``

--- a/Sources/GRPCCore/Documentation.docc/reference/ServerContext.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/ServerContext.md
@@ -1,0 +1,20 @@
+# ``ServerContext``
+
+## Topics
+
+### Creating a context
+
+- ``init(descriptor:remotePeer:localPeer:cancellation:)``
+
+### Reading the request
+
+- ``descriptor``
+- ``remotePeer``
+- ``localPeer``
+- ``transportSpecific``
+- ``TransportSpecific-swift.protocol``
+
+### Managing cancellation
+
+- ``cancellation``
+- ``RPCCancellationHandle``

--- a/Sources/GRPCCore/Documentation.docc/reference/ServerResponse.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/ServerResponse.md
@@ -1,0 +1,17 @@
+# ``ServerResponse``
+
+## Topics
+
+### Creating a response
+
+- ``init(message:metadata:trailingMetadata:)``
+- ``init(of:error:)``
+- ``init(accepted:)``
+
+### Reading the outcome
+
+- ``accepted``
+- ``Contents``
+- ``message``
+- ``metadata``
+- ``trailingMetadata``

--- a/Sources/GRPCCore/Documentation.docc/reference/ServerTransport.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/ServerTransport.md
@@ -1,0 +1,18 @@
+# ``ServerTransport``
+
+## Topics
+
+### Starting the transport
+
+- ``configure(context:)``
+- ``listen(streamHandler:)``
+
+### Stopping the transport
+
+- ``beginGracefulShutdown()``
+
+### Associated types
+
+- ``Bytes``
+- ``Inbound``
+- ``Outbound``

--- a/Sources/GRPCCore/Documentation.docc/reference/ServerTransport.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/ServerTransport.md
@@ -11,7 +11,7 @@
 
 - ``beginGracefulShutdown()``
 
-### Associated types
+### Inspecting the transport
 
 - ``Bytes``
 - ``Inbound``

--- a/Sources/GRPCCore/Documentation.docc/reference/ServiceConfig.LoadBalancingConfig.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/ServiceConfig.LoadBalancingConfig.md
@@ -1,0 +1,19 @@
+# ``ServiceConfig/LoadBalancingConfig-swift.struct``
+
+## Topics
+
+### Creating a pick-first policy
+
+- ``pickFirst(shuffleAddressList:)``
+- ``pickFirst(_:)``
+- ``PickFirst-swift.struct``
+
+### Creating a round-robin policy
+
+- ``roundRobin-swift.type.property``
+- ``RoundRobin-swift.struct``
+
+### Reading a policy
+
+- ``pickFirst-swift.property``
+- ``roundRobin-swift.property``

--- a/Sources/GRPCCore/Documentation.docc/reference/ServiceConfig.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/ServiceConfig.md
@@ -1,0 +1,21 @@
+# ``ServiceConfig``
+
+## Topics
+
+### Creating a configuration
+
+- ``init(methodConfig:loadBalancingConfig:retryThrottling:)``
+
+### Configuring methods
+
+- ``methodConfig``
+
+### Configuring load balancing
+
+- ``loadBalancingConfig-swift.property``
+- ``LoadBalancingConfig-swift.struct``
+
+### Configuring retry throttling
+
+- ``retryThrottling-swift.property``
+- ``RetryThrottling-swift.struct``

--- a/Sources/GRPCCore/Documentation.docc/reference/Status.Code.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/Status.Code.md
@@ -2,30 +2,45 @@
 
 ## Topics
 
+### Getting the success code
+
+- ``ok``
+
+### Handling invalid or conflicting requests
+
+- ``invalidArgument``
+- ``outOfRange``
+- ``notFound``
+- ``alreadyExists``
+- ``failedPrecondition``
+
+### Handling authorization failures
+
+- ``unauthenticated``
+- ``permissionDenied``
+
+### Handling timing and cancellation
+
+- ``deadlineExceeded``
+- ``cancelled``
+
+### Handling concurrency and capacity limits
+
+- ``aborted``
+- ``resourceExhausted``
+- ``unavailable``
+
+### Handling server and protocol errors
+
+- ``unknown``
+- ``unimplemented``
+- ``internalError``
+- ``dataLoss``
+
 ### Creating a code
 
 - ``init(_:)``
 - ``init(rawValue:)``
-
-### Getting the standard codes
-
-- ``ok``
-- ``cancelled``
-- ``unknown``
-- ``invalidArgument``
-- ``deadlineExceeded``
-- ``notFound``
-- ``alreadyExists``
-- ``permissionDenied``
-- ``resourceExhausted``
-- ``failedPrecondition``
-- ``aborted``
-- ``outOfRange``
-- ``unimplemented``
-- ``internalError``
-- ``unavailable``
-- ``dataLoss``
-- ``unauthenticated``
 
 ### Reading a code
 

--- a/Sources/GRPCCore/Documentation.docc/reference/Status.Code.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/Status.Code.md
@@ -1,0 +1,33 @@
+# ``Status/Code-swift.struct``
+
+## Topics
+
+### Creating a code
+
+- ``init(_:)``
+- ``init(rawValue:)``
+
+### Getting the standard codes
+
+- ``ok``
+- ``cancelled``
+- ``unknown``
+- ``invalidArgument``
+- ``deadlineExceeded``
+- ``notFound``
+- ``alreadyExists``
+- ``permissionDenied``
+- ``resourceExhausted``
+- ``failedPrecondition``
+- ``aborted``
+- ``outOfRange``
+- ``unimplemented``
+- ``internalError``
+- ``unavailable``
+- ``dataLoss``
+- ``unauthenticated``
+
+### Reading a code
+
+- ``rawValue``
+- ``description``

--- a/Sources/GRPCCore/Documentation.docc/reference/Status.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/Status.md
@@ -1,0 +1,14 @@
+# ``Status``
+
+## Topics
+
+### Creating a status
+
+- ``init(code:message:)``
+- ``init(httpStatusCode:)``
+
+### Reading a status
+
+- ``code-swift.property``
+- ``message``
+- ``Code-swift.struct``

--- a/Sources/GRPCCore/Documentation.docc/reference/Status.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/Status.md
@@ -6,9 +6,9 @@
 
 - ``init(code:message:)``
 - ``init(httpStatusCode:)``
+- ``Code-swift.struct``
 
 ### Reading a status
 
 - ``code-swift.property``
 - ``message``
-- ``Code-swift.struct``

--- a/Sources/GRPCCore/Documentation.docc/reference/StreamingClientResponse.Contents.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/StreamingClientResponse.Contents.md
@@ -1,0 +1,13 @@
+# ``StreamingClientResponse/Contents``
+
+## Topics
+
+### Creating contents
+
+- ``init(metadata:bodyParts:)``
+
+### Reading contents
+
+- ``metadata``
+- ``bodyParts``
+- ``BodyPart``

--- a/Sources/GRPCCore/Documentation.docc/reference/StreamingClientResponse.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/StreamingClientResponse.md
@@ -1,0 +1,17 @@
+# ``StreamingClientResponse``
+
+## Topics
+
+### Creating a response
+
+- ``init(of:metadata:bodyParts:)``
+- ``init(of:error:)``
+- ``init(accepted:)``
+
+### Reading the outcome
+
+- ``accepted``
+- ``Contents``
+- ``messages``
+- ``metadata``
+- ``bodyParts``

--- a/Sources/GRPCCore/Documentation.docc/reference/StreamingServerResponse.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/StreamingServerResponse.md
@@ -1,0 +1,16 @@
+# ``StreamingServerResponse``
+
+## Topics
+
+### Creating a response
+
+- ``init(of:metadata:producer:)``
+- ``init(of:error:)``
+- ``init(single:)``
+- ``init(accepted:)``
+
+### Reading the outcome
+
+- ``accepted``
+- ``Contents``
+- ``metadata``

--- a/Sources/GRPCCore/Documentation.docc/reference/client.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/client.md
@@ -1,0 +1,41 @@
+# Client API
+
+Types for creating and configuring a gRPC client and making RPCs.
+
+## Topics
+
+### Entry points
+
+- ``GRPCClient``
+- ``withGRPCClient(transport:interceptors:isolation:handleClient:)``
+- ``withGRPCClient(transport:interceptorPipeline:isolation:handleClient:)``
+- ``ClientTransport``
+- ``CallOptions``
+- ``RetryThrottle``
+- ``ClientInterceptor``
+- ``ClientContext``
+
+### Requests and responses
+
+- ``ClientRequest``
+- ``StreamingClientRequest``
+- ``ClientResponse``
+- ``StreamingClientResponse``
+
+### Service configuration
+
+- ``ServiceConfig``
+- ``MethodConfig``
+- ``HedgingPolicy``
+- ``RetryPolicy``
+- ``RPCExecutionPolicy``
+
+### Status and metadata
+
+- ``Status``
+- ``Metadata``
+
+### RPC descriptors
+
+- ``MethodDescriptor``
+- ``ServiceDescriptor``

--- a/Sources/GRPCCore/Documentation.docc/reference/server.md
+++ b/Sources/GRPCCore/Documentation.docc/reference/server.md
@@ -1,0 +1,42 @@
+# Server API
+
+Types for creating and running a gRPC server and handling RPCs.
+
+## Topics
+
+### Entry points
+
+- ``GRPCServer``
+- ``withGRPCServer(transport:services:interceptors:isolation:handleServer:)``
+- ``withGRPCServer(transport:services:interceptorPipeline:isolation:handleServer:)``
+- ``ServerTransport``
+- ``GRPCServerContext``
+- ``ServerInterceptor``
+- ``ServerContext``
+
+### Service definition and routing
+
+- ``RegistrableRPCService``
+- ``RPCRouter``
+
+### Requests and responses
+
+- ``ServerRequest``
+- ``StreamingServerRequest``
+- ``ServerResponse``
+- ``StreamingServerResponse``
+
+### Cancellation
+
+- ``withServerContextRPCCancellationHandle(_:)``
+- ``withRPCCancellationHandler(operation:onCancelRPC:)``
+
+### Status and metadata
+
+- ``Status``
+- ``Metadata``
+
+### RPC descriptors
+
+- ``MethodDescriptor``
+- ``ServiceDescriptor``

--- a/Sources/GRPCCore/GRPCClient.swift
+++ b/Sources/GRPCCore/GRPCClient.swift
@@ -173,7 +173,7 @@ public final class GRPCClient<Transport: ClientTransport>: Sendable {
     }
   }
 
-  /// Creates a new client with the given transport, interceptors, and configuration.
+  /// Creates a new client that applies the given interceptors to every RPC.
   ///
   /// - Parameters:
   ///   - transport: The transport used to establish a communication channel with a server.
@@ -192,7 +192,7 @@ public final class GRPCClient<Transport: ClientTransport>: Sendable {
     )
   }
 
-  /// Creates a new client with the given transport, interceptors, and configuration.
+  /// Creates a new client that applies interceptors selectively to the RPCs each one targets.
   ///
   /// - Parameters:
   ///   - transport: The transport used to establish a communication channel with a server.
@@ -392,7 +392,7 @@ public final class GRPCClient<Transport: ClientTransport>: Sendable {
   }
 }
 
-/// Creates and runs a new client with the given transport and interceptors.
+/// Creates and runs a new client with the given transport, applying the given interceptors to every RPC.
 ///
 /// - Parameters:
 ///   - transport: The transport used to establish a communication channel with a server.
@@ -420,7 +420,7 @@ public func withGRPCClient<Transport: ClientTransport, Result: Sendable>(
   )
 }
 
-/// Creates and runs a new client with the given transport and interceptors.
+/// Creates and runs a new client with the given transport, applying interceptors selectively to the RPCs each one targets.
 ///
 /// - Parameters:
 ///   - transport: The transport used to establish a communication channel with a server.

--- a/Sources/GRPCCore/GRPCClient.swift
+++ b/Sources/GRPCCore/GRPCClient.swift
@@ -31,8 +31,8 @@ private import Synchronization
 /// ## Creating a client
 ///
 /// You can create and run a client using ``withGRPCClient(transport:interceptors:isolation:handleClient:)``
-/// or ``withGRPCClient(transport:interceptorPipeline:isolation:handleClient:)`` which create, configure, and
-/// run the client providing scoped access to it via the `handleClient` closure. The client will
+/// or ``withGRPCClient(transport:interceptorPipeline:isolation:handleClient:)`` which creates, configures, and
+/// runs the client, providing scoped access to it through the `handleClient` closure. The client will
 /// begin gracefully shutting down when the closure returns.
 ///
 /// ```swift
@@ -41,6 +41,14 @@ private import Synchronization
 ///   // ...
 /// }
 /// ```
+///
+/// Within the closure, create service-specific clients to access any gRPC services available at the server that the transport connects to.
+/// For example, a client for a service called `Api` could be created using the related generated code:
+/// ```swift
+/// let apiClient = Grpc_Api.Client(wrapping: client)
+/// ```
+///
+/// You can use a single `GRPCClient` instance to connect to as many services as the endpoint provides.
 ///
 /// ## Creating a client manually
 ///
@@ -51,12 +59,20 @@ private import Synchronization
 /// The ``runConnections()`` method won't return until the client has finished handling all requests. You can
 /// signal to the client that it should stop creating new request streams by calling ``beginGracefulShutdown()``.
 /// This gives the client enough time to drain any requests already in flight. To stop the client
-/// more abruptly you can cancel the task running your client. If your application requires
-/// additional resources that need their lifecycles managed you should consider using [Swift Service
-/// Lifecycle](https://github.com/swift-server/swift-service-lifecycle).
+/// more abruptly you can cancel the task running your client.
 ///
-/// Once the client has stopped it can't be restarted: calling ``runConnections()`` again throws a
-/// ``RuntimeError``. Create a new ``GRPCClient`` (and a new transport) if you need to reconnect.
+/// If your application requires additional resources that need their lifecycles managed,
+/// consider managing the client and its resources with [Swift Service
+/// Lifecycle](https://github.com/swift-server/swift-service-lifecycle).
+/// Use the [GRPCServiceLifecycle](https://swiftpackageindex.com/grpc/grpc-swift-extras/documentation/grpcservicelifecycle) module
+/// of [grpc-swift-extras](https://swiftpackageindex.com/grpc/grpc-swift-extras) to conform a `GRPCClient` to the `Service` protocol, and use it directly
+/// within a [ServiceGroup](https://swiftpackageindex.com/swift-server/swift-service-lifecycle/documentation/servicelifecycle/servicegroup).
+/// Read [Adopting ServiceLifecycle in applications](https://swiftpackageindex.com/swift-server/swift-service-lifecycle/documentation/servicelifecycle/adopting-servicelifecycle-in-applications) or
+/// [Adopting ServiceLifecycle in libraries](https://swiftpackageindex.com/swift-server/swift-service-lifecycle/documentation/servicelifecycle/adopting-servicelifecycle-in-libraries) for more detail.
+///
+/// Once the client stops, it can't be restarted. If you call ``runConnections()`` again,
+/// the client throws a ``RuntimeError``.
+/// Create a new ``GRPCClient`` (and a new transport) if you need to reconnect.
 @available(gRPCSwift 2.0, *)
 public final class GRPCClient<Transport: ClientTransport>: Sendable {
   /// The transport which provides a bidirectional communication channel with the server.
@@ -142,8 +158,8 @@ public final class GRPCClient<Transport: ClientTransport>: Sendable {
     /// A collection of interceptors providing cross-cutting functionality to each accepted RPC, keyed by the method to which they apply.
     ///
     /// This type computes the list of interceptors for each method from `interceptorPipeline` the
-    /// first time it calls that method, and caches the result to avoid recomputing the applicable
-    /// interceptors for each request.
+    /// first time a caller invokes that method, and caches the result to avoid recomputing the
+    /// applicable interceptors for each request.
     ///
     /// The order in which you add interceptors determines the order in which they run. The first
     /// interceptor added is the first interceptor to intercept each request. The last interceptor
@@ -239,7 +255,7 @@ public final class GRPCClient<Transport: ClientTransport>: Sendable {
 
   /// Closes the client.
   ///
-  /// This closes the transport, giving it enough time to wait for
+  /// This begins closing the transport, giving it enough time for
   /// in-flight RPCs to finish executing, but it won't accept new RPCs. To abruptly stop
   /// in-flight RPCs, cancel the task executing ``runConnections()``.
   public func beginGracefulShutdown() {
@@ -250,6 +266,10 @@ public final class GRPCClient<Transport: ClientTransport>: Sendable {
   }
 
   /// Executes a unary RPC.
+  ///
+  /// - Note: You mustn't have called ``beginGracefulShutdown()``. You don't need to have called
+  /// ``runConnections()`` first — a request made before the client starts running is queued — but
+  /// if you have called it, it must still be executing.
   ///
   /// - Parameters:
   ///   - request: The unary request.
@@ -285,6 +305,10 @@ public final class GRPCClient<Transport: ClientTransport>: Sendable {
 
   /// Starts a client-streaming RPC.
   ///
+  /// - Note: You mustn't have called ``beginGracefulShutdown()``. You don't need to have called
+  /// ``runConnections()`` first — a request made before the client starts running is queued — but
+  /// if you have called it, it must still be executing.
+  ///
   /// - Parameters:
   ///   - request: The request stream.
   ///   - descriptor: The method descriptor for which to execute this request.
@@ -319,6 +343,10 @@ public final class GRPCClient<Transport: ClientTransport>: Sendable {
 
   /// Starts a server-streaming RPC.
   ///
+  /// - Note: You mustn't have called ``beginGracefulShutdown()``. You don't need to have called
+  /// ``runConnections()`` first — a request made before the client starts running is queued — but
+  /// if you have called it, it must still be executing.
+  ///
   /// - Parameters:
   ///   - request: The unary request.
   ///   - descriptor: The method descriptor for which to execute this request.
@@ -351,8 +379,9 @@ public final class GRPCClient<Transport: ClientTransport>: Sendable {
 
   /// Starts a bidirectional streaming RPC.
   ///
-  /// - Note: You must have called ``runConnections()`` and it must still be executing, and you
-  /// mustn't have called ``beginGracefulShutdown()``.
+  /// - Note: You mustn't have called ``beginGracefulShutdown()``. You don't need to have called
+  /// ``runConnections()`` first — a request made before the client starts running is queued — but
+  /// if you have called it, it must still be executing.
   ///
   /// - Parameters:
   ///   - request: The streaming request.

--- a/Sources/GRPCCore/GRPCClient.swift
+++ b/Sources/GRPCCore/GRPCClient.swift
@@ -68,14 +68,14 @@ public final class GRPCClient<Transport: ClientTransport>: Sendable {
   /// The state of the client.
   private enum State: Sendable {
 
-    /// The client hasn't been started yet. Can transition to `running` or `stopped`.
+    /// The client hasn't started yet. Can transition to `running` or `stopped`.
     case notStarted
     /// The client is running and can send RPCs. Can transition to `stopping`.
     case running
-    /// The client is stopping and no new RPCs will be sent. Existing RPCs may run to
+    /// The client is stopping and won't send new RPCs. Existing RPCs may run to
     /// completion. May transition to `stopped`.
     case stopping
-    /// The client has stopped, no RPCs are in flight and no more will be accepted. This state
+    /// The client has stopped: no RPCs are in flight and it won't accept any more. This state
     /// is terminal.
     case stopped
 
@@ -141,13 +141,14 @@ public final class GRPCClient<Transport: ClientTransport>: Sendable {
 
     /// A collection of interceptors providing cross-cutting functionality to each accepted RPC, keyed by the method to which they apply.
     ///
-    /// The list of interceptors for each method is computed from `interceptorsPipeline` when calling a method for the first time.
-    /// This caching is done to avoid having to compute the applicable interceptors for each request made.
+    /// This type computes the list of interceptors for each method from `interceptorPipeline` the
+    /// first time it calls that method, and caches the result to avoid recomputing the applicable
+    /// interceptors for each request.
     ///
-    /// The order in which interceptors are added reflects the order in which they are called. The
-    /// first interceptor added will be the first interceptor to intercept each request. The last
-    /// interceptor added will be the final interceptor to intercept each request before calling
-    /// the appropriate handler.
+    /// The order in which you add interceptors determines the order in which they run. The first
+    /// interceptor added is the first interceptor to intercept each request. The last interceptor
+    /// added is the final interceptor to intercept each request before calling the appropriate
+    /// handler.
     var interceptorsPerMethod: [MethodDescriptor: [any ClientInterceptor]]
 
     init(interceptorPipeline: [ConditionalInterceptor<any ClientInterceptor>]) {
@@ -178,9 +179,9 @@ public final class GRPCClient<Transport: ClientTransport>: Sendable {
   /// - Parameters:
   ///   - transport: The transport used to establish a communication channel with a server.
   ///   - interceptors: A collection of ``ClientInterceptor``s providing cross-cutting functionality to each
-  ///       accepted RPC. The order in which interceptors are added reflects the order in which they
-  ///       are called. The first interceptor added will be the first interceptor to intercept each
-  ///       request. The last interceptor added will be the final interceptor to intercept each
+  ///       accepted RPC. The order in which you add interceptors determines the order in which they
+  ///       run. The first interceptor added is the first interceptor to intercept each
+  ///       request. The last interceptor added is the final interceptor to intercept each
   ///       request before calling the appropriate handler.
   convenience public init(
     transport: Transport,
@@ -197,10 +198,11 @@ public final class GRPCClient<Transport: ClientTransport>: Sendable {
   /// - Parameters:
   ///   - transport: The transport used to establish a communication channel with a server.
   ///   - interceptorPipeline: A collection of ``ConditionalInterceptor``s providing cross-cutting
-  ///       functionality to each accepted RPC. Only applicable interceptors from the pipeline will be applied to each RPC.
-  ///       The order in which interceptors are added reflects the order in which they are called.
-  ///       The first interceptor added will be the first interceptor to intercept each request.
-  ///       The last interceptor added will be the final interceptor to intercept each request before calling the appropriate handler.
+  ///       functionality to each accepted RPC. This applies only the interceptors from the
+  ///       pipeline that apply to each RPC. The order in which you add interceptors determines
+  ///       the order in which they run. The first interceptor added is the first interceptor
+  ///       to intercept each request. The last interceptor added is the final interceptor to
+  ///       intercept each request before calling the appropriate handler.
   public init(
     transport: Transport,
     interceptorPipeline: [ConditionalInterceptor<any ClientInterceptor>]
@@ -211,11 +213,11 @@ public final class GRPCClient<Transport: ClientTransport>: Sendable {
 
   /// Starts the client.
   ///
-  /// This returns once ``beginGracefulShutdown()`` has been called and all in-flight RPCs have finished executing.
+  /// This returns once you've called ``beginGracefulShutdown()`` and all in-flight RPCs have finished executing.
   /// If you need to abruptly stop all work you should cancel the task executing this method.
   ///
-  /// The client, and by extension this function, can only be run once. If the client is already
-  /// running or has already been closed then a ``RuntimeError`` is thrown.
+  /// Call this function at most once per client. If the client is already
+  /// running, or you've already closed it, this function throws a ``RuntimeError``.
   public func runConnections() async throws {
     try self.stateMachine.withLock { try $0.state.run() }
 
@@ -237,9 +239,9 @@ public final class GRPCClient<Transport: ClientTransport>: Sendable {
 
   /// Closes the client.
   ///
-  /// The transport will be closed: this means that it will be given enough time to wait for
-  /// in-flight RPCs to finish executing, but no new RPCs will be accepted. You can cancel the task
-  /// executing ``runConnections()`` if you want to abruptly stop in-flight RPCs.
+  /// This closes the transport, giving it enough time to wait for
+  /// in-flight RPCs to finish executing, but it won't accept new RPCs. To abruptly stop
+  /// in-flight RPCs, cancel the task executing ``runConnections()``.
   public func beginGracefulShutdown() {
     let wasRunning = self.stateMachine.withLock { $0.state.beginGracefulShutdown() }
     if wasRunning {
@@ -349,8 +351,8 @@ public final class GRPCClient<Transport: ClientTransport>: Sendable {
 
   /// Starts a bidirectional streaming RPC.
   ///
-  /// - Note: ``runConnections()`` must have been called and still executing, and ``beginGracefulShutdown()`` mustn't
-  /// have been called.
+  /// - Note: You must have called ``runConnections()`` and it must still be executing, and you
+  /// mustn't have called ``beginGracefulShutdown()``.
   ///
   /// - Parameters:
   ///   - request: The streaming request.
@@ -397,14 +399,14 @@ public final class GRPCClient<Transport: ClientTransport>: Sendable {
 /// - Parameters:
 ///   - transport: The transport used to establish a communication channel with a server.
 ///   - interceptors: A collection of ``ClientInterceptor``s providing cross-cutting functionality to each
-///       accepted RPC. The order in which interceptors are added reflects the order in which they
-///       are called. The first interceptor added will be the first interceptor to intercept each
-///       request. The last interceptor added will be the final interceptor to intercept each
+///       accepted RPC. The order in which you add interceptors determines the order in which they
+///       run. The first interceptor added is the first interceptor to intercept each
+///       request. The last interceptor added is the final interceptor to intercept each
 ///       request before calling the appropriate handler.
 ///   - isolation: A reference to the actor to which the enclosing code is isolated, or nil if the
 ///       code is nonisolated.
 ///   - handleClient: A closure which is called with the client. When the closure returns, the
-///       client is shutdown gracefully.
+///       client shuts down gracefully.
 @available(gRPCSwift 2.0, *)
 public func withGRPCClient<Transport: ClientTransport, Result: Sendable>(
   transport: Transport,
@@ -425,14 +427,14 @@ public func withGRPCClient<Transport: ClientTransport, Result: Sendable>(
 /// - Parameters:
 ///   - transport: The transport used to establish a communication channel with a server.
 ///   - interceptorPipeline: A collection of ``ConditionalInterceptor``s providing cross-cutting
-///       functionality to each accepted RPC. Only applicable interceptors from the pipeline will be applied to each RPC.
-///       The order in which interceptors are added reflects the order in which they are called.
-///       The first interceptor added will be the first interceptor to intercept each request.
-///       The last interceptor added will be the final interceptor to intercept each request before calling the appropriate handler.
+///       functionality to each accepted RPC. This applies only the interceptors from the pipeline
+///       that apply to each RPC. The order in which you add interceptors determines the order in
+///       which they run. The first interceptor added is the first interceptor to intercept each request.
+///       The last interceptor added is the final interceptor to intercept each request before calling the appropriate handler.
 ///   - isolation: A reference to the actor to which the enclosing code is isolated, or nil if the
 ///       code is nonisolated.
 ///   - handleClient: A closure which is called with the client. When the closure returns, the
-///       client is shutdown gracefully.
+///       client shuts down gracefully.
 /// - Returns: The result of the `handleClient` closure.
 @available(gRPCSwift 2.0, *)
 public func withGRPCClient<Transport: ClientTransport, Result: Sendable>(

--- a/Sources/GRPCCore/GRPCServer.swift
+++ b/Sources/GRPCCore/GRPCServer.swift
@@ -79,7 +79,9 @@ private import Synchronization
 public final class GRPCServer<Transport: ServerTransport>: Sendable {
   typealias Stream = RPCStream<Transport.Inbound, Transport.Outbound>
 
-  /// The ``ServerTransport`` implementation that the server uses to listen for new requests.
+  /// The transport implementation that the server uses to listen for new requests.
+  ///
+  /// Conforms to ``ServerTransport``.
   public let transport: Transport
 
   /// The services registered which the server is serving.

--- a/Sources/GRPCCore/GRPCServer.swift
+++ b/Sources/GRPCCore/GRPCServer.swift
@@ -140,7 +140,7 @@ public final class GRPCServer<Transport: ServerTransport>: Sendable {
     }
   }
 
-  /// Creates a new server.
+  /// Creates a new server that applies the given interceptors to every RPC.
   ///
   /// - Parameters:
   ///   - transport: The transport the server should listen on.
@@ -162,7 +162,7 @@ public final class GRPCServer<Transport: ServerTransport>: Sendable {
     )
   }
 
-  /// Creates a new server.
+  /// Creates a new server that applies interceptors selectively to the RPCs each one targets.
   ///
   /// - Parameters:
   ///   - transport: The transport the server should listen on.
@@ -250,7 +250,7 @@ public final class GRPCServer<Transport: ServerTransport>: Sendable {
   }
 }
 
-/// Creates and runs a gRPC server.
+/// Creates and runs a gRPC server, applying the given interceptors to every RPC.
 ///
 /// - Parameters:
 ///   - transport: The transport the server should listen on.
@@ -282,7 +282,7 @@ public func withGRPCServer<Transport: ServerTransport, Result: Sendable>(
   )
 }
 
-/// Creates and runs a gRPC server.
+/// Creates and runs a gRPC server, applying interceptors selectively to the RPCs each one targets.
 ///
 /// - Parameters:
 ///   - transport: The transport the server should listen on.

--- a/Sources/GRPCCore/GRPCServer.swift
+++ b/Sources/GRPCCore/GRPCServer.swift
@@ -19,15 +19,15 @@ private import Synchronization
 /// A gRPC server.
 ///
 /// The server accepts connections from clients and listens on each connection for new streams
-/// which are initiated by the client. Each stream maps to a single RPC. The server routes accepted
+/// that the client initiates. Each stream maps to a single RPC. The server routes accepted
 /// streams to a service to handle the RPC or rejects them with an appropriate error if no service
 /// can handle the RPC.
 ///
 /// A ``GRPCServer`` listens with a specific transport implementation (for example, HTTP/2 or in-process),
 /// and routes requests from the transport to the service instance. You can also use "interceptors"
 /// to implement cross-cutting logic that applies to all accepted RPCs. Example uses of interceptors
-/// include request filtering, authentication, and logging. Once requests have been intercepted
-/// they are passed to a handler which in turn returns a response to send back to the client.
+/// include request filtering, authentication, and logging. Once the interceptors have processed a
+/// request, the server passes it to a handler, which in turn returns a response to send back to the client.
 ///
 /// ## Configuring and starting a server
 ///
@@ -60,8 +60,8 @@ private import Synchronization
 ///
 /// If the `with`-style methods for creating a server aren't suitable for your application then you
 /// can create and run it manually. This requires you to call the ``serve()`` method in a task
-/// which instructs the server to start its transport and listen for new RPCs. A ``RuntimeError`` is
-/// thrown if the transport can't be started or encounters some other runtime error.
+/// which instructs the server to start its transport and listen for new RPCs. This method throws a
+/// ``RuntimeError`` if the transport can't start or encounters some other runtime error.
 ///
 /// ```swift
 /// // Start running the server.
@@ -91,14 +91,14 @@ public final class GRPCServer<Transport: ServerTransport>: Sendable {
   private let state: Mutex<State>
 
   private enum State: Sendable {
-    /// The server hasn't been started yet. Can transition to `running` or `stopped`.
+    /// The server hasn't started yet. Can transition to `running` or `stopped`.
     case notStarted
     /// The server is running and accepting RPCs. Can transition to `stopping`.
     case running
-    /// The server is stopping and no new RPCs will be accepted. Existing RPCs may run to
+    /// The server is stopping and won't accept new RPCs. Existing RPCs may run to
     /// completion. May transition to `stopped`.
     case stopping
-    /// The server has stopped, no RPCs are in flight and no more will be accepted. This state
+    /// The server has stopped: no RPCs are in flight and it won't accept any more. This state
     /// is terminal.
     case stopped
 
@@ -146,9 +146,9 @@ public final class GRPCServer<Transport: ServerTransport>: Sendable {
   ///   - transport: The transport the server should listen on.
   ///   - services: Services offered by the server.
   ///   - interceptors: A collection of interceptors providing cross-cutting functionality to each
-  ///       accepted RPC. The order in which interceptors are added reflects the order in which they
-  ///       are called. The first interceptor added will be the first interceptor to intercept each
-  ///       request. The last interceptor added will be the final interceptor to intercept each
+  ///       accepted RPC. The order in which you add interceptors determines the order in which they
+  ///       run. The first interceptor added is the first interceptor to intercept each
+  ///       request. The last interceptor added is the final interceptor to intercept each
   ///       request before calling the appropriate handler.
   public convenience init(
     transport: Transport,
@@ -168,9 +168,9 @@ public final class GRPCServer<Transport: ServerTransport>: Sendable {
   ///   - transport: The transport the server should listen on.
   ///   - services: Services offered by the server.
   ///   - interceptorPipeline: A collection of interceptors providing cross-cutting functionality to each
-  ///       accepted RPC. The order in which interceptors are added reflects the order in which they
-  ///       are called. The first interceptor added will be the first interceptor to intercept each
-  ///       request. The last interceptor added will be the final interceptor to intercept each
+  ///       accepted RPC. The order in which you add interceptors determines the order in which they
+  ///       run. The first interceptor added is the first interceptor to intercept each
+  ///       request. The last interceptor added is the final interceptor to intercept each
   ///       request before calling the appropriate handler.
   public convenience init(
     transport: Transport,
@@ -199,17 +199,16 @@ public final class GRPCServer<Transport: ServerTransport>: Sendable {
 
   /// Starts the server and runs until the registered transport has closed.
   ///
-  /// No RPCs are processed until the configured transport is listening. If the transport fails to start
-  /// listening, or if it encounters a runtime error, then ``RuntimeError`` is thrown.
+  /// The server processes no RPCs until the configured transport is listening. If the transport fails to start
+  /// listening, or if it encounters a runtime error, then this function throws ``RuntimeError``.
   ///
-  /// This function returns when the configured transport has stopped listening and all requests have been
-  /// handled. You can signal to the transport that it should stop listening by calling
+  /// This function returns when the configured transport has stopped listening and the server has handled
+  /// all requests. To signal to the transport that it should stop listening, call
   /// ``beginGracefulShutdown()``. The server will continue to process existing requests.
   ///
   /// To stop the server more abruptly you can cancel the task that this function is running in.
   ///
-  /// - Note: You can only call this function once, repeated calls will result in a
-  ///   ``RuntimeError`` being thrown.
+  /// - Note: Call this function at most once; repeated calls throw a ``RuntimeError``.
   public func serve() async throws {
     try self.state.withLock { try $0.startServing() }
 
@@ -256,14 +255,14 @@ public final class GRPCServer<Transport: ServerTransport>: Sendable {
 ///   - transport: The transport the server should listen on.
 ///   - services: Services offered by the server.
 ///   - interceptors: A collection of interceptors providing cross-cutting functionality to each
-///       accepted RPC. The order in which interceptors are added reflects the order in which they
-///       are called. The first interceptor added will be the first interceptor to intercept each
-///       request. The last interceptor added will be the final interceptor to intercept each
+///       accepted RPC. The order in which you add interceptors determines the order in which they
+///       run. The first interceptor added is the first interceptor to intercept each
+///       request. The last interceptor added is the final interceptor to intercept each
 ///       request before calling the appropriate handler.
 ///   - isolation: A reference to the actor to which the enclosing code is isolated, or nil if the
 ///       code is nonisolated.
 ///   - handleServer: A closure which is called with the server. When the closure returns, the
-///       server is shutdown gracefully.
+///       server shuts down gracefully.
 /// - Returns: The result of the `handleServer` closure.
 @available(gRPCSwift 2.0, *)
 public func withGRPCServer<Transport: ServerTransport, Result: Sendable>(
@@ -288,14 +287,14 @@ public func withGRPCServer<Transport: ServerTransport, Result: Sendable>(
 ///   - transport: The transport the server should listen on.
 ///   - services: Services offered by the server.
 ///   - interceptorPipeline: A collection of interceptors providing cross-cutting functionality to each
-///       accepted RPC. The order in which interceptors are added reflects the order in which they
-///       are called. The first interceptor added will be the first interceptor to intercept each
-///       request. The last interceptor added will be the final interceptor to intercept each
+///       accepted RPC. The order in which you add interceptors determines the order in which they
+///       run. The first interceptor added is the first interceptor to intercept each
+///       request. The last interceptor added is the final interceptor to intercept each
 ///       request before calling the appropriate handler.
 ///   - isolation: A reference to the actor to which the enclosing code is isolated, or nil if the
 ///       code is nonisolated.
 ///   - handleServer: A closure which is called with the server. When the closure returns, the
-///       server is shutdown gracefully.
+///       server shuts down gracefully.
 /// - Returns: The result of the `handleServer` closure.
 @available(gRPCSwift 2.0, *)
 public func withGRPCServer<Transport: ServerTransport, Result: Sendable>(

--- a/Sources/GRPCCore/Internal/MethodConfigs.swift
+++ b/Sources/GRPCCore/Internal/MethodConfigs.swift
@@ -16,8 +16,8 @@
 
 /// A collection of ``MethodConfig``s, mapped to specific methods or services.
 ///
-/// When creating a new instance, no overrides and no default will be set for using when getting
-/// a configuration for a method that has not been given a specific override.
+/// Creating a new instance sets no overrides and no default, so getting a configuration for
+/// a method without a specific override returns none.
 /// Use ``setDefaultConfig(_:forService:)`` to set a specific override for a whole
 /// service, or set a default configuration for all methods by calling ``setDefaultConfig(_:)``.
 ///
@@ -41,12 +41,12 @@ package struct MethodConfigs: Sendable, Hashable {
 
   /// Get or set the corresponding ``MethodConfig`` for the given ``MethodDescriptor``.
   ///
-  /// Configuration is hierarchical and can be set per-method, per-service
-  /// (``setDefaultConfig(_:forService:)``) and globally (``setDefaultConfig(_:)``).
+  /// Configuration is hierarchical: set it per-method, per-service
+  /// (``setDefaultConfig(_:forService:)``), or globally (``setDefaultConfig(_:)``).
   /// This subscript sets the per-method configuration but retrieves a configuration respecting
-  /// the hierarchy. If no per-method configuration is present, the per-service configuration is
-  /// checked and returned if present. If the per-service configuration isn't present then the
-  /// global configuration is returned, if present.
+  /// the hierarchy. If no per-method configuration is present, this subscript checks and returns
+  /// the per-service configuration if present. If the per-service configuration isn't present,
+  /// this subscript returns the global configuration if present.
   ///
   /// - Parameters:
   ///  - descriptor: The ``MethodDescriptor`` for which to get or set a ``MethodConfig``.
@@ -93,7 +93,7 @@ package struct MethodConfigs: Sendable, Hashable {
   /// Set a default configuration for a service.
   ///
   /// If getting a configuration for a method that's part of a service, and the method itself doesn't have an
-  /// override, then this configuration will be used instead of the default configuration passed when creating
+  /// override, then this configuration takes precedence over the default configuration passed when creating
   /// this instance of ``MethodConfigs``.
   ///
   /// - Parameters:

--- a/Sources/GRPCCore/Internal/Result+Catching.swift
+++ b/Sources/GRPCCore/Internal/Result+Catching.swift
@@ -30,7 +30,8 @@ extension Result {
 
   /// Attempts to map the error to the given error type.
   ///
-  /// If the cast fails then the provided closure is used to create an error of the given type.
+  /// If the cast fails, this function uses the provided closure to create an error of the given
+  /// type.
   ///
   /// - Parameters:
   ///   - errorType: The type of error to cast to.
@@ -48,7 +49,8 @@ extension Result {
 
   /// Attempt to map or convert the error to an `RPCError`.
   ///
-  /// If the cast or conversion is not possible then the provided closure is used to create an error of the given type.
+  /// If the cast or conversion is not possible, this function uses the provided closure to create
+  /// an error of the given type.
   ///
   /// - Parameter buildError: A closure which constructs the desired error if conversion is not possible.
   @inlinable

--- a/Sources/GRPCCore/Internal/TaskGroup+CancellableTask.swift
+++ b/Sources/GRPCCore/Internal/TaskGroup+CancellableTask.swift
@@ -19,7 +19,7 @@ extension TaskGroup {
   /// Adds a child task to the group which is individually cancellable.
   ///
   /// - Parameter operation: The task to add to the group.
-  /// - Returns: A handle which can be used to cancel the task without cancelling the rest of
+  /// - Returns: A handle that a caller can use to cancel the task without cancelling the rest of
   ///     the group.
   @inlinable
   mutating func addCancellableTask(

--- a/Sources/GRPCCore/Metadata.swift
+++ b/Sources/GRPCCore/Metadata.swift
@@ -271,6 +271,7 @@ public struct Metadata: Sendable, Hashable {
 extension Metadata: RandomAccessCollection {
   public typealias Element = (key: String, value: Value)
 
+  /// A position of a key-value pair in a ``Metadata`` collection.
   public struct Index: Comparable, Sendable {
     @usableFromInline
     let _base: Array<Element>.Index

--- a/Sources/GRPCCore/Metadata.swift
+++ b/Sources/GRPCCore/Metadata.swift
@@ -135,7 +135,7 @@ public struct Metadata: Sendable, Hashable {
     self.elements = []
   }
 
-  /// Initialize `Metadata` from a `Sequence` of `Element`s.
+  /// Creates a metadata collection from a sequence of key-value pairs.
   public init(_ elements: some Sequence<Element>) {
     self.elements = elements.map { key, value in
       KeyValuePair(key: key, value: value)
@@ -158,7 +158,7 @@ public struct Metadata: Sendable, Hashable {
     self.addValue(.string(stringValue), forKey: key)
   }
 
-  /// Adds a new key-value pair, where the value is binary data, in the form of `[UInt8]`.
+  /// Adds a new key-value pair whose value is binary data.
   ///
   /// - Parameters:
   ///   - binaryValue: The binary data (that is, `[UInt8]`) to be associated with the given key.
@@ -176,14 +176,14 @@ public struct Metadata: Sendable, Hashable {
     self.elements.append(.init(key: key, value: value))
   }
 
-  /// Adds the contents of a `Sequence` of key-value pairs to this `Metadata` instance.
+  /// Adds the contents of a sequence of key-value pairs to this instance.
   ///
   /// - Parameter other: the `Sequence` whose key-value pairs should be added into this `Metadata` instance.
   public mutating func add(contentsOf other: some Sequence<Element>) {
     self.elements.append(contentsOf: other.map(KeyValuePair.init))
   }
 
-  /// Adds the contents of another `Metadata` to this instance.
+  /// Adds the contents of another metadata collection to this instance.
   ///
   /// - Parameter other: the `Metadata` whose key-value pairs should be added into this one.
   public mutating func add(contentsOf other: Metadata) {
@@ -215,7 +215,7 @@ public struct Metadata: Sendable, Hashable {
     self.replaceOrAddValue(.string(stringValue), forKey: key)
   }
 
-  /// Adds a key-value pair to the collection, where the value is `[UInt8]`.
+  /// Adds a key-value pair to the collection, where the value is binary data.
   ///
   /// If there are pairs already associated with the given key, they will all be removed first, and the new pair
   /// will be added. If no pairs are present with the given key, a new one will be added.
@@ -271,7 +271,7 @@ public struct Metadata: Sendable, Hashable {
 extension Metadata: RandomAccessCollection {
   public typealias Element = (key: String, value: Value)
 
-  /// A position of a key-value pair in a ``Metadata`` collection.
+  /// A position of a key-value pair in a metadata collection.
   public struct Index: Comparable, Sendable {
     @usableFromInline
     let _base: Array<Element>.Index
@@ -314,7 +314,9 @@ extension Metadata {
   /// A sequence of metadata values for a given key.
   public struct Values: Sequence, Sendable {
 
-    /// An iterator for all metadata ``Value``s associated with a given key.
+    /// An iterator over the values associated with a given key.
+    ///
+    /// Produces ``Metadata/Value`` elements.
     public struct Iterator: IteratorProtocol, Sendable {
       private var metadataIterator: Metadata.Iterator
       private let key: String
@@ -347,7 +349,7 @@ extension Metadata {
     }
   }
 
-  /// Get a ``Values`` sequence for a given key.
+  /// Returns all values associated with a given key.
   ///
   /// - Parameter key: The returned sequence will only return values for this key.
   ///
@@ -397,7 +399,7 @@ extension Metadata {
     }
   }
 
-  /// Get a ``StringValues`` sequence for a given key.
+  /// Returns the string values associated with a given key.
   ///
   /// - Parameter key: The returned sequence will only return string values for this key.
   ///
@@ -453,7 +455,7 @@ extension Metadata {
     }
   }
 
-  /// A subscript to get a ``BinaryValues`` sequence for a given key.
+  /// Returns the binary values associated with a given key.
   ///
   /// As it's iterated, this sequence will return values originally stored as binary data for a given key, and will
   /// also try to decode values stored as strings as if they were base64-encoded strings; only strings that

--- a/Sources/GRPCCore/Metadata.swift
+++ b/Sources/GRPCCore/Metadata.swift
@@ -16,12 +16,12 @@
 
 /// A collection of metadata key-value pairs, found in RPC streams.
 ///
-/// Metadata is a side channel associated with an RPC that allows you to send information between clients
-/// and servers. Metadata is stored as a list of key-value pairs where keys aren't required to be unique;
-/// a single key may have multiple values associated with it.
+/// Metadata is a side channel associated with an RPC that allows you to send information between
+/// clients and servers. Metadata stores key-value pairs as a list, so keys aren't required to be
+/// unique; a single key may have multiple values associated with it.
 ///
 /// Keys are case-insensitive ASCII strings. Values may be ASCII strings or binary data. The keys
-/// for binary data should end with "-bin": this will be asserted when adding a new binary value.
+/// for binary data should end with "-bin": adding a new binary value asserts this.
 /// Keys must not be prefixed with "grpc-" as these are reserved for gRPC.
 ///
 /// # Using Metadata
@@ -76,9 +76,9 @@
 /// }
 /// ```
 ///
-/// - Note: Binary values are encoded as base64 strings when they are sent over the wire, so keys with
-/// the "-bin" suffix may have string values (rather than binary). These are deserialized automatically when
-/// using ``subscript(binaryValues:)``.
+/// - Note: gRPC encodes binary values as base64 strings when it sends them over the wire, so keys
+/// with the "-bin" suffix may have string values (rather than binary). ``subscript(binaryValues:)``
+/// deserializes these automatically.
 @available(gRPCSwift 2.0, *)
 public struct Metadata: Sendable, Hashable {
 
@@ -91,8 +91,8 @@ public struct Metadata: Sendable, Hashable {
 
     /// The value as a String.
     ///
-    /// If it was originally stored as a binary, the base64-encoded String version
-    /// of the binary data will be returned instead.
+    /// If this value's case is `.binary`, this method returns the base64-encoded String version
+    /// of the binary data instead.
     public func encoded() -> String {
       switch self {
       case .string(let string):
@@ -112,8 +112,9 @@ public struct Metadata: Sendable, Hashable {
     ///
     /// - Parameters:
     ///   - key: The key for the key-value pair.
-    ///   - value: The value to be associated with the given key. If it's a binary value, then the associated
-    ///   key must end in "-bin", otherwise, this method will produce an assertion failure.
+    ///   - value: The value to associate with the given key. If it's a binary value, then the
+    ///   associated key must end in "-bin", otherwise, this method will produce an assertion
+    ///   failure.
     init(key: String, value: Value) {
       if case .binary = value {
         assert(key.hasSuffix("-bin"), "Keys for binary values must end in -bin")
@@ -152,8 +153,8 @@ public struct Metadata: Sendable, Hashable {
   /// Adds a new key-value pair, where the value is a string.
   ///
   /// - Parameters:
-  ///   - stringValue: The string value to be associated with the given key.
-  ///   - key: The key to be associated with the given value.
+  ///   - stringValue: The string value to associate with the given key.
+  ///   - key: The key to associate with the given value.
   public mutating func addString(_ stringValue: String, forKey key: String) {
     self.addValue(.string(stringValue), forKey: key)
   }
@@ -161,8 +162,8 @@ public struct Metadata: Sendable, Hashable {
   /// Adds a new key-value pair whose value is binary data.
   ///
   /// - Parameters:
-  ///   - binaryValue: The binary data (that is, `[UInt8]`) to be associated with the given key.
-  ///   - key: The key to be associated with the given value. Must end in "-bin".
+  ///   - binaryValue: The binary data (that is, `[UInt8]`) to associate with the given key.
+  ///   - key: The key to associate with the given value. Must end in "-bin".
   public mutating func addBinary(_ binaryValue: [UInt8], forKey key: String) {
     self.addValue(.binary(binaryValue), forKey: key)
   }
@@ -170,29 +171,30 @@ public struct Metadata: Sendable, Hashable {
   /// Adds a new key-value pair.
   ///
   /// - Parameters:
-  ///   - value: The ``Value`` to be associated with the given key.
-  ///   - key: The key to be associated with the given value. If value is binary, it must end in "-bin".
+  ///   - value: The ``Value`` to associate with the given key.
+  ///   - key: The key to associate with the given value. If value is binary, it must end in "-bin".
   internal mutating func addValue(_ value: Value, forKey key: String) {
     self.elements.append(.init(key: key, value: value))
   }
 
   /// Adds the contents of a sequence of key-value pairs to this instance.
   ///
-  /// - Parameter other: the `Sequence` whose key-value pairs should be added into this `Metadata` instance.
+  /// - Parameter other: The `Sequence` containing the key-value pairs to add to this `Metadata`
+  /// instance.
   public mutating func add(contentsOf other: some Sequence<Element>) {
     self.elements.append(contentsOf: other.map(KeyValuePair.init))
   }
 
   /// Adds the contents of another metadata collection to this instance.
   ///
-  /// - Parameter other: the `Metadata` whose key-value pairs should be added into this one.
+  /// - Parameter other: The `Metadata` containing the key-value pairs to add to this one.
   public mutating func add(contentsOf other: Metadata) {
     self.elements.append(contentsOf: other.elements)
   }
 
   /// Removes all values associated with the given key.
   ///
-  /// - Parameter key: The key for which all values should be removed.
+  /// - Parameter key: The key for which to remove all values.
   ///
   /// - Complexity: O(*n*), where *n* is the number of entries in the metadata instance.
   public mutating func removeAllValues(forKey key: String) {
@@ -203,12 +205,12 @@ public struct Metadata: Sendable, Hashable {
 
   /// Adds a key-value pair to the collection, where the value is a string.
   ///
-  /// If there are pairs already associated with the given key, they will all be removed first, and the new pair
-  /// will be added. If no pairs are present with the given key, a new one will be added.
+  /// If pairs already exist for the given key, this method removes them first and adds the new
+  /// pair. If no pairs exist for the given key, it adds a new one.
   ///
   /// - Parameters:
-  ///   - stringValue: The string value to be associated with the given key.
-  ///   - key: The key to be associated with the given value.
+  ///   - stringValue: The string value to associate with the given key.
+  ///   - key: The key to associate with the given value.
   ///
   /// - Complexity: O(*n*), where *n* is the number of entries in the metadata instance.
   public mutating func replaceOrAddString(_ stringValue: String, forKey key: String) {
@@ -217,12 +219,12 @@ public struct Metadata: Sendable, Hashable {
 
   /// Adds a key-value pair to the collection, where the value is binary data.
   ///
-  /// If there are pairs already associated with the given key, they will all be removed first, and the new pair
-  /// will be added. If no pairs are present with the given key, a new one will be added.
+  /// If pairs already exist for the given key, this method removes them first and adds the new
+  /// pair. If no pairs exist for the given key, it adds a new one.
   ///
   /// - Parameters:
-  ///   - binaryValue: The `[UInt8]` to be associated with the given key.
-  ///   - key: The key to be associated with the given value. Must end in "-bin".
+  ///   - binaryValue: The `[UInt8]` to associate with the given key.
+  ///   - key: The key to associate with the given value. Must end in "-bin".
   ///
   /// - Complexity: O(*n*), where *n* is the number of entries in the metadata instance.
   public mutating func replaceOrAddBinary(_ binaryValue: [UInt8], forKey key: String) {
@@ -231,12 +233,12 @@ public struct Metadata: Sendable, Hashable {
 
   /// Adds a key-value pair to the collection.
   ///
-  /// If there are pairs already associated with the given key, they will all be removed first, and the new pair
-  /// will be added. If no pairs are present with the given key, a new one will be added.
+  /// If pairs already exist for the given key, this method removes them first and adds the new
+  /// pair. If no pairs exist for the given key, it adds a new one.
   ///
   /// - Parameters:
-  ///   - value: The ``Value`` to be associated with the given key.
-  ///   - key: The key to be associated with the given value. If value is binary, it must end in "-bin".
+  ///   - value: The ``Value`` to associate with the given key.
+  ///   - key: The key to associate with the given value. If value is binary, it must end in "-bin".
   ///
   /// - Complexity: O(*n*), where *n* is the number of entries in the metadata instance.
   internal mutating func replaceOrAddValue(_ value: Value, forKey key: String) {
@@ -246,7 +248,7 @@ public struct Metadata: Sendable, Hashable {
 
   /// Removes all key-value pairs from this metadata instance.
   ///
-  /// - Parameter keepingCapacity: Whether the current capacity should be kept or reset.
+  /// - Parameter keepingCapacity: Whether to keep or reset the current capacity.
   ///
   /// - Complexity: O(*n*), where *n* is the number of entries in the metadata instance.
   public mutating func removeAll(keepingCapacity: Bool) {
@@ -457,9 +459,9 @@ extension Metadata {
 
   /// Returns the binary values associated with a given key.
   ///
-  /// As it's iterated, this sequence will return values originally stored as binary data for a given key, and will
-  /// also try to decode values stored as strings as if they were base64-encoded strings; only strings that
-  /// are successfully decoded will be returned.
+  /// As it's iterated, this sequence returns values originally stored as binary data for a given
+  /// key, and tries to decode values stored as strings as if they were base64-encoded strings; it
+  /// returns only successfully decoded strings.
   ///
   /// - Parameter key: The returned sequence will only return binary (that is, `[UInt8]`) values for this key.
   ///

--- a/Sources/GRPCCore/MethodDescriptor.swift
+++ b/Sources/GRPCCore/MethodDescriptor.swift
@@ -74,7 +74,7 @@ public struct MethodDescriptor: Sendable, Hashable {
     }
   }
 
-  /// Creates a new method descriptor.
+  /// Creates a new method descriptor from a service descriptor and method name.
   ///
   /// - Parameters:
   ///   - service: The name of the service, including the package name. For example,
@@ -84,7 +84,7 @@ public struct MethodDescriptor: Sendable, Hashable {
     self.init(service: service, method: method, type: nil)
   }
 
-  /// Creates a new method descriptor.
+  /// Creates a new method descriptor from a service descriptor, method name, and RPC type.
   ///
   /// - Parameters:
   ///   - service: The name of the service, including the package name. For example,
@@ -98,7 +98,7 @@ public struct MethodDescriptor: Sendable, Hashable {
     self.type = type
   }
 
-  /// Creates a new method descriptor.
+  /// Creates a new method descriptor from a fully qualified service name and method name.
   ///
   /// - Parameters:
   ///   - fullyQualifiedService: The fully qualified name of the service, including the package
@@ -108,7 +108,7 @@ public struct MethodDescriptor: Sendable, Hashable {
     self.init(fullyQualifiedService: fullyQualifiedService, method: method, type: nil)
   }
 
-  /// Creates a new method descriptor.
+  /// Creates a new method descriptor from a fully qualified service name, method name, and RPC type.
   ///
   /// - Parameters:
   ///   - fullyQualifiedService: The fully qualified name of the service, including the package

--- a/Sources/GRPCCore/MethodDescriptor.swift
+++ b/Sources/GRPCCore/MethodDescriptor.swift
@@ -38,6 +38,7 @@ public struct MethodDescriptor: Sendable, Hashable {
   @available(gRPCSwift 2.3, *)
   public var type: RPCType?
 
+  /// The pattern of request and response messages exchanged over an RPC.
   @available(gRPCSwift 2.3, *)
   @frozen
   public enum RPCType: Hashable, Sendable, CaseIterable {

--- a/Sources/GRPCCore/RPCError.swift
+++ b/Sources/GRPCCore/RPCError.swift
@@ -214,7 +214,7 @@ extension RPCError.Code {
   /// expire.
   public static let deadlineExceeded = Self(code: .deadlineExceeded)
 
-  /// The server couldn't find the requested entity (for example, a file or directory).
+  /// The requested entity (for example, a file or directory) couldn't be found.
   public static let notFound = Self(code: .notFound)
 
   /// Some entity that we attempted to create (for example, file or directory) already
@@ -279,7 +279,7 @@ extension RPCError.Code {
   /// easily look for an ``outOfRange`` error to detect when they are done.
   public static let outOfRange = Self(code: .outOfRange)
 
-  /// The service doesn't implement, support, or enable this operation.
+  /// This operation isn't implemented, supported, or enabled.
   public static let unimplemented = Self(code: .unimplemented)
 
   /// Internal errors.

--- a/Sources/GRPCCore/RPCError.swift
+++ b/Sources/GRPCCore/RPCError.swift
@@ -27,25 +27,25 @@ public struct RPCError: Sendable, Hashable, Error {
 
   /// Metadata associated with the error.
   ///
-  /// Any metadata included in the error thrown from a service will be sent back to the client and
-  /// conversely any ``RPCError`` received by the client may include metadata sent by a service.
+  /// If a service throws an error that includes metadata, the client receives that metadata;
+  /// conversely, an ``RPCError`` that the client receives may include metadata that a service sent.
   ///
   /// Note that clients and servers may synthesise errors which may not include metadata.
   public var metadata: Metadata
 
-  /// The original error which led to this error being thrown.
+  /// The original error that caused this error.
   public var cause: (any Error)?
 
   /// Creates a new RPC error that accepts any error as its cause.
   ///
   /// If the given `cause` is also an ``RPCError`` sharing the same `code`,
-  /// then they will be flattened into a single error, by merging the messages and metadata.
+  /// this initializer flattens them into a single error by merging the messages and metadata.
   ///
   /// - Parameters:
   ///   - code: The status code.
   ///   - message: A message providing additional context about the code.
   ///   - metadata: Any metadata to attach to the error.
-  ///   - cause: An underlying error which led to this error being thrown.
+  ///   - cause: An underlying error that caused this error.
   public init(
     code: Code,
     message: String,
@@ -69,14 +69,14 @@ public struct RPCError: Sendable, Hashable, Error {
 
   /// Creates a new RPC error that accepts another RPC error as its cause.
   ///
-  /// If the given `cause` shares the same `code`, then it will be flattened
-  /// into a single error, by merging the messages and metadata.
+  /// If the given `cause` shares the same `code`, this initializer flattens it
+  /// into a single error by merging the messages and metadata.
   ///
   /// - Parameters:
   ///   - code: The status code.
   ///   - message: A message providing additional context about the code.
   ///   - metadata: Any metadata to attach to the error.
-  ///   - cause: An underlying ``RPCError`` which led to this error being thrown.
+  ///   - cause: An underlying ``RPCError`` that caused this error.
   public init(
     code: Code,
     message: String,
@@ -186,15 +186,15 @@ extension RPCError {
 
 @available(gRPCSwift 2.0, *)
 extension RPCError.Code {
-  /// The operation was cancelled (typically by the caller).
+  /// The caller typically cancelled the operation.
   public static let cancelled = Self(code: .cancelled)
 
   /// Unknown error.
   ///
-  /// An example of where this error may be returned is if a
-  /// Status value received from another address space belongs to an error-space
-  /// that is not known in this address space. Also errors raised by APIs that
-  /// do not return enough error information may be converted to this error.
+  /// The system may return this error if a
+  /// Status value it received from another address space belongs to an error-space
+  /// this address space doesn't know about. The system may also convert errors that
+  /// APIs raise without returning enough error information into this error.
   public static let unknown = Self(code: .unknown)
 
   /// Client specified an invalid argument.
@@ -208,13 +208,13 @@ extension RPCError.Code {
   /// Deadline expired before operation could complete.
   ///
   /// For operations that
-  /// change the state of the system, this error may be returned even if the
-  /// operation has completed successfully. For example, a successful response
-  /// from a server could have been delayed long enough for the deadline to
+  /// change the state of the system, the server may return this error even if the
+  /// operation has completed successfully. For example, the network could delay a
+  /// successful response from a server long enough for the deadline to
   /// expire.
   public static let deadlineExceeded = Self(code: .deadlineExceeded)
 
-  /// Some requested entity (for example, file or directory) was not found.
+  /// The server couldn't find the requested entity (for example, a file or directory).
   public static let notFound = Self(code: .notFound)
 
   /// Some entity that we attempted to create (for example, file or directory) already
@@ -223,9 +223,9 @@ extension RPCError.Code {
 
   /// The caller does not have permission to execute the specified operation.
   ///
-  /// ``permissionDenied`` must not be used for rejections caused by exhausting
+  /// Don't use ``permissionDenied`` for rejections caused by exhausting
   /// some resource (use ``resourceExhausted`` instead for those errors).
-  /// ``permissionDenied`` must not be used if the caller cannot be identified
+  /// Don't use ``permissionDenied`` if the caller cannot be identified
   /// (use ``unauthenticated`` instead for those errors).
   public static let permissionDenied = Self(code: .permissionDenied)
 
@@ -233,11 +233,11 @@ extension RPCError.Code {
   /// entire file system is out of space.
   public static let resourceExhausted = Self(code: .resourceExhausted)
 
-  /// Operation was rejected because the system is not in a state required for
+  /// The system rejected the operation because it wasn't in a state required for
   /// the operation's execution.
   ///
-  /// For example, directory to be deleted may be
-  /// non-empty, an rmdir operation is applied to a non-directory, etc.
+  /// For example, the directory you want to delete may be
+  /// non-empty, or you apply an rmdir operation to a non-directory, etc.
   ///
   /// A litmus test that may help a service implementor in deciding
   /// between ``failedPrecondition``, ``aborted``, and ``unavailable``:
@@ -245,9 +245,9 @@ extension RPCError.Code {
   /// - Use ``aborted`` if the client should retry at a higher-level
   ///   (for example, restarting a read-modify-write sequence).
   /// - Use ``failedPrecondition`` if the client should not retry until
-  ///   the system state has been explicitly fixed. For example, if an "rmdir"
-  ///   fails because the directory is non-empty, ``failedPrecondition``
-  ///   should be returned since the client should not retry unless
+  ///   it has explicitly fixed the system state. For example, if an "rmdir"
+  ///   fails because the directory is non-empty, the server should return
+  ///   ``failedPrecondition`` since the client should not retry unless
   ///   they have first fixed up the directory by deleting files from it.
   /// - Use ``failedPrecondition`` if the client performs conditional
   ///   REST Get/Update/Delete on a resource and the resource on the
@@ -255,22 +255,22 @@ extension RPCError.Code {
   ///   read-modify-write on the same resource.
   public static let failedPrecondition = Self(code: .failedPrecondition)
 
-  /// The operation was aborted, typically due to a concurrency issue like
-  /// sequencer check failures, transaction aborts, etc.
+  /// A concurrency issue, such as sequencer check failures or transaction aborts, typically
+  /// aborts the operation.
   ///
   /// See litmus test above for deciding between ``failedPrecondition``, ``aborted``,
   /// and ``unavailable``.
   public static let aborted = Self(code: .aborted)
 
-  /// Operation was attempted past the valid range.
+  /// The client attempted an operation past the valid range.
   ///
   /// For example, seeking or reading
   /// past end of file.
   ///
   /// Unlike ``invalidArgument``, this error indicates a problem that may be fixed
   /// if the system state changes. For example, a 32-bit file system will
-  /// generate ``invalidArgument`` if asked to read at an offset that is not in the
-  /// range [0,2^32-1], but it will generate ``outOfRange`` if asked to read from
+  /// generate ``invalidArgument`` if the caller asks it to read at an offset that is not in the
+  /// range [0,2^32-1], but it will generate ``outOfRange`` if the caller asks it to read from
   /// an offset past the current file size.
   ///
   /// There is a fair bit of overlap between ``failedPrecondition`` and
@@ -279,19 +279,19 @@ extension RPCError.Code {
   /// easily look for an ``outOfRange`` error to detect when they are done.
   public static let outOfRange = Self(code: .outOfRange)
 
-  /// Operation is not implemented or not supported/enabled in this service.
+  /// The service doesn't implement, support, or enable this operation.
   public static let unimplemented = Self(code: .unimplemented)
 
   /// Internal errors.
   ///
-  /// This means some invariants expected by the underlying system have
-  /// been broken. If you see one of these errors, something is very broken.
+  /// This means something has broken invariants that the underlying system expects. If you see
+  /// one of these errors, something is very broken.
   public static let internalError = Self(code: .internalError)
 
   /// The service is currently unavailable.
   ///
   /// This is most likely a transient
-  /// condition and may be corrected by retrying with a backoff.
+  /// condition, and retrying with a backoff may correct it.
   ///
   /// See litmus test above for deciding between ``failedPrecondition``, ``aborted``,
   /// and ``unavailable``.
@@ -309,7 +309,7 @@ extension RPCError.Code {
 ///
 /// Converts to an ``RPCError``.
 /// You can conform types to this protocol to have more control over the status codes and
-/// error information provided to clients when a service throws an error.
+/// error information that a service provides to clients when it throws an error.
 @available(gRPCSwift 2.0, *)
 public protocol RPCErrorConvertible {
   /// The error code to terminate the RPC with.
@@ -320,13 +320,13 @@ public protocol RPCErrorConvertible {
 
   /// Metadata associated with the error.
   ///
-  /// Any metadata included in the error thrown from a service will be sent back to the client and
-  /// conversely any ``RPCError`` received by the client may include metadata sent by a service.
+  /// If a service throws an error that includes metadata, the client receives that metadata;
+  /// conversely, an ``RPCError`` that the client receives may include metadata that a service sent.
   ///
   /// Note that clients and servers may synthesise errors which may not include metadata.
   var rpcErrorMetadata: Metadata { get }
 
-  /// The original error which led to this error being thrown.
+  /// The original error that caused this error.
   var rpcErrorCause: (any Error)? { get }
 }
 
@@ -334,8 +334,8 @@ public protocol RPCErrorConvertible {
 extension RPCErrorConvertible {
   /// Metadata associated with the error.
   ///
-  /// Any metadata included in the error thrown from a service will be sent back to the client and
-  /// conversely any ``RPCError`` received by the client may include metadata sent by a service.
+  /// If a service throws an error that includes metadata, the client receives that metadata;
+  /// conversely, an ``RPCError`` that the client receives may include metadata that a service sent.
   ///
   /// Note that clients and servers may synthesise errors which may not include metadata.
   public var rpcErrorMetadata: Metadata {
@@ -350,7 +350,7 @@ extension RPCErrorConvertible {
 
 @available(gRPCSwift 2.0, *)
 extension RPCErrorConvertible where Self: Error {
-  /// When a value is itself an error, it's treated as its own original error.
+  /// When a value is itself an error, it serves as its own original error.
   public var rpcErrorCause: (any Error)? {
     self
   }

--- a/Sources/GRPCCore/RPCError.swift
+++ b/Sources/GRPCCore/RPCError.swift
@@ -98,13 +98,14 @@ public struct RPCError: Sendable, Hashable, Error {
     }
   }
 
-  /// Creates a new RPC error from the provided ``Status``.
-  ///
-  /// Returns `nil` if the provided ``Status`` has code ``Status/Code-swift.struct/ok``.
+  /// Creates a new RPC error from a status.
   ///
   /// - Parameters:
   ///   - status: The status to convert.
   ///   - metadata: Any metadata to attach to the error.
+  ///
+  /// Converts from a ``Status``.
+  /// Returns `nil` if the provided ``Status`` has code ``Status/Code-swift.struct/ok``.
   public init?(status: Status, metadata: Metadata = [:]) {
     guard let code = Code(status.code) else { return nil }
     self.init(code: code, message: status.message, metadata: metadata)
@@ -134,7 +135,7 @@ extension RPCError: CustomStringConvertible {
 
 @available(gRPCSwift 2.0, *)
 extension RPCError {
-  /// A code representing the high-level classification of an ``RPCError``.
+  /// A code representing the high-level classification of an error.
   public struct Code: Hashable, Sendable, CustomStringConvertible {
     /// The numeric value of the error code.
     public var rawValue: Int { Int(self.wrapped.rawValue) }
@@ -144,10 +145,12 @@ extension RPCError {
       self.wrapped = code
     }
 
-    /// Creates an error code from the given ``Status/Code-swift.struct``; returns `nil` if the
-    /// code is ``Status/Code-swift.struct/ok``.
+    /// Creates an error code from a status code, if the status wasn't successful.
     ///
     /// - Parameter code: The status code to create this ``RPCError/Code-swift.struct`` from.
+    /// 
+    /// Converts from ``Status/Code-swift.struct``. 
+    /// Returns `nil` if `code` is ``Status/Code-swift.struct/ok``, since that isn't a valid error.
     public init?(_ code: Status.Code) {
       if code == .ok {
         return nil
@@ -302,8 +305,9 @@ extension RPCError.Code {
   public static let unauthenticated = Self(code: .unauthenticated)
 }
 
-/// A value that can be converted to an ``RPCError``.
+/// A value that can be converted to an error.
 ///
+/// Converts to an ``RPCError``.
 /// You can conform types to this protocol to have more control over the status codes and
 /// error information provided to clients when a service throws an error.
 @available(gRPCSwift 2.0, *)

--- a/Sources/GRPCCore/RPCError.swift
+++ b/Sources/GRPCCore/RPCError.swift
@@ -208,7 +208,7 @@ extension RPCError.Code {
   /// Deadline expired before operation could complete.
   ///
   /// For operations that
-  /// change the state of the system, the server may return this error even if the
+  /// change the state of the system, this error may occur even if the
   /// operation has completed successfully. For example, the network could delay a
   /// successful response from a server long enough for the deadline to
   /// expire.

--- a/Sources/GRPCCore/RPCError.swift
+++ b/Sources/GRPCCore/RPCError.swift
@@ -134,6 +134,7 @@ extension RPCError: CustomStringConvertible {
 
 @available(gRPCSwift 2.0, *)
 extension RPCError {
+  /// A code representing the high-level classification of an ``RPCError``.
   public struct Code: Hashable, Sendable, CustomStringConvertible {
     /// The numeric value of the error code.
     public var rawValue: Int { Int(self.wrapped.rawValue) }

--- a/Sources/GRPCCore/RPCError.swift
+++ b/Sources/GRPCCore/RPCError.swift
@@ -36,7 +36,7 @@ public struct RPCError: Sendable, Hashable, Error {
   /// The original error which led to this error being thrown.
   public var cause: (any Error)?
 
-  /// Creates a new RPC error.
+  /// Creates a new RPC error that accepts any error as its cause.
   ///
   /// If the given `cause` is also an ``RPCError`` sharing the same `code`,
   /// then they will be flattened into a single error, by merging the messages and metadata.
@@ -67,7 +67,7 @@ public struct RPCError: Sendable, Hashable, Error {
     }
   }
 
-  /// Creates a new RPC error.
+  /// Creates a new RPC error that accepts another RPC error as its cause.
   ///
   /// If the given `cause` shares the same `code`, then it will be flattened
   /// into a single error, by merging the messages and metadata.
@@ -148,8 +148,8 @@ extension RPCError {
     /// Creates an error code from a status code, if the status wasn't successful.
     ///
     /// - Parameter code: The status code to create this ``RPCError/Code-swift.struct`` from.
-    /// 
-    /// Converts from ``Status/Code-swift.struct``. 
+    ///
+    /// Converts from ``Status/Code-swift.struct``.
     /// Returns `nil` if `code` is ``Status/Code-swift.struct/ok``, since that isn't a valid error.
     public init?(_ code: Status.Code) {
       if code == .ok {
@@ -342,7 +342,7 @@ extension RPCErrorConvertible {
     [:]
   }
 
-  /// The original error which led to this error being thrown.
+  /// By default, a value has no original error.
   public var rpcErrorCause: (any Error)? {
     nil
   }
@@ -350,7 +350,7 @@ extension RPCErrorConvertible {
 
 @available(gRPCSwift 2.0, *)
 extension RPCErrorConvertible where Self: Error {
-  /// The original error which led to this error being thrown.
+  /// When a value is itself an error, it's treated as its own original error.
   public var rpcErrorCause: (any Error)? {
     self
   }

--- a/Sources/GRPCCore/RuntimeError.swift
+++ b/Sources/GRPCCore/RuntimeError.swift
@@ -27,7 +27,7 @@ public struct RuntimeError: Error, Hashable, Sendable {
   /// instance of the error.
   public var message: String
 
-  /// The original error which led to this error being thrown.
+  /// The original error that caused this error.
   public var cause: (any Error)?
 
   /// Creates a new error.
@@ -35,7 +35,7 @@ public struct RuntimeError: Error, Hashable, Sendable {
   /// - Parameters:
   ///   - code: The error code.
   ///   - message: A description of the error.
-  ///   - cause: The original error which led to this error being thrown.
+  ///   - cause: The original error that caused this error.
   public init(code: Code, message: String, cause: (any Error)? = nil) {
     self.code = code
     self.message = message
@@ -86,22 +86,22 @@ extension RuntimeError {
       Self(.invalidArgument)
     }
 
-    /// An attempt to start the server was made but it is already running.
+    /// The caller tried to start the server, but it's already running.
     public static var serverIsAlreadyRunning: Self {
       Self(.serverIsAlreadyRunning)
     }
 
-    /// An attempt to start the server was made but it has already stopped.
+    /// The caller tried to start the server, but it has already stopped.
     public static var serverIsStopped: Self {
       Self(.serverIsStopped)
     }
 
-    /// An attempt to start the client was made but it is already running.
+    /// The caller tried to start the client, but it's already running.
     public static var clientIsAlreadyRunning: Self {
       Self(.clientIsAlreadyRunning)
     }
 
-    /// An attempt to start the client was made but it has already stopped.
+    /// The caller tried to start the client, but it has already stopped.
     public static var clientIsStopped: Self {
       Self(.clientIsStopped)
     }

--- a/Sources/GRPCCore/RuntimeError.swift
+++ b/Sources/GRPCCore/RuntimeError.swift
@@ -65,7 +65,7 @@ extension RuntimeError: CustomStringConvertible {
 
 @available(gRPCSwift 2.0, *)
 extension RuntimeError {
-  /// A code representing the high-level classification of a ``RuntimeError``.
+  /// A code representing the high-level classification of a runtime error.
   public struct Code: Hashable, Sendable {
     private enum Value {
       case invalidArgument

--- a/Sources/GRPCCore/RuntimeError.swift
+++ b/Sources/GRPCCore/RuntimeError.swift
@@ -65,6 +65,7 @@ extension RuntimeError: CustomStringConvertible {
 
 @available(gRPCSwift 2.0, *)
 extension RuntimeError {
+  /// A code representing the high-level classification of a ``RuntimeError``.
   public struct Code: Hashable, Sendable {
     private enum Value {
       case invalidArgument

--- a/Sources/GRPCCore/ServiceDescriptor.swift
+++ b/Sources/GRPCCore/ServiceDescriptor.swift
@@ -42,8 +42,8 @@ public struct ServiceDescriptor: Sendable, Hashable {
   }
 
   /// The fully qualified service name in the format:
-  /// - "package.service": if a package name is specified. For example, "helloworld.Greeter".
-  /// - "service": if a package name is not specified. For example, "Greeter".
+  /// - "package.service": if you specify a package name. For example, "helloworld.Greeter".
+  /// - "service": if you don't specify a package name. For example, "Greeter".
   public var fullyQualifiedService: String
 
   /// Creates a new descriptor from the fully qualified service name.

--- a/Sources/GRPCCore/Status.swift
+++ b/Sources/GRPCCore/Status.swift
@@ -228,7 +228,7 @@ extension Status.Code {
   /// expire.
   public static let deadlineExceeded = Self(code: .deadlineExceeded)
 
-  /// The server couldn't find the requested entity (for example, a file or directory).
+  /// The requested entity (for example, a file or directory) couldn't be found.
   public static let notFound = Self(code: .notFound)
 
   /// Some entity that we attempted to create (for example, file or directory) already
@@ -293,7 +293,7 @@ extension Status.Code {
   /// easily look for an ``outOfRange`` error to detect when they are done.
   public static let outOfRange = Self(code: .outOfRange)
 
-  /// The service doesn't implement, support, or enable this operation.
+  /// This operation isn't implemented, supported, or enabled.
   public static let unimplemented = Self(code: .unimplemented)
 
   /// Internal errors.

--- a/Sources/GRPCCore/Status.swift
+++ b/Sources/GRPCCore/Status.swift
@@ -222,7 +222,7 @@ extension Status.Code {
   /// Deadline expired before operation could complete.
   ///
   /// For operations that
-  /// change the state of the system, the server may return this error even if the
+  /// change the state of the system, this error may occur even if the
   /// operation has completed successfully. For example, the network could delay a
   /// successful response from a server long enough for the deadline to
   /// expire.

--- a/Sources/GRPCCore/Status.swift
+++ b/Sources/GRPCCore/Status.swift
@@ -155,7 +155,9 @@ extension Status {
       }
     }
 
-    /// Creates a status code from an ``RPCError/Code-swift.struct``.
+    /// Creates a status code from an error code.
+    ///
+    /// Converts from ``RPCError/Code-swift.struct``.
     ///
     /// - Parameters:
     ///   - code: The error code to create this ``Status/Code-swift.struct`` from.

--- a/Sources/GRPCCore/Status.swift
+++ b/Sources/GRPCCore/Status.swift
@@ -16,8 +16,8 @@
 
 /// A status object represents the outcome of an RPC.
 ///
-/// Each ``Status`` is composed of a ``Status/code-swift.property`` and ``Status/message``. Each
-/// service implementation chooses the code and message returned to the client for each RPC
+/// Each ``Status`` consists of a ``Status/code-swift.property`` and ``Status/message``. Each
+/// service implementation chooses the code and message that it returns to the client for each RPC
 /// it implements. However, client and server implementations may also generate status objects
 /// on their own if an error happens.
 ///
@@ -113,7 +113,7 @@ extension Status {
 extension Status {
   /// Status codes for gRPC operations.
   ///
-  /// The outcome of every RPC is indicated by a status code.
+  /// A status code indicates the outcome of every RPC.
   public struct Code: Hashable, CustomStringConvertible, Sendable {
     // Source: https://github.com/grpc/grpc/blob/6c0578099835c854b0ff36a4b8db98ed49278ed5/doc/statuscodes.md
     enum Wrapped: UInt8, Hashable, Sendable {
@@ -200,15 +200,15 @@ extension Status.Code {
   /// The operation completed successfully.
   public static let ok = Self(code: .ok)
 
-  /// The operation was cancelled (typically by the caller).
+  /// The caller typically cancelled the operation.
   public static let cancelled = Self(code: .cancelled)
 
   /// Unknown error.
   ///
-  /// An example of where this error may be returned is if a
-  /// Status value received from another address space belongs to an error-space
-  /// that is not known in this address space. Also errors raised by APIs that
-  /// do not return enough error information may be converted to this error.
+  /// The system may return this error if a
+  /// Status value it received from another address space belongs to an error-space
+  /// this address space doesn't know about. The system may also convert errors that
+  /// APIs raise without returning enough error information into this error.
   public static let unknown = Self(code: .unknown)
 
   /// Client specified an invalid argument.
@@ -222,13 +222,13 @@ extension Status.Code {
   /// Deadline expired before operation could complete.
   ///
   /// For operations that
-  /// change the state of the system, this error may be returned even if the
-  /// operation has completed successfully. For example, a successful response
-  /// from a server could have been delayed long enough for the deadline to
+  /// change the state of the system, the server may return this error even if the
+  /// operation has completed successfully. For example, the network could delay a
+  /// successful response from a server long enough for the deadline to
   /// expire.
   public static let deadlineExceeded = Self(code: .deadlineExceeded)
 
-  /// Some requested entity (for example, file or directory) was not found.
+  /// The server couldn't find the requested entity (for example, a file or directory).
   public static let notFound = Self(code: .notFound)
 
   /// Some entity that we attempted to create (for example, file or directory) already
@@ -237,9 +237,9 @@ extension Status.Code {
 
   /// The caller does not have permission to execute the specified operation.
   ///
-  /// ``permissionDenied`` must not be used for rejections caused by exhausting
+  /// Don't use ``permissionDenied`` for rejections caused by exhausting
   /// some resource (use ``resourceExhausted`` instead for those errors).
-  /// ``permissionDenied`` must not be used if the caller cannot be identified
+  /// Don't use ``permissionDenied`` if the caller cannot be identified
   /// (use ``unauthenticated`` instead for those errors).
   public static let permissionDenied = Self(code: .permissionDenied)
 
@@ -247,11 +247,11 @@ extension Status.Code {
   /// entire file system is out of space.
   public static let resourceExhausted = Self(code: .resourceExhausted)
 
-  /// Operation was rejected because the system is not in a state required for
+  /// The system rejected the operation because it wasn't in a state required for
   /// the operation's execution.
   ///
-  /// For example, directory to be deleted may be
-  /// non-empty, an rmdir operation is applied to a non-directory, etc.
+  /// For example, the directory you want to delete may be
+  /// non-empty, or you apply an rmdir operation to a non-directory, etc.
   ///
   /// A litmus test that may help a service implementor in deciding
   /// between ``failedPrecondition``, ``aborted``, and ``unavailable``:
@@ -259,9 +259,9 @@ extension Status.Code {
   /// - Use ``aborted`` if the client should retry at a higher-level
   ///   (for example, restarting a read-modify-write sequence).
   /// - Use ``failedPrecondition`` if the client should not retry until
-  ///   the system state has been explicitly fixed. For example, if an "rmdir"
-  ///   fails because the directory is non-empty, ``failedPrecondition``
-  ///   should be returned since the client should not retry unless
+  ///   it has explicitly fixed the system state. For example, if an "rmdir"
+  ///   fails because the directory is non-empty, the server should return
+  ///   ``failedPrecondition`` since the client should not retry unless
   ///   they have first fixed up the directory by deleting files from it.
   /// - Use ``failedPrecondition`` if the client performs conditional
   ///   REST Get/Update/Delete on a resource and the resource on the
@@ -269,22 +269,22 @@ extension Status.Code {
   ///   read-modify-write on the same resource.
   public static let failedPrecondition = Self(code: .failedPrecondition)
 
-  /// The operation was aborted, typically due to a concurrency issue like
-  /// sequencer check failures, transaction aborts, etc.
+  /// A concurrency issue, such as sequencer check failures or transaction aborts, typically
+  /// aborts the operation.
   ///
   /// See litmus test above for deciding between ``failedPrecondition``, ``aborted``,
   /// and ``unavailable``.
   public static let aborted = Self(code: .aborted)
 
-  /// Operation was attempted past the valid range.
+  /// The client attempted an operation past the valid range.
   ///
   /// For example, seeking or reading
   /// past end of file.
   ///
   /// Unlike ``invalidArgument``, this error indicates a problem that may be fixed
   /// if the system state changes. For example, a 32-bit file system will
-  /// generate ``invalidArgument`` if asked to read at an offset that is not in the
-  /// range [0,2^32-1], but it will generate ``outOfRange`` if asked to read from
+  /// generate ``invalidArgument`` if the caller asks it to read at an offset that is not in the
+  /// range [0,2^32-1], but it will generate ``outOfRange`` if the caller asks it to read from
   /// an offset past the current file size.
   ///
   /// There is a fair bit of overlap between ``failedPrecondition`` and
@@ -293,19 +293,19 @@ extension Status.Code {
   /// easily look for an ``outOfRange`` error to detect when they are done.
   public static let outOfRange = Self(code: .outOfRange)
 
-  /// Operation is not implemented or not supported/enabled in this service.
+  /// The service doesn't implement, support, or enable this operation.
   public static let unimplemented = Self(code: .unimplemented)
 
   /// Internal errors.
   ///
-  /// This means some invariants expected by the underlying system have
-  /// been broken. If you see one of these errors, something is very broken.
+  /// This means something has broken invariants that the underlying system expects. If you see
+  /// one of these errors, something is very broken.
   public static let internalError = Self(code: .internalError)
 
   /// The service is currently unavailable.
   ///
   /// This is most likely a transient
-  /// condition and may be corrected by retrying with a backoff.
+  /// condition, and retrying with a backoff may correct it.
   ///
   /// See litmus test above for deciding between ``failedPrecondition``, ``aborted``,
   /// and ``unavailable``.

--- a/Sources/GRPCCore/Streaming/Internal/BroadcastAsyncSequence.swift
+++ b/Sources/GRPCCore/Streaming/Internal/BroadcastAsyncSequence.swift
@@ -19,15 +19,16 @@ public import Synchronization  // should be @usableFromInline
 
 /// An `AsyncSequence` which can broadcast its values to multiple consumers concurrently.
 ///
-/// The sequence is not a general-purpose broadcast sequence; it is tailored specifically for the
-/// requirements of gRPC Swift, in particular it is used to support retrying and hedging requests.
+/// The sequence is not a general-purpose broadcast sequence; gRPC Swift tailors it specifically
+/// to its own requirements, using it in particular to support retrying and hedging requests.
 ///
 /// In order to achieve this it maintains on an internal buffer of elements which is limited in
 /// size. Each iterator ("subscriber") maintains an offset into the elements which the sequence has
 /// produced over time. If a subscriber is consuming too slowly (and the buffer is full) then the
 /// sequence will cancel the subscriber's subscription to the stream, dropping the oldest element
 /// in the buffer to make space for more elements. If the buffer is full and all subscribers are
-/// equally slow then all producers are suspended until the buffer drops to a reasonable size.
+/// equally slow then the sequence suspends all producers until the buffer drops to a reasonable
+/// size.
 ///
 /// The expectation is that the number of subscribers will be low; for retries there will be at most
 /// one subscriber at a time, for hedging there may be at most five subscribers at a time.
@@ -65,8 +66,8 @@ struct BroadcastAsyncSequence<Element: Sendable>: Sendable, AsyncSequence {
     return AsyncIterator(_storage: _storage, id: id)
   }
 
-  /// Returns true if it is known to be safe for the next subscriber to subscribe and successfully
-  /// consume elements.
+  /// Returns true if the sequence knows it's safe for the next subscriber to subscribe and
+  /// successfully consume elements.
   ///
   /// This function can return `false` if there are active subscribers or the internal buffer no
   /// longer contains the first element in the sequence.
@@ -234,7 +235,7 @@ final class _BroadcastSequenceStorage<Element: Sendable>: Sendable {
     }
   }
 
-  /// Indicate that no more values will be produced.
+  /// Indicate that the sequence will produce no more values.
   ///
   /// - Parameter result: Whether the stream is finishing cleanly or because of an error.
   @inlinable
@@ -262,7 +263,7 @@ final class _BroadcastSequenceStorage<Element: Sendable>: Sendable {
   /// Returns the next element for the given subscriber, if it is available.
   ///
   /// - Parameter id: The ID of the subscriber requesting the element.
-  /// - Returns: The next element or `nil` if the stream has been terminated.
+  /// - Returns: The next element or `nil` if the stream has finished.
   @inlinable
   func nextElement(
     forSubscriber id: _BroadcastSequenceStateMachine<Element>.Subscriptions.ID
@@ -306,8 +307,8 @@ final class _BroadcastSequenceStorage<Element: Sendable>: Sendable {
     }
   }
 
-  /// Returns true if it's guaranteed that the next subscriber may join and safely begin consuming
-  /// elements.
+  /// Returns true if the storage guarantees that the next subscriber may join and safely begin
+  /// consuming elements.
   @inlinable
   var isKnownSafeForNextSubscriber: Bool {
     self._state.withLock { state in
@@ -390,13 +391,13 @@ struct _BroadcastSequenceStateMachine<Element: Sendable>: Sendable {
 
   @usableFromInline
   enum State: Sendable {
-    /// No subscribers and no elements have been produced.
+    /// No subscribers exist, and the producer hasn't produced any elements yet.
     case initial(Initial)
-    /// Subscribers exist but no elements have been produced.
+    /// Subscribers exist, but the producer hasn't produced any elements yet.
     case subscribed(Subscribed)
-    /// Elements have been produced, there may or may not be subscribers.
+    /// The producer has produced elements; subscribers may or may not exist.
     case streaming(Streaming)
-    /// No more elements will be produced. There may or may not been subscribers.
+    /// The producer won't produce any more elements. Subscribers may or may not exist.
     case finished(Finished)
     /// Temporary state to avoid CoWs.
     case _modifying
@@ -530,10 +531,10 @@ struct _BroadcastSequenceStateMachine<Element: Sendable>: Sendable {
       let bufferSize: Int
 
       // TODO: (optimisation) one-or-many Deque to avoid allocations in the case of a single writer
-      /// Producers which have been suspended.
+      /// Suspended producers.
       @usableFromInline
       var producers: [(ProducerContinuation, Int)]
-      /// The IDs of producers which have been cancelled.
+      /// The IDs of cancelled producers.
       @usableFromInline
       var cancelledProducers: [Int]
       /// The next token for a producer.
@@ -1389,8 +1390,9 @@ struct _BroadcastSequenceStateMachine<Element: Sendable>: Sendable {
 extension _BroadcastSequenceStateMachine {
   /// A collection of elements tagged with an identifier.
   ///
-  /// Identifiers are assigned when elements are added to the collection and are monotonically
-  /// increasing. If element 'A' is added before element 'B' then 'A' will have a lower ID than 'B'.
+  /// The collection assigns each element an identifier as callers add it, and identifiers increase
+  /// monotonically. If a caller adds element 'A' before element 'B' then 'A' has a lower ID than
+  /// 'B'.
   @usableFromInline
   struct Elements: Sendable {
     /// The ID of an element
@@ -1502,7 +1504,7 @@ extension _BroadcastSequenceStateMachine {
 
     @usableFromInline
     enum ElementLookup: Sendable {
-      /// The element was found in the collection.
+      /// The lookup found the element in the collection.
       case found(Element)
       /// The element isn't in the collection, but it could be in the future.
       case maybeAvailableLater
@@ -1578,7 +1580,7 @@ extension _BroadcastSequenceStateMachine {
       @usableFromInline
       var nextElementID: _BroadcastSequenceStateMachine<Element>.Elements.ID
 
-      /// A continuation which which will be resumed when the next element becomes available.
+      /// A continuation that the state machine resumes when the next element becomes available.
       @usableFromInline
       var continuation: ConsumerContinuation?
 
@@ -1595,7 +1597,7 @@ extension _BroadcastSequenceStateMachine {
 
       /// Returns and sets the continuation to `nil` if one exists.
       ///
-      /// The next element ID is advanced if a contination exists.
+      /// This function advances the next element ID if a continuation exists.
       ///
       /// - Returns: The continuation, if one existed.
       @inlinable
@@ -1642,9 +1644,8 @@ extension _BroadcastSequenceStateMachine {
     /// - Parameters:
     ///   - id: The ID of the subscriber.
     ///   - body: A closure to mutate the element ID of the subscriber which returns the result and
-    ///      a boolean indicating whether the subscriber should be removed.
-    /// - Returns: The result returned from the closure or `nil` if no subscriber exists with the
-    ///     given ID.
+    ///      a boolean indicating whether the caller should remove the subscriber.
+    /// - Returns: The closure's result, or `nil` if no subscriber exists with the given ID.
     @inlinable
     mutating func withMutableElementID<R>(
       forSubscriber id: ID,
@@ -1664,7 +1665,7 @@ extension _BroadcastSequenceStateMachine {
     /// - Parameters:
     ///   - continuation: The continuation to set.
     ///   - id: The ID of the subscriber.
-    /// - Returns: A boolean indicating whether the continuation was set or not.
+    /// - Returns: A boolean indicating whether this function set the continuation.
     @inlinable
     mutating func setContinuation(
       _ continuation: ConsumerContinuation,
@@ -1693,8 +1694,8 @@ extension _BroadcastSequenceStateMachine {
 
     /// Removes the subscriber with the given ID.
     /// - Parameter id: The ID of the subscriber to remove.
-    /// - Returns: A tuple indicating whether a subscriber was removed and any continuation
-    ///     associated with the subscriber.
+    /// - Returns: A tuple indicating whether this function removed a subscriber, and any
+    ///     continuation associated with it.
     @inlinable
     mutating func removeSubscriber(withID id: ID) -> (Bool, ConsumerContinuation?) {
       guard let index = self._subscribers.firstIndex(where: { $0.id == id }) else {

--- a/Sources/GRPCCore/Streaming/Internal/BroadcastAsyncSequence.swift
+++ b/Sources/GRPCCore/Streaming/Internal/BroadcastAsyncSequence.swift
@@ -391,13 +391,13 @@ struct _BroadcastSequenceStateMachine<Element: Sendable>: Sendable {
 
   @usableFromInline
   enum State: Sendable {
-    /// No subscribers exist, and the producer hasn't produced any elements yet.
+    /// No subscribers exist, and no producers have produced any elements yet.
     case initial(Initial)
-    /// Subscribers exist, but the producer hasn't produced any elements yet.
+    /// Subscribers exist, but no producers have produced any elements yet.
     case subscribed(Subscribed)
-    /// The producer has produced elements; subscribers may or may not exist.
+    /// Producers have produced elements; subscribers may or may not exist.
     case streaming(Streaming)
-    /// The producer won't produce any more elements. Subscribers may or may not exist.
+    /// No producers will produce any more elements. Subscribers may or may not exist.
     case finished(Finished)
     /// Temporary state to avoid CoWs.
     case _modifying
@@ -1580,7 +1580,7 @@ extension _BroadcastSequenceStateMachine {
       @usableFromInline
       var nextElementID: _BroadcastSequenceStateMachine<Element>.Elements.ID
 
-      /// A continuation that the state machine resumes when the next element becomes available.
+      /// A continuation that's resumed when the next element becomes available.
       @usableFromInline
       var continuation: ConsumerContinuation?
 

--- a/Sources/GRPCCore/Streaming/Internal/UncheckedAsyncIteratorSequence.swift
+++ b/Sources/GRPCCore/Streaming/Internal/UncheckedAsyncIteratorSequence.swift
@@ -39,7 +39,7 @@ final class UncheckedAsyncIteratorSequence<
   @usableFromInline
   private(set) var base: Base
 
-  /// Set to `true` when an iterator has been made.
+  /// Set to `true` after a caller makes an iterator.
   @usableFromInline
   let _hasMadeIterator = Atomic(false)
 

--- a/Sources/GRPCCore/Streaming/RPCAsyncSequence.swift
+++ b/Sources/GRPCCore/Streaming/RPCAsyncSequence.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-/// A type-erasing `AsyncSequence`.
+/// A type-erasing wrapper around an asynchronous sequence.
 @available(gRPCSwift 2.0, *)
 public struct RPCAsyncSequence<
   Element: Sendable,
@@ -29,7 +29,7 @@ public struct RPCAsyncSequence<
   @usableFromInline
   let _wrapped: any AsyncSequence<Element, Failure>
 
-  /// Creates an ``RPCAsyncSequence`` by wrapping another `AsyncSequence`.
+  /// Creates a new sequence by wrapping another asynchronous sequence.
   @inlinable
   public init<Source: AsyncSequence<Element, Failure>>(
     wrapping other: Source
@@ -42,7 +42,7 @@ public struct RPCAsyncSequence<
     AsyncIterator(wrapping: self._wrapped.makeAsyncIterator())
   }
 
-  /// The iterator used by ``RPCAsyncSequence``.
+  /// An iterator over the elements of an asynchronous sequence.
   public struct AsyncIterator: AsyncIteratorProtocol {
     @usableFromInline
     private(set) var iterator: any AsyncIteratorProtocol<Element, Failure>

--- a/Sources/GRPCCore/Streaming/RPCAsyncSequence.swift
+++ b/Sources/GRPCCore/Streaming/RPCAsyncSequence.swift
@@ -42,6 +42,7 @@ public struct RPCAsyncSequence<
     AsyncIterator(wrapping: self._wrapped.makeAsyncIterator())
   }
 
+  /// The iterator used by ``RPCAsyncSequence``.
   public struct AsyncIterator: AsyncIteratorProtocol {
     @usableFromInline
     private(set) var iterator: any AsyncIteratorProtocol<Element, Failure>

--- a/Sources/GRPCCore/Streaming/RPCWriter+Closable.swift
+++ b/Sources/GRPCCore/Streaming/RPCWriter+Closable.swift
@@ -16,7 +16,7 @@
 
 @available(gRPCSwift 2.0, *)
 extension RPCWriter {
-  /// A concrete ``RPCWriter`` that wraps another ``ClosableRPCWriterProtocol``.
+  /// A concrete, closable writer that wraps another ``ClosableRPCWriterProtocol``.
   public struct Closable: ClosableRPCWriterProtocol {
     @usableFromInline
     let writer: any ClosableRPCWriterProtocol<Element>

--- a/Sources/GRPCCore/Streaming/RPCWriter+Closable.swift
+++ b/Sources/GRPCCore/Streaming/RPCWriter+Closable.swift
@@ -33,8 +33,8 @@ extension RPCWriter {
 
     /// Writes a single element.
     ///
-    /// This function suspends until the element has been accepted. Implementers can use this
-    /// to exert backpressure on callers.
+    /// This function suspends until the wrapped writer accepts the element. Implementers can use
+    /// this to exert backpressure on callers.
     ///
     /// - Parameter element: The element to write.
     @inlinable
@@ -44,8 +44,8 @@ extension RPCWriter {
 
     /// Writes a sequence of elements.
     ///
-    /// This function suspends until the elements have been accepted. Implementers can use this
-    /// to exert backpressure on callers.
+    /// This function suspends until the wrapped writer accepts the elements. Implementers can use
+    /// this to exert backpressure on callers.
     ///
     /// - Parameter elements: The elements to write.
     @inlinable
@@ -53,19 +53,17 @@ extension RPCWriter {
       try await self.writer.write(contentsOf: elements)
     }
 
-    /// Indicates to the writer that no more writes are to be accepted.
+    /// Tells the writer to reject any further writes.
     ///
-    /// All writes after ``finish()`` has been called should result in an error
-    /// being thrown.
+    /// After a caller calls ``finish()``, any further write should throw an error.
     @inlinable
     public func finish() async {
       await self.writer.finish()
     }
 
-    /// Indicates to the writer that no more writes are to be accepted because an error occurred.
+    /// Tells the writer to reject any further writes because an error occurred.
     ///
-    /// All writes after ``finish(throwing:)`` has been called should result in an error
-    /// being thrown.
+    /// After a caller calls ``finish(throwing:)``, any further write should throw an error.
     @inlinable
     public func finish(throwing error: any Error) async {
       await self.writer.finish(throwing: error)

--- a/Sources/GRPCCore/Streaming/RPCWriter+Closable.swift
+++ b/Sources/GRPCCore/Streaming/RPCWriter+Closable.swift
@@ -16,12 +16,14 @@
 
 @available(gRPCSwift 2.0, *)
 extension RPCWriter {
-  /// A concrete, closable writer that wraps another ``ClosableRPCWriterProtocol``.
+  /// A concrete, closable writer.
+  ///
+  /// Wraps another ``ClosableRPCWriterProtocol``.
   public struct Closable: ClosableRPCWriterProtocol {
     @usableFromInline
     let writer: any ClosableRPCWriterProtocol<Element>
 
-    /// Creates an ``RPCWriter/Closable`` by wrapping the `other` writer.
+    /// Creates a new writer that wraps another writer.
     ///
     /// - Parameter other: The writer to wrap.
     @inlinable

--- a/Sources/GRPCCore/Streaming/RPCWriter+Closable.swift
+++ b/Sources/GRPCCore/Streaming/RPCWriter+Closable.swift
@@ -16,6 +16,7 @@
 
 @available(gRPCSwift 2.0, *)
 extension RPCWriter {
+  /// A concrete ``RPCWriter`` that wraps another ``ClosableRPCWriterProtocol``.
   public struct Closable: ClosableRPCWriterProtocol {
     @usableFromInline
     let writer: any ClosableRPCWriterProtocol<Element>

--- a/Sources/GRPCCore/Streaming/RPCWriter.swift
+++ b/Sources/GRPCCore/Streaming/RPCWriter.swift
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-/// A type-erasing ``RPCWriterProtocol``.
+/// A type-erasing writer.
+///
+/// Wraps any ``RPCWriterProtocol``.
 @available(gRPCSwift 2.0, *)
 public struct RPCWriter<Element: Sendable>: Sendable, RPCWriterProtocol {
   private let writer: any RPCWriterProtocol<Element>
 
-  /// Creates an ``RPCWriter`` by wrapping the `other` writer.
+  /// Creates a new writer that wraps another writer.
   ///
   /// - Parameter other: The writer to wrap.
   public init(wrapping other: some RPCWriterProtocol<Element>) {

--- a/Sources/GRPCCore/Streaming/RPCWriter.swift
+++ b/Sources/GRPCCore/Streaming/RPCWriter.swift
@@ -30,8 +30,8 @@ public struct RPCWriter<Element: Sendable>: Sendable, RPCWriterProtocol {
 
   /// Writes a single element.
   ///
-  /// This function suspends until the element has been accepted. Implementers can use this
-  /// to exert backpressure on callers.
+  /// This function suspends until the wrapped writer accepts the element. Implementers can use
+  /// this to exert backpressure on callers.
   ///
   /// - Parameter element: The element to write.
   public func write(_ element: Element) async throws {
@@ -40,8 +40,8 @@ public struct RPCWriter<Element: Sendable>: Sendable, RPCWriterProtocol {
 
   /// Writes a sequence of elements.
   ///
-  /// This function suspends until the elements have been accepted. Implementers can use this
-  /// to exert backpressure on callers.
+  /// This function suspends until the wrapped writer accepts the elements. Implementers can use
+  /// this to exert backpressure on callers.
   ///
   /// - Parameter elements: The elements to write.
   public func write(contentsOf elements: some Sequence<Element>) async throws {

--- a/Sources/GRPCCore/Streaming/RPCWriterProtocol.swift
+++ b/Sources/GRPCCore/Streaming/RPCWriterProtocol.swift
@@ -39,7 +39,7 @@ public protocol RPCWriterProtocol<Element>: Sendable {
 
 @available(gRPCSwift 2.0, *)
 extension RPCWriterProtocol {
-  /// Writes an `AsyncSequence` of values into the sink.
+  /// Writes an asynchronous sequence of values into the sink.
   ///
   /// - Parameter elements: The elements to write.
   public func write<Elements: AsyncSequence>(

--- a/Sources/GRPCCore/Streaming/RPCWriterProtocol.swift
+++ b/Sources/GRPCCore/Streaming/RPCWriterProtocol.swift
@@ -22,16 +22,16 @@ public protocol RPCWriterProtocol<Element>: Sendable {
 
   /// Writes a single element.
   ///
-  /// This function suspends until the element has been accepted. Implementers can use this
-  /// to exert backpressure on callers.
+  /// This function suspends until the implementation accepts the element. Implementers can use
+  /// this to exert backpressure on callers.
   ///
   /// - Parameter element: The element to write.
   func write(_ element: Element) async throws
 
   /// Writes a sequence of elements.
   ///
-  /// This function suspends until the elements have been accepted. Implementers can use this
-  /// to exert backpressure on callers.
+  /// This function suspends until the implementation accepts the elements. Implementers can use
+  /// this to exert backpressure on callers.
   ///
   /// - Parameter elements: The elements to write.
   func write(contentsOf elements: some Sequence<Element>) async throws
@@ -54,15 +54,13 @@ extension RPCWriterProtocol {
 /// A type into which values can be written until it is finished.
 @available(gRPCSwift 2.0, *)
 public protocol ClosableRPCWriterProtocol<Element>: RPCWriterProtocol {
-  /// Indicates to the writer that no more writes are to be accepted.
+  /// Tells the writer to reject any further writes.
   ///
-  /// All writes after ``finish()`` has been called should result in an error
-  /// being thrown.
+  /// After a caller calls ``finish()``, any further write should throw an error.
   func finish() async
 
-  /// Indicates to the writer that no more writes are to be accepted because an error occurred.
+  /// Tells the writer to reject any further writes because an error occurred.
   ///
-  /// All writes after ``finish(throwing:)`` has been called should result in an error
-  /// being thrown.
+  /// After a caller calls ``finish(throwing:)``, any further write should throw an error.
   func finish(throwing error: any Error) async
 }

--- a/Sources/GRPCCore/Timeout.swift
+++ b/Sources/GRPCCore/Timeout.swift
@@ -16,7 +16,7 @@
 
 /// A timeout for a gRPC call.
 ///
-/// It's a combination of an amount (expressed as an integer of at maximum 8 digits), and a unit, which is
+/// It's a combination of an amount (an integer with at most 8 digits), and a unit, which is
 /// one of ``Timeout/Unit`` (hours, minutes, seconds, milliseconds, microseconds or nanoseconds).
 ///
 /// Timeouts must be positive and at most 8-digits long.
@@ -33,7 +33,7 @@ struct Timeout: CustomStringConvertible, Hashable, Sendable {
     case nanoseconds = "n"
   }
 
-  /// The largest amount of any unit of time which may be represented by a gRPC timeout.
+  /// The largest amount of any unit of time that a gRPC timeout may represent.
   static let maxAmount: Int64 = 99_999_999
 
   private let amount: Int64
@@ -44,7 +44,7 @@ struct Timeout: CustomStringConvertible, Hashable, Sendable {
     Duration(amount: amount, unit: unit)
   }
 
-  /// The wire encoding of this timeout as described in the gRPC protocol.
+  /// The wire encoding of this timeout, as the gRPC protocol describes.
   /// See "Timeout" in https://github.com/grpc/grpc/blob/6c0578099835c854b0ff36a4b8db98ed49278ed5/doc/PROTOCOL-HTTP2.md#requests
   var wireEncoding: String {
     "\(amount)\(unit.rawValue)"
@@ -72,10 +72,10 @@ struct Timeout: CustomStringConvertible, Hashable, Sendable {
 
   /// Create a ``Timeout`` from a ``Duration``.
   ///
-  /// - Important: It's not possible to know with what precision the duration was created: that is,
-  /// it's not possible to know whether `Duration.seconds(value)` or `Duration.milliseconds(value)`
-  /// was used. For this reason, the unit chosen for the ``Timeout`` (and thus the wire encoding) may be
-  /// different from the one originally used to create the `Duration`. Despite this, we guarantee that
+  /// - Important: It's not possible to know with what precision you created the duration: that is,
+  /// it's not possible to know whether you used `Duration.seconds(value)` or `Duration.milliseconds(value)`.
+  /// For this reason, the unit that ``Timeout`` chooses (and thus the wire encoding) may be
+  /// different from the one you originally used to create the `Duration`. Despite this, we guarantee that
   /// both durations will be equivalent if there was no loss in precision during the transformation.
   /// For example, `Duration.hours(123)` will yield a ``Timeout`` with `wireEncoding` equal to
   /// `"442800S"`, which is in seconds. However, 442800 seconds and 123 hours are equivalent.
@@ -117,8 +117,7 @@ struct Timeout: CustomStringConvertible, Hashable, Sendable {
     }
   }
 
-  /// Create a timeout by rounding up the timeout so that it may be represented in the gRPC
-  /// wire format.
+  /// Create a timeout by rounding up the timeout so that the gRPC wire format can represent it.
   private init(rounding amount: Int64, unit: Unit) {
     var roundedAmount = amount
     var roundedUnit = unit
@@ -170,7 +169,7 @@ struct Timeout: CustomStringConvertible, Hashable, Sendable {
 }
 
 extension Int64 {
-  /// Returns the quotient of this value when divided by `divisor` rounded up to the nearest
+  /// Returns the quotient when you divide this value by `divisor`, rounded up to the nearest
   /// multiple of `divisor` if the remainder is non-zero.
   ///
   /// - Parameter divisor: The value to divide this value by.
@@ -182,7 +181,7 @@ extension Int64 {
 
 @available(gRPCSwift 2.0, *)
 extension Duration {
-  /// Construct a `Duration` given a number of minutes represented as an `Int64`.
+  /// Construct a `Duration` given a number of minutes as an `Int64`.
   ///
   ///       let d: Duration = .minutes(5)
   ///
@@ -191,7 +190,7 @@ extension Duration {
     return Self.init(secondsComponent: 60 * minutes, attosecondsComponent: 0)
   }
 
-  /// Construct a `Duration` given a number of hours represented as an `Int64`.
+  /// Construct a `Duration` given a number of hours as an `Int64`.
   ///
   ///       let d: Duration = .hours(3)
   ///

--- a/Sources/GRPCCore/Transport/ClientTransport.swift
+++ b/Sources/GRPCCore/Transport/ClientTransport.swift
@@ -16,11 +16,11 @@
 
 /// A type that provides a long-lived bidirectional communication channel to a server.
 ///
-/// The client transport is responsible for providing streams to a backend on top of which an
-/// RPC can be executed. A typical transport implementation will establish and maintain connections
-/// to a server (or servers) and manage these over time, potentially closing idle connections and
-/// creating new ones on demand. As such transports can be expensive to create and as such are
-/// intended to be used as long-lived objects that exist for the lifetime of your application.
+/// The client transport is responsible for providing streams to a backend that the client can
+/// use to execute an RPC. A typical transport implementation will establish and maintain
+/// connections to a server (or servers) and manage these over time, potentially closing idle
+/// connections and creating new ones on demand. As such transports can be expensive to create,
+/// use them as long-lived objects that exist for the lifetime of your application.
 ///
 /// gRPC provides an in-process transport in the `GRPCInProcessTransport` module and an HTTP/2
 /// transport built on top of SwiftNIO in the https://github.com/grpc/grpc-swift-nio-transport
@@ -33,30 +33,30 @@ public protocol ClientTransport<Bytes>: Sendable {
   typealias Inbound = RPCAsyncSequence<RPCResponsePart<Bytes>, any Error>
   typealias Outbound = RPCWriter<RPCRequestPart<Bytes>>.Closable
 
-  /// Returns a throttle which gRPC uses to determine whether retries can be executed.
+  /// Returns a throttle which gRPC uses to determine whether it can execute retries.
   ///
   /// Client transports don't need to implement the throttle or interact with it beyond its
-  /// creation. gRPC will record the results of requests to determine whether retries can be
-  /// performed.
+  /// creation. gRPC will record the results of requests to determine whether it can perform
+  /// retries.
   var retryThrottle: RetryThrottle? { get }
 
   /// Establishes and maintains a connection to the remote destination.
   ///
-  /// Maintains a long-lived connection, or set of connections, to a remote destination.
-  /// Connections may be added or removed over time as required by the implementation and the
-  /// demand for streams by the client.
+  /// Maintains a long-lived connection, or set of connections, to a remote destination. The
+  /// implementation may add or remove connections over time, based on the demand for streams
+  /// from the client.
   ///
   /// Implementations of this function will typically create a long-lived task group that
-  /// maintains connections. The function exits either when all open streams have been closed and
-  /// new connections are no longer required by the caller — signaled by calling
-  /// ``beginGracefulShutdown()`` — or when the task this function runs in is cancelled.
+  /// maintains connections. The function exits either when all open streams have closed and
+  /// the caller no longer requires new connections — signaled by calling
+  /// ``beginGracefulShutdown()`` — or when the caller cancels the task this function runs in.
   func connect() async throws
 
-  /// Signals to the transport that no new streams may be created.
+  /// Signals to the transport to stop creating new streams.
   ///
   /// Existing streams may run to completion naturally, but calling
-  /// ``ClientTransport/withStream(descriptor:options:_:)`` should result in an ``RPCError`` with
-  /// code ``RPCError/Code/failedPrecondition`` being thrown.
+  /// ``ClientTransport/withStream(descriptor:options:_:)`` should throw an ``RPCError`` with
+  /// code ``RPCError/Code/failedPrecondition``.
   ///
   /// If you want to forcefully cancel all active streams, then cancel the task
   /// running ``connect()``.
@@ -64,10 +64,10 @@ public protocol ClientTransport<Bytes>: Sendable {
 
   /// Opens a stream using the transport, and uses it as input to a user-provided closure alongside the given context.
   ///
-  /// - Important: The opened stream is closed after the closure is finished.
+  /// - Important: This function closes the opened stream after the closure finishes.
   ///
   /// Transport implementations should throw an ``RPCError`` with the following error codes:
-  /// - ``RPCError/Code/failedPrecondition`` if the transport is closing or has been closed.
+  /// - ``RPCError/Code/failedPrecondition`` if the transport is closing or is already closed.
   /// - ``RPCError/Code/unavailable`` if it's temporarily not possible to create a stream and it
   ///   may be possible after some backoff period.
   ///
@@ -75,7 +75,7 @@ public protocol ClientTransport<Bytes>: Sendable {
   ///   - descriptor: A description of the method to open a stream for.
   ///   - options: Options specific to the stream.
   ///   - closure: A closure that takes the opened stream and the client context as its parameters.
-  /// - Returns: Whatever value was returned from `closure`.
+  /// - Returns: The value that `closure` returns.
   func withStream<T: Sendable>(
     descriptor: MethodDescriptor,
     options: CallOptions,

--- a/Sources/GRPCCore/Transport/RPCParts.swift
+++ b/Sources/GRPCCore/Transport/RPCParts.swift
@@ -19,13 +19,13 @@
 public enum RPCRequestPart<Bytes: GRPCContiguousBytes> {
   /// Key-value pairs sent at the start of a request stream.
   ///
-  /// Only one ``metadata(_:)`` value may be sent to the server.
+  /// The client may send only one ``metadata(_:)`` value to the server.
   case metadata(Metadata)
 
   /// The bytes of a serialized message to send to the server.
   ///
-  /// A stream may have any number of messages sent on it. Restrictions for unary request or
-  /// response streams are imposed at a higher level.
+  /// A stream may have any number of messages sent on it. A higher level imposes restrictions
+  /// for unary request or response streams.
   case message(Bytes)
 }
 
@@ -41,14 +41,14 @@ extension RPCRequestPart: Equatable where Bytes: Equatable {}
 public enum RPCResponsePart<Bytes: GRPCContiguousBytes> {
   /// Key-value pairs sent at the start of the response stream.
   ///
-  /// At most one ``metadata(_:)`` value may be sent to the client. If the server sends
+  /// The server may send at most one ``metadata(_:)`` value to the client. If the server sends
   /// ``metadata(_:)``, it must be the first part in the response stream.
   case metadata(Metadata)
 
   /// The bytes of a serialized message to send to the client.
   ///
-  /// A stream may have any number of messages sent on it. Restrictions for unary request or
-  /// response streams are imposed at a higher level.
+  /// A stream may have any number of messages sent on it. A higher level imposes restrictions
+  /// for unary request or response streams.
   case message(Bytes)
 
   /// A status and key-value pairs sent to the client at the end of the response stream.

--- a/Sources/GRPCCore/Transport/RetryThrottle.swift
+++ b/Sources/GRPCCore/Transport/RetryThrottle.swift
@@ -18,7 +18,7 @@ private import Synchronization
 
 /// A throttle used to rate-limit retries and hedging attempts.
 ///
-/// gRPC prevents servers from being overloaded by retries and hedging by using a token-based
+/// gRPC prevents retries and hedging from overloading servers by using a token-based
 /// throttling mechanism at the transport level.
 ///
 /// Each client transport maintains a throttle for the server it is connected to, and gRPC records
@@ -43,18 +43,18 @@ public final class RetryThrottle: Sendable {
   /// The maximum number of tokens, multiplied by 1000.
   private let scaledMaxTokens: Int
   /// The retry threshold, multiplied by 1000. If ``scaledTokensAvailable`` is above this then
-  /// retries are permitted.
+  /// the throttle permits retries.
   private let scaledRetryThreshold: Int
 
   /// Returns the throttling token ratio.
   ///
-  /// The number of tokens held by the throttle is incremented by this value for each successful
+  /// The throttle increments the number of tokens it holds by this value for each successful
   /// response. In the context of throttling, a successful response is one that:
   /// - receives metadata from the server, or
-  /// - is terminated with a non-retryable or fatal status code.
+  /// - ends with a non-retryable or fatal status code.
   ///
-  /// If the response is a pushback response, then it is not considered to be successful, even if
-  /// either of the preceding conditions are met.
+  /// If the response is a pushback response, then it does not count as successful, even if it
+  /// meets either of the preceding conditions.
   public var tokenRatio: Double {
     Double(self.scaledTokenRatio) / 1000
   }
@@ -67,14 +67,14 @@ public final class RetryThrottle: Sendable {
   /// The number of tokens the throttle currently has.
   ///
   /// If this value is less than or equal to the retry threshold (defined as `maxTokens / 2`),
-  /// then RPCs will not be retried and hedging will be disabled.
+  /// then the throttle will not retry RPCs and will disable hedging.
   public var tokens: Double {
     self.scaledTokensAvailable.withLock {
       Double($0) / 1000
     }
   }
 
-  /// Returns whether retries and hedging are permitted at this time.
+  /// Returns whether the throttle permits retries and hedging at this time.
   public var isRetryPermitted: Bool {
     self.scaledTokensAvailable.withLock {
       $0 > self.scaledRetryThreshold
@@ -87,7 +87,8 @@ public final class RetryThrottle: Sendable {
   ///   - maxTokens: The maximum number of tokens available. Must be in the range `1...1000`.
   ///   - tokenRatio: The number of tokens to increment the available tokens by for successful
   ///       responses. See the documentation on this type for a description of what counts as a
-  ///       successful response. Note that only three decimal places are used from this value.
+  ///       successful response. Note that the throttle uses only three decimal places from this
+  ///       value.
   /// - Precondition: `maxTokens` must be in the range `1...1000`.
   /// - Precondition: `tokenRatio` must be `>= 0.001`.
   public init(maxTokens: Int, tokenRatio: Double) {
@@ -122,7 +123,7 @@ public final class RetryThrottle: Sendable {
   }
 
   /// Records a failure, removing tokens from the throttle.
-  /// - Returns: Whether retries will now be throttled.
+  /// - Returns: Whether the throttle will now limit retries.
   @usableFromInline
   @discardableResult
   func recordFailure() -> Bool {

--- a/Sources/GRPCCore/Transport/RetryThrottle.swift
+++ b/Sources/GRPCCore/Transport/RetryThrottle.swift
@@ -81,7 +81,7 @@ public final class RetryThrottle: Sendable {
     }
   }
 
-  /// Creates a new throttle.
+  /// Creates a new throttle with explicit token limits.
   ///
   /// - Parameters:
   ///   - maxTokens: The maximum number of tokens available. Must be in the range `1...1000`.
@@ -106,7 +106,7 @@ public final class RetryThrottle: Sendable {
     self.scaledTokensAvailable = Mutex(scaledTokens)
   }
 
-  /// Creates a new throttle.
+  /// Creates a new throttle configured from a retry-throttling policy.
   ///
   /// - Parameter policy: The policy to use to configure the throttle.
   public convenience init(policy: ServiceConfig.RetryThrottling) {

--- a/Sources/GRPCCore/Transport/RetryThrottle.swift
+++ b/Sources/GRPCCore/Transport/RetryThrottle.swift
@@ -67,7 +67,7 @@ public final class RetryThrottle: Sendable {
   /// The number of tokens the throttle currently has.
   ///
   /// If this value is less than or equal to the retry threshold (defined as `maxTokens / 2`),
-  /// then the throttle will not retry RPCs and will disable hedging.
+  /// then the throttle no longer permits retries or hedging.
   public var tokens: Double {
     self.scaledTokensAvailable.withLock {
       Double($0) / 1000

--- a/Sources/GRPCCore/Transport/ServerTransport.swift
+++ b/Sources/GRPCCore/Transport/ServerTransport.swift
@@ -40,14 +40,14 @@ public protocol ServerTransport<Bytes>: Sendable {
 
   /// Starts the transport.
   ///
-  /// Implementations will typically bind to a listening port when this function is called
-  /// and start accepting new connections. Each accepted inbound RPC stream will be handed over to
-  /// the provided `streamHandler` to handle accordingly.
+  /// Implementations will typically bind to a listening port when you call this function
+  /// and start accepting new connections. Implementations hand each accepted inbound RPC stream
+  /// over to the provided `streamHandler` to handle accordingly.
   ///
-  /// You can call ``beginGracefulShutdown()`` to stop the transport from accepting new streams. Existing
-  /// streams must be allowed to complete naturally. However, transports may also enforce a grace
-  /// period after which any open streams may be cancelled. You can also cancel the task running
-  /// ``listen(streamHandler:)`` to abruptly close connections and streams.
+  /// Call ``beginGracefulShutdown()`` to stop the transport from accepting new streams.
+  /// Transports must allow existing streams to complete naturally. However, transports may also
+  /// enforce a grace period after which they may cancel any open streams. Alternatively, cancel
+  /// the task running ``listen(streamHandler:)`` to abruptly close connections and streams.
   func listen(
     streamHandler:
       @escaping @Sendable (
@@ -56,10 +56,10 @@ public protocol ServerTransport<Bytes>: Sendable {
       ) async -> Void
   ) async throws
 
-  /// Indicates to the transport that no new streams should be accepted.
+  /// Indicates to the transport that it should not accept new streams.
   ///
-  /// Existing streams are permitted to run to completion. However, the transport may also enforce
-  /// a grace period, after which remaining streams are cancelled.
+  /// The transport permits existing streams to run to completion. However, it may also enforce
+  /// a grace period, after which it cancels remaining streams.
   func beginGracefulShutdown()
 }
 

--- a/Sources/GRPCInProcessTransport/InProcessTransport+Client.swift
+++ b/Sources/GRPCInProcessTransport/InProcessTransport+Client.swift
@@ -28,16 +28,16 @@ extension InProcessTransport {
   /// as a `ServiceConfig`.
   ///
   /// Once you have a client, you must keep a long-running task executing ``connect()``, which
-  /// will return only once all streams have been finished and ``beginGracefulShutdown()`` has been called on this client, or
-  /// when the containing task is cancelled.
+  /// will return only once all streams have finished and you have called ``beginGracefulShutdown()``
+  /// on this client, or when the containing task is cancelled.
   ///
-  /// To execute requests using this client, use ``withStream(descriptor:options:_:)``. If this function is
-  /// called before ``connect()`` is called, then any streams will remain pending and the call will
-  /// block until ``connect()`` is called or the task is cancelled.
+  /// To execute requests using this client, use ``withStream(descriptor:options:_:)``. If you call
+  /// this function before calling ``connect()``, then any streams will remain pending and the call
+  /// will block until you call ``connect()`` or the task is cancelled.
   ///
   /// - SeeAlso: `ClientTransport`
   public final class Client: ClientTransport {
-    /// The type of bytes this client sends and receives, represented as an array of bytes.
+    /// The type of bytes this client sends and receives: an array of bytes.
     public typealias Bytes = [UInt8]
 
     private enum State: Sendable {
@@ -104,7 +104,7 @@ extension InProcessTransport {
 
     /// The retry throttle configuration.
     ///
-    /// This is derived from the `ServiceConfig` passed to the transport's initializer; it's
+    /// The transport derives this from the `ServiceConfig` you pass to its initializer; it's
     /// `nil` if the service config doesn't specify a retry-throttling policy.
     public let retryThrottle: RetryThrottle?
 
@@ -131,13 +131,13 @@ extension InProcessTransport {
 
     /// Establishes and maintains a connection to the remote destination.
     ///
-    /// Maintains a long-lived connection, or set of connections, to a remote destination.
-    /// Connections may be added or removed over time as required by the implementation and the
-    /// demand for streams by the client.
+    /// Maintains a long-lived connection, or set of connections, to a remote destination. The
+    /// implementation may add or remove connections over time to meet the client's demand for
+    /// streams.
     ///
     /// Implementations of this function will typically create a long-lived task group that
-    /// maintains connections. The function exits either when all open streams have been closed
-    /// and new connections are no longer required by the caller — signaled by calling
+    /// maintains connections. The function exits either when all open streams have closed and the
+    /// caller no longer requires new connections — which it signals by calling
     /// ``beginGracefulShutdown()`` — or when the task this function runs in is cancelled.
     public func connect() async throws {
       let (stream, continuation) = AsyncStream<Void>.makeStream()
@@ -195,10 +195,10 @@ extension InProcessTransport {
       }
     }
 
-    /// Signals to the transport that no new streams may be created.
+    /// Signals to the transport to stop creating new streams.
     ///
     /// Existing streams may run to completion naturally, but calling ``withStream(descriptor:options:_:)``
-    /// will result in an `RPCError` with code `RPCError/Code/failedPrecondition` being thrown.
+    /// throws an `RPCError` with code `RPCError/Code/failedPrecondition`.
     ///
     /// If you want to forcefully cancel all active streams, then cancel the task running ``connect()``.
     public func beginGracefulShutdown() {
@@ -224,20 +224,20 @@ extension InProcessTransport {
 
     /// Opens a stream using the transport, and uses it as input to a user-provided closure alongside the given context.
     ///
-    /// - Important: The opened stream is closed after the closure is finished.
+    /// - Important: The opened stream closes after the closure finishes.
     ///
     /// This transport implementation throws `RPCError/Code/failedPrecondition` if the transport
-    /// is closing or has been closed.
+    /// is closing or has already closed.
     ///
-    ///   This implementation will queue any streams (and thus block this call) if this function is called before
-    ///   ``connect()``, until a connection is established — at which point all streams will be
-    ///   created.
+    ///   This implementation will queue any streams (and thus block this call) if you call this
+    ///   function before calling ``connect()``, until ``connect()`` establishes a connection — at
+    ///   which point it will create all streams.
     ///
     /// - Parameters:
     ///   - descriptor: A description of the method to open a stream for.
     ///   - options: Options specific to the stream.
     ///   - closure: A closure that takes the opened stream and the client context as its parameters.
-    /// - Returns: Whatever value was returned from `closure`.
+    /// - Returns: Whatever value `closure` returns.
     public func withStream<T>(
       descriptor: MethodDescriptor,
       options: CallOptions,

--- a/Sources/GRPCInProcessTransport/InProcessTransport+Server.swift
+++ b/Sources/GRPCInProcessTransport/InProcessTransport+Server.swift
@@ -25,12 +25,12 @@ extension InProcessTransport {
   /// involved, as the client and server will communicate directly with each other via in-process streams.
   ///
   /// To use this server, you call ``listen(streamHandler:)`` and iterate over the returned `AsyncSequence` to get all
-  /// RPC requests made from clients (as `RPCStream`s).
+  /// RPC requests that clients make (as `RPCStream`s).
   /// To stop listening to new requests, call ``beginGracefulShutdown()``.
   ///
   /// - SeeAlso: `ServerTransport`
   public final class Server: ServerTransport, Sendable {
-    /// The type of bytes this server sends and receives, represented as an array of bytes.
+    /// The type of bytes this server sends and receives: an array of bytes.
     public typealias Bytes = [UInt8]
 
     /// The stream of inbound requests this server receives.
@@ -89,12 +89,12 @@ extension InProcessTransport {
       self.peer = peer
     }
 
-    /// Publish a new ``RPCStream``, which will be returned by the transport's ``events``
-    /// successful case.
+    /// Publish a new ``RPCStream``, which the transport's ``events`` successful case returns.
     ///
     /// - Parameter stream: The new ``RPCStream`` to publish.
     /// - Throws: ``RPCError`` with code ``RPCError/Code-swift.struct/failedPrecondition``
-    /// if the server transport stopped listening to new streams (i.e., if ``beginGracefulShutdown()`` has been called).
+    /// if the server transport stopped listening to new streams (i.e., if you have already called
+    /// ``beginGracefulShutdown()``).
     internal func acceptStream(_ stream: RPCStream<Inbound, Outbound>) throws {
       let yieldResult = self.newStreamsContinuation.yield(stream)
       if case .terminated = yieldResult {
@@ -105,14 +105,14 @@ extension InProcessTransport {
       }
     }
 
-    /// Starts the server, listening for new streams opened by an in-process client.
+    /// Starts the server, listening for new streams that an in-process client opens.
     ///
-    /// This function returns only once ``beginGracefulShutdown()`` has been called and every
+    /// This function returns only once you have called ``beginGracefulShutdown()`` and every
     /// in-flight stream has finished, or when the calling task is cancelled. Call this from a
     /// long-running task, typically inside a task group alongside the client's `connect()`.
     ///
-    /// - Parameter streamHandler: A closure invoked with each new `RPCStream` and its
-    ///   `ServerContext`, responsible for handling the RPC.
+    /// - Parameter streamHandler: A closure that this method invokes with each new `RPCStream` and
+    ///   its `ServerContext`; it's responsible for handling the RPC.
     public func listen(
       streamHandler:
         @escaping @Sendable (

--- a/Sources/GRPCInProcessTransport/InProcessTransport.swift
+++ b/Sources/GRPCInProcessTransport/InProcessTransport.swift
@@ -20,7 +20,7 @@ public import GRPCCore
 public struct InProcessTransport: Sendable {
   /// The server side of this transport pairing.
   ///
-  /// Pass this to a `GRPCServer` to accept RPCs made via ``client``.
+  /// Pass this to a `GRPCServer` to accept RPCs that ``client`` makes.
   public let server: Self.Server
 
   /// The client side of this transport pairing.
@@ -31,7 +31,7 @@ public struct InProcessTransport: Sendable {
   /// Initializes a new ``InProcessTransport`` pairing a ``Client`` and a ``Server``.
   ///
   /// - Parameters:
-  ///   - serviceConfig: Configuration describing how methods should be executed.
+  ///   - serviceConfig: Configuration describing how to execute methods.
   public init(serviceConfig: ServiceConfig = ServiceConfig()) {
     let peer = System.pid().map { "in-process:\($0)" } ?? "in-process"
     self.server = Self.Server(peer: peer)

--- a/Tests/GRPCCodeGenTests/Internal/StructuredSwift+ClientTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/StructuredSwift+ClientTests.swift
@@ -128,9 +128,9 @@ extension StructuredSwiftTests {
           ///   - serializer: A serializer for `BarInput` messages.
           ///   - deserializer: A deserializer for `BarOutput` messages.
           ///   - options: Options to apply to this RPC.
-          ///   - handleResponse: A closure which handles the response, the result of which is
-          ///       returned to the caller. Returning from the closure will cancel the RPC if it
-          ///       hasn't already finished.
+          ///   - handleResponse: A closure which handles the response and returns its result to
+          ///       the caller. Returning from the closure will cancel the RPC if it hasn't
+          ///       already finished.
           /// - Returns: The result of `handleResponse`.
           func bar<Result>(
             request: GRPCCore.ClientRequest<BarInput>,
@@ -210,9 +210,9 @@ extension StructuredSwiftTests {
           /// - Parameters:
           ///   - request: A request containing a single `BarInput` message.
           ///   - options: Options to apply to this RPC.
-          ///   - handleResponse: A closure which handles the response, the result of which is
-          ///       returned to the caller. Returning from the closure will cancel the RPC if it
-          ///       hasn't already finished.
+          ///   - handleResponse: A closure which handles the response and returns its result to
+          ///       the caller. Returning from the closure will cancel the RPC if it hasn't
+          ///       already finished.
           /// - Returns: The result of `handleResponse`.
           \(access) func bar<Result>(
             request: GRPCCore.ClientRequest<BarInput>,
@@ -371,9 +371,9 @@ extension StructuredSwiftTests {
           ///   - message: request message to send.
           ///   - metadata: Additional metadata to send, defaults to empty.
           ///   - options: Options to apply to this RPC, defaults to `.defaults`.
-          ///   - handleResponse: A closure which handles the response, the result of which is
-          ///       returned to the caller. Returning from the closure will cancel the RPC if it
-          ///       hasn't already finished.
+          ///   - handleResponse: A closure which handles the response and returns its result to
+          ///       the caller. Returning from the closure will cancel the RPC if it hasn't
+          ///       already finished.
           /// - Returns: The result of `handleResponse`.
           \(access) func bar<Result>(
             _ message: Input,
@@ -522,9 +522,9 @@ extension StructuredSwiftTests {
           ///   - serializer: A serializer for `Input` messages.
           ///   - deserializer: A deserializer for `Output` messages.
           ///   - options: Options to apply to this RPC.
-          ///   - handleResponse: A closure which handles the response, the result of which is
-          ///       returned to the caller. Returning from the closure will cancel the RPC if it
-          ///       hasn't already finished.
+          ///   - handleResponse: A closure which handles the response and returns its result to
+          ///       the caller. Returning from the closure will cancel the RPC if it hasn't
+          ///       already finished.
           /// - Returns: The result of `handleResponse`.
           \(access) func unary<Result>(
             request: GRPCCore.ClientRequest<Input>,
@@ -556,9 +556,9 @@ extension StructuredSwiftTests {
           ///   - serializer: A serializer for `Input` messages.
           ///   - deserializer: A deserializer for `Output` messages.
           ///   - options: Options to apply to this RPC.
-          ///   - handleResponse: A closure which handles the response, the result of which is
-          ///       returned to the caller. Returning from the closure will cancel the RPC if it
-          ///       hasn't already finished.
+          ///   - handleResponse: A closure which handles the response and returns its result to
+          ///       the caller. Returning from the closure will cancel the RPC if it hasn't
+          ///       already finished.
           /// - Returns: The result of `handleResponse`.
           \(access) func clientStreaming<Result>(
             request: GRPCCore.StreamingClientRequest<Input>,
@@ -590,9 +590,9 @@ extension StructuredSwiftTests {
           ///   - serializer: A serializer for `Input` messages.
           ///   - deserializer: A deserializer for `Output` messages.
           ///   - options: Options to apply to this RPC.
-          ///   - handleResponse: A closure which handles the response, the result of which is
-          ///       returned to the caller. Returning from the closure will cancel the RPC if it
-          ///       hasn't already finished.
+          ///   - handleResponse: A closure which handles the response and returns its result to
+          ///       the caller. Returning from the closure will cancel the RPC if it hasn't
+          ///       already finished.
           /// - Returns: The result of `handleResponse`.
           \(access) func serverStreaming<Result>(
             request: GRPCCore.ClientRequest<Input>,
@@ -622,9 +622,9 @@ extension StructuredSwiftTests {
           ///   - serializer: A serializer for `Input` messages.
           ///   - deserializer: A deserializer for `Output` messages.
           ///   - options: Options to apply to this RPC.
-          ///   - handleResponse: A closure which handles the response, the result of which is
-          ///       returned to the caller. Returning from the closure will cancel the RPC if it
-          ///       hasn't already finished.
+          ///   - handleResponse: A closure which handles the response and returns its result to
+          ///       the caller. Returning from the closure will cancel the RPC if it hasn't
+          ///       already finished.
           /// - Returns: The result of `handleResponse`.
           \(access) func bidiStreaming<Result>(
             request: GRPCCore.StreamingClientRequest<Input>,

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ClientCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ClientCodeTranslatorSnippetBasedTests.swift
@@ -65,9 +65,9 @@ struct ClientCodeTranslatorSnippetBasedTests {
               ///   - serializer: A serializer for `NamespaceA_ServiceARequest` messages.
               ///   - deserializer: A deserializer for `NamespaceA_ServiceAResponse` messages.
               ///   - options: Options to apply to this RPC.
-              ///   - handleResponse: A closure which handles the response, the result of which is
-              ///       returned to the caller. Returning from the closure will cancel the RPC if it
-              ///       hasn't already finished.
+              ///   - handleResponse: A closure which handles the response and returns its result to
+              ///       the caller. Returning from the closure will cancel the RPC if it hasn't
+              ///       already finished.
               /// - Returns: The result of `handleResponse`.
               func methodA<Result>(
                   request: GRPCCore.ClientRequest<NamespaceA_ServiceARequest>,
@@ -109,9 +109,9 @@ struct ClientCodeTranslatorSnippetBasedTests {
               ///   - serializer: A serializer for `NamespaceA_ServiceARequest` messages.
               ///   - deserializer: A deserializer for `NamespaceA_ServiceAResponse` messages.
               ///   - options: Options to apply to this RPC.
-              ///   - handleResponse: A closure which handles the response, the result of which is
-              ///       returned to the caller. Returning from the closure will cancel the RPC if it
-              ///       hasn't already finished.
+              ///   - handleResponse: A closure which handles the response and returns its result to
+              ///       the caller. Returning from the closure will cancel the RPC if it hasn't
+              ///       already finished.
               /// - Returns: The result of `handleResponse`.
               public func methodA<Result>(
                   request: GRPCCore.ClientRequest<NamespaceA_ServiceARequest>,
@@ -145,9 +145,9 @@ struct ClientCodeTranslatorSnippetBasedTests {
           /// - Parameters:
           ///   - request: A request containing a single `NamespaceA_ServiceARequest` message.
           ///   - options: Options to apply to this RPC.
-          ///   - handleResponse: A closure which handles the response, the result of which is
-          ///       returned to the caller. Returning from the closure will cancel the RPC if it
-          ///       hasn't already finished.
+          ///   - handleResponse: A closure which handles the response and returns its result to
+          ///       the caller. Returning from the closure will cancel the RPC if it hasn't
+          ///       already finished.
           /// - Returns: The result of `handleResponse`.
           public func methodA<Result>(
               request: GRPCCore.ClientRequest<NamespaceA_ServiceARequest>,
@@ -178,9 +178,9 @@ struct ClientCodeTranslatorSnippetBasedTests {
           ///   - message: request message to send.
           ///   - metadata: Additional metadata to send, defaults to empty.
           ///   - options: Options to apply to this RPC, defaults to `.defaults`.
-          ///   - handleResponse: A closure which handles the response, the result of which is
-          ///       returned to the caller. Returning from the closure will cancel the RPC if it
-          ///       hasn't already finished.
+          ///   - handleResponse: A closure which handles the response and returns its result to
+          ///       the caller. Returning from the closure will cancel the RPC if it hasn't
+          ///       already finished.
           /// - Returns: The result of `handleResponse`.
           public func methodA<Result>(
               _ message: NamespaceA_ServiceARequest,

--- a/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/IDLToStructuredSwiftTranslatorSnippetBasedTests.swift
@@ -83,8 +83,9 @@ final class IDLToStructuredSwiftTranslatorSnippetBasedTests: XCTestCase {
           /// This protocol is the lowest-level of the service protocols generated for this service
           /// giving you the most flexibility over the implementation of your service. This comes at
           /// the cost of more verbose and less strict APIs. Each RPC requires you to implement it in
-          /// terms of a request stream and response stream. Where only a single request or response
-          /// message is expected, you are responsible for enforcing this invariant is maintained.
+          /// terms of a request stream and response stream. Where the RPC expects only a single
+          /// request or response message, you are responsible for ensuring your implementation
+          /// maintains this invariant.
           ///
           /// Where possible, prefer using the stricter, less-verbose ``ServiceProtocol``
           /// or ``SimpleServiceProtocol`` instead.

--- a/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
+++ b/Tests/GRPCCodeGenTests/Internal/Translator/ServerCodeTranslatorSnippetBasedTests.swift
@@ -50,8 +50,9 @@ final class ServerCodeTranslatorSnippetBasedTests {
           /// This protocol is the lowest-level of the service protocols generated for this service
           /// giving you the most flexibility over the implementation of your service. This comes at
           /// the cost of more verbose and less strict APIs. Each RPC requires you to implement it in
-          /// terms of a request stream and response stream. Where only a single request or response
-          /// message is expected, you are responsible for enforcing this invariant is maintained.
+          /// terms of a request stream and response stream. Where the RPC expects only a single
+          /// request or response message, you are responsible for ensuring your implementation
+          /// maintains this invariant.
           ///
           /// Where possible, prefer using the stricter, less-verbose ``ServiceProtocol``
           /// or ``SimpleServiceProtocol`` instead.


### PR DESCRIPTION
A broad sweep of doc updates:
- reworked passive voice to active voice, present tense - the broadest sweep of updates and changes
- added deep curation to organize the top level docs and all the content within the various types
- updated all the abstracts to be a single sentence, narrative English - moving any relevant type annotations (or code voice) into the discussion for that type.
- ensured that neighbor abstracts for functions that differ by type don't have identical abstracts - they should meaningfully (and concisely) be descriptive to enable and easier choice between which you want/need.
- added missing abstracts for some public types
- reworked the GRPCCore docs overview - it's map of the related Swift packages - and referenced (with links to their docs) what they offered to provide easier guidance on what you might want to choose or use, and provide some guidance on the expected dependencies and imports when assembling gRPC clients or building servers.
- dropped swift 6.0 constraint from .spi.yml (for building docs)
- updated the GRPCClient overview to provide clarity on allowing multiple "service clients" for each transport client (assuming a transport offers more than one service endpoint at it), and added links to Service Lifecycle and it's documentation for managing lifecycle with dependencies.
